### PR TITLE
Change trackGroups to trackSections, avoid usage of a dedicated "domain-specific" Thing subclass

### DIFF
--- a/src/data/things/track.js
+++ b/src/data/things/track.js
@@ -152,9 +152,9 @@ export class Track extends Thing {
         dependencies: ['albumData'],
 
         compute: ({albumData, [Track.instance]: track}) =>
-          Track.findAlbum(track, albumData)?.trackGroups.find((tg) =>
-            tg.tracks.includes(track)
-          )?.color ?? null,
+          Track.findAlbum(track, albumData)
+            ?.trackSections.find(({tracks}) => tracks.includes(track))
+              ?.color ?? null,
       },
     },
 

--- a/src/data/things/validators.js
+++ b/src/data/things/validators.js
@@ -96,6 +96,10 @@ export function isStringNonEmpty(value) {
   return true;
 }
 
+export function optional(validator) {
+  return value => value === null || value === undefined || validator(value);
+}
+
 // Complex types (non-primitives)
 
 export function isInstance(value, constructor) {
@@ -251,6 +255,16 @@ export const isAdditionalFile = validateProperties({
 });
 
 export const isAdditionalFileList = validateArrayItems(isAdditionalFile);
+
+export const isTrackSection = validateProperties({
+  name: optional(isString),
+  color: optional(isColor),
+  dateOriginallyReleased: optional(isDate),
+  isDefaultTrackSection: optional(isBoolean),
+  tracksByRef: optional(validateReferenceList('track')),
+});
+
+export const isTrackSectionList = validateArrayItems(isTrackSection);
 
 export function isDimensions(dimensions) {
   isArray(dimensions);

--- a/src/page/album.js
+++ b/src/page/album.js
@@ -50,10 +50,10 @@ export function write(album, {wikiData}) {
   const hasAdditionalFiles = !empty(album.additionalFiles);
   const albumDuration = getTotalDuration(album.tracks);
 
-  const displayTrackGroups =
-    album.trackGroups &&
-      (album.trackGroups.length > 1 ||
-        !album.trackGroups[0].isDefaultTrackGroup);
+  const displayTrackSections =
+    album.trackSections &&
+      (album.trackSections.length > 1 ||
+        !album.trackSections[0].isDefaultTrackSection);
 
   const listTag = getAlbumListTag(album);
 
@@ -107,10 +107,10 @@ export function write(album, {wikiData}) {
       wallpaperArtistContribs: serializeContribs(album.wallpaperArtistContribs),
       bannerArtistContribs: serializeContribs(album.bannerArtistContribs),
       groups: serializeGroupsForAlbum(album),
-      trackGroups: album.trackGroups?.map((trackGroup) => ({
-        name: trackGroup.name,
-        color: trackGroup.color,
-        tracks: trackGroup.tracks.map((track) => track.directory),
+      trackSections: album.trackSections?.map((section) => ({
+        name: section.name,
+        color: section.color,
+        tracks: section.tracks.map((track) => track.directory),
       })),
       tracks: album.tracks.map((track) => ({
         link: serializeLink(track),
@@ -300,10 +300,10 @@ export function write(album, {wikiData}) {
                   ),
                 })),
 
-            displayTrackGroups &&
+            displayTrackSections &&
               html.tag('dl',
                 {class: 'album-group-list'},
-                album.trackGroups.flatMap(({
+                album.trackSections.flatMap(({
                   name,
                   startIndex,
                   tracks,
@@ -322,7 +322,7 @@ export function write(album, {wikiData}) {
                       tracks.map(trackToListItem))),
                 ])),
 
-            !displayTrackGroups &&
+            !displayTrackSections &&
               html.tag(listTag,
                 album.tracks.map(trackToListItem)),
 
@@ -515,7 +515,7 @@ export function generateAlbumSidebar(album, currentTrack, {
 
   const listTag = getAlbumListTag(album);
 
-  const {trackGroups} = album;
+  const {trackSections} = album;
 
   const trackToListItem = (track) =>
     html.tag('li',
@@ -524,19 +524,19 @@ export function generateAlbumSidebar(album, currentTrack, {
         track: link.track(track),
       }));
 
-  const nameOrDefault = (isDefaultTrackGroup, name) =>
-    isDefaultTrackGroup
+  const nameOrDefault = (isDefaultTrackSection, name) =>
+    isDefaultTrackSection
       ? language.$('albumSidebar.trackList.fallbackGroupName')
       : name;
 
   const trackListPart = [
     html.tag('h1', link.album(album)),
-    ...trackGroups.map(({name, color, startIndex, tracks, isDefaultTrackGroup}) => {
+    ...trackSections.map(({name, color, startIndex, tracks, isDefaultTrackSection}) => {
       const groupName =
         html.tag('span',
           {class: 'group-name'},
           nameOrDefault(
-            isDefaultTrackGroup,
+            isDefaultTrackSection,
             name
           ));
       return html.tag('details',

--- a/src/page/album.js
+++ b/src/page/album.js
@@ -526,7 +526,7 @@ export function generateAlbumSidebar(album, currentTrack, {
 
   const nameOrDefault = (isDefaultTrackSection, name) =>
     isDefaultTrackSection
-      ? language.$('albumSidebar.trackList.fallbackGroupName')
+      ? language.$('albumSidebar.trackList.fallbackSectionName')
       : name;
 
   const trackListPart = [

--- a/src/strings-default.json
+++ b/src/strings-default.json
@@ -191,7 +191,7 @@
   "homepage.title": "{TITLE}",
   "homepage.news.title": "News",
   "homepage.news.entry.viewRest": "(View rest of entry!)",
-  "albumSidebar.trackList.fallbackGroupName": "Track list",
+  "albumSidebar.trackList.fallbackSectionName": "Track list",
   "albumSidebar.trackList.group": "{GROUP}",
   "albumSidebar.trackList.group.withRange": "{GROUP} ({RANGE})",
   "albumSidebar.trackList.item": "{TRACK}",

--- a/test/things.js
+++ b/test/things.js
@@ -9,9 +9,11 @@ import {
 
 function stubAlbum(tracks) {
   const album = new Album();
-  const trackGroup = new TrackGroup();
-  trackGroup.tracksByRef = tracks.map(t => Thing.getReference(t));
-  album.trackGroups = [trackGroup];
+  album.trackSections = [
+    {
+      tracksByRef: tracks.map(t => Thing.getReference(t)),
+    },
+  ];
   album.trackData = tracks;
   return album;
 }


### PR DESCRIPTION
Development:

- Resolves #76

Notable changes:

- Rename `trackGroups` to `trackSections` for a more distinct name from the completely unrelated and much more prevalent type of thing, Groups (of albums)
- Use a cleaner approach for updating and exposing `trackSections`
  - Update: validate with `validateProperties` instead of `validateInstanceOf(TrackGroup)`, using a similar approach as validating additional files
  - Expose: transform visible "extra" properties (`tracks`) and fallback values (`color`)
  - YAML: when saving albumData, match minimal `TrackSectionHelper` thing and turn it into a normal object which will be pushed to the album's (final) `trackSections` property
    - This PR doesn't change the visible YAML format, so sections are still indicated by a `Group: (section name)`-headed document
  - Reducing the usage of a dedicated `TrackGroup` / `TrackSectionHelper` Thing subclass allows for cleaner data manipulation as described above, and cuts out the need for additional "supporting" boilerplate, ex. providing (let alone syncing) `trackData` to each `TrackGroup`, back-referencing the album to the `TrackGroup`, and a more expensive/redundant `startingIndex` compute

Localization changes:

- Changed key `albumSidebar.trackList.fallbackSectionName` to `(…).fallbackGroupName` (value is still "Track list")

Follow-up changes (not this PR):

- YAML format should be changed so that section documents are headed by `Section: (section name)` instead of `Group: (section name)`

Other notes:

- This PR doesn't completely remove `TrackGroup`, now named `TrackSectionHelper`, because it's still useful to tie the YAML parser in (it expects to convert a given YAML document into a specific Thing subclass—during the `save` step we need to distinguish between a tracks and track sections, which are inline with each other, and a Thing subclass is the easiest way to do so, as well as to validate properties on the document).

  However, in the future, if/when we implement multiple track listings per album (or whatever terminology), the YAML format may be changed to not use YAML documents (tracks inline with sections) at all. In this case it should be doable to remove `TrackSectionHelper` entirely and just pass the object/array-shaped value directly to an album's `trackSections` property (or whatever).

  This would reduce the overall codebase footprint and avoid code-duplicating some property validation between `validateTrackSection` (validators.js) and `TrackSectionHelper` (album.js).

- "Track group" isn't actually a term present *on* the wiki at all; it's exclusively internal. This PR changes the "Default Track Group" internal string to "Default Track Section", but this isn't reflected on the site, which checks `isDefaultTrackSection` and `trackSections.length` to decide whether to display custom section names or just use a no-sections alternate design (`<ul>` instead of `<dl>`).