### PR TITLE
Fix threshold requirement for lazy loading

### DIFF
--- a/src/static/lazy-loading.js
+++ b/src/static/lazy-loading.js
@@ -37,7 +37,7 @@ function lazyLoadMain() {
   if (window.IntersectionObserver) {
     observer = new IntersectionObserver(lazyLoad, {
       rootMargin: '200px',
-      threshold: 1.0,
+      threshold: 0,
     });
     for (i = 0; i < lazyElements.length; i++) {
       observer.observe(lazyElements[i]);


### PR DESCRIPTION
Lazy loading previously used a `rootMargin` of 200px and a `threshold` of 1.0, which requires the entire image to be contained within an area that expands 200px past the screen. This PR makes it reflect what I think was the intended behavior: if *any* portion of the image enters an area 200px past the screen, load it.

This fixes large (or even medium - anything +200px) images not being loaded until a certain amount *more* than zero of the [blank] image has been displayed on screen, rather than loading in advance of entering the screen.