### PR TITLE
Remove unused CSS & reduce layout footprint of images

### DIFF
--- a/src/static/site2.css
+++ b/src/static/site2.css
@@ -709,13 +709,6 @@ li > ul {
   height: 100%;
 }
 
-.image-inner-area {
-  overflow: hidden;
-  width: 100%;
-  height: 100%;
-  position: relative;
-}
-
 .image-text-area {
   position: absolute;
   top: 0;

--- a/src/static/site2.css
+++ b/src/static/site2.css
@@ -730,12 +730,6 @@ li > ul {
 
 img {
   object-fit: cover;
-  /* these unfortunately dont take effect while loading, so...
-    text-align: center;
-    line-height: 2em;
-    text-shadow: 0 0 5px black;
-    font-style: oblique;
-    */
 }
 
 .reveal {

--- a/src/static/site2.css
+++ b/src/static/site2.css
@@ -631,11 +631,6 @@ blockquote {
   padding-right: 12%;
 }
 
-p img {
-  max-width: 100%;
-  height: auto;
-}
-
 dl dt {
   padding-left: 40px;
   max-width: 600px;

--- a/src/static/site2.css
+++ b/src/static/site2.css
@@ -1029,17 +1029,6 @@ html[data-url-key="localized.home"] .carousel-container {
   height: 100%;
 }
 
-.vertical-square {
-  position: relative;
-  height: 100%;
-}
-
-.vertical-square::after {
-  content: "";
-  display: block;
-  padding-right: 100%;
-}
-
 /* Info card */
 
 #info-card-container {

--- a/src/upd8.js
+++ b/src/upd8.js
@@ -703,7 +703,6 @@ function img({
   function wrap(input, hide = false) {
     let wrapped = input;
 
-    wrapped = html.tag('div', {class: 'image-inner-area'}, wrapped);
     wrapped = html.tag('div', {class: 'image-container'}, wrapped);
 
     if (reveal) {


### PR DESCRIPTION
This PR removes the `image-inner-area` wrapper, which appeared to only be used for cutting off content which expanded beyond the bounds of the container (`overflow: hidden`), but this shouldn't have been an issue [anymore] with `width: 100%; height: 100%` being set for images under `a.box` (all linked images).

Technically this may be an issue for `p img` rule which sets `max-width: 100%; height: auto`, a different layout, but due to `transformMultiline` automatically linking images, I doubt there exist any such "images outside of boxes" [d'accord, this PR removes this rule].