### PR TITLE
URL & path utilities cleanup

### DIFF
--- a/src/misc-templates.js
+++ b/src/misc-templates.js
@@ -973,10 +973,8 @@ function unbound_getFooterLocalizationLinks(pathname, {
   defaultLanguage,
   language,
   languages,
+  pagePath,
   to,
-
-  pageSubKey,
-  urlArgs,
 }) {
   const links = Object.entries(languages)
     .filter(([code, language]) => code !== 'default' && !language.hidden)
@@ -989,11 +987,12 @@ function unbound_getFooterLocalizationLinks(pathname, {
             href:
               language === defaultLanguage
                 ? to(
-                    'localizedDefaultLanguage.' + pageSubKey,
-                    ...urlArgs)
+                    'localizedDefaultLanguage.' + pagePath[0],
+                    ...pagePath.slice(1))
                 : to(
-                    'localizedWithBaseDirectory.' + pageSubKey,
-                    language.code, ...urlArgs),
+                    'localizedWithBaseDirectory.' + pagePath[0],
+                    language.code,
+                    ...pagePath.slice(1)),
           },
           language.name)));
 

--- a/src/misc-templates.js
+++ b/src/misc-templates.js
@@ -968,7 +968,7 @@ function unbound_generateStickyHeadingContainer({
 
 // Footer stuff
 
-function unbound_getFooterLocalizationLinks(pathname, {
+function unbound_getFooterLocalizationLinks({
   html,
   defaultLanguage,
   language,

--- a/src/util/urls.js
+++ b/src/util/urls.js
@@ -233,6 +233,29 @@ export function getPagePathname({
           ...urlArgs));
 }
 
+export function getPagePathnameAcrossLanguages({
+  defaultLanguage,
+  languages,
+  pageSubKey,
+  urlArgs,
+  urls,
+}) {
+  return withEntries(languages, entries => entries
+    .filter(([key, language]) => key !== 'default' && !language.hidden)
+    .map(([_key, language]) => [
+      language.code,
+      getPagePathname({
+        baseDirectory:
+          (language === defaultLanguage
+            ? ''
+            : language.code),
+        fullKey: 'localized.' + pageSubKey,
+        urlArgs,
+        urls,
+      }),
+    ]));
+}
+
 // Needed for the rare path arguments which themselves contains one or more
 // slashes, e.g. for listings, with arguments like 'albums/by-name'.
 export function getPageSubdirectoryPrefix({urlArgs}) {

--- a/src/util/urls.js
+++ b/src/util/urls.js
@@ -238,36 +238,3 @@ export function getPagePathname({
 export function getPageSubdirectoryPrefix({urlArgs}) {
   return '../'.repeat(urlArgs.join('/').split('/').length - 1);
 }
-
-export function getPagePaths({
-  baseDirectory,
-  fullKey,
-  outputPath,
-  urlArgs,
-  urls,
-}) {
-  const [groupKey, subKey] = fullKey.split('.');
-
-  const pathname = getPagePathname({
-    baseDirectory,
-    device: true,
-    fullKey,
-    urlArgs,
-    urls,
-  });
-
-  const outputDirectory = path.join(outputPath, pathname);
-
-  const output = {
-    directory: outputDirectory,
-    documentHTML: path.join(outputDirectory, 'index.html'),
-    oEmbedJSON: path.join(outputDirectory, 'oembed.json'),
-  };
-
-  return {
-    urlPath: [fullKey, ...urlArgs],
-
-    output,
-    pathname,
-  };
-}

--- a/src/util/urls.js
+++ b/src/util/urls.js
@@ -213,24 +213,14 @@ export function getURLsFromRoot({
 export function getPagePathname({
   baseDirectory,
   device = false,
-  fullKey,
+  pageSubKey,
   urlArgs,
   urls,
 }) {
-  const [groupKey, subKey] = fullKey.split('.');
-
-  const toKey = device ? 'toDevice' : 'to';
-
-  return (groupKey === 'localized' && baseDirectory
-    ? urls
-        .from('shared.root')[toKey](
-          'localizedWithBaseDirectory.' + subKey,
-          baseDirectory,
-          ...urlArgs)
-    : urls
-        .from('shared.root')[toKey](
-          fullKey,
-          ...urlArgs));
+  const to = urls.from('shared.root')[device ? 'toDevice' : 'to'];
+  return (baseDirectory
+    ? to('localizedWithBaseDirectory.' + pageSubKey, baseDirectory, ...urlArgs)
+    : to('localized.' + pageSubKey, ...urlArgs));
 }
 
 export function getPagePathnameAcrossLanguages({
@@ -249,7 +239,7 @@ export function getPagePathnameAcrossLanguages({
           (language === defaultLanguage
             ? ''
             : language.code),
-        fullKey: 'localized.' + pageSubKey,
+        pageSubKey,
         urlArgs,
         urls,
       }),

--- a/src/util/urls.js
+++ b/src/util/urls.js
@@ -140,20 +140,16 @@ export const thumb = {
 // Makes the generally-used and wiki-specialized "to" page utility.
 // "to" returns a relative path from the current page to the target.
 export function getURLsFrom({
-  urls,
-
   baseDirectory,
   pagePath,
-  subdirectoryPrefix,
+  urls,
 }) {
   const pageSubKey = pagePath[0];
+  const subdirectoryPrefix = getPageSubdirectoryPrefix({pagePath});
 
   return (targetFullKey, ...args) => {
     const [groupKey, subKey] = targetFullKey.split('.');
-    let path = subdirectoryPrefix;
-
-    let from;
-    let to;
+    let from, to;
 
     // When linking to *outside* the localized area of the site, we need to
     // make sure the result is correctly relative to the 8ase directory.
@@ -182,9 +178,9 @@ export function getURLsFrom({
       to = targetFullKey;
     }
 
-    path += urls.from(from).to(to, ...args);
-
-    return path;
+    return (
+      subdirectoryPrefix +
+      urls.from(from).to(to, ...args));
   };
 }
 

--- a/src/write/bind-utilities.js
+++ b/src/write/bind-utilities.js
@@ -52,8 +52,10 @@ import {
 
 export function bindUtilities({
   absoluteTo,
+  defaultLanguage,
   getSizeOfAdditionalFile,
   language,
+  languages,
   to,
   urls,
   wikiData,
@@ -65,9 +67,11 @@ export function bindUtilities({
 
   Object.assign(bound, {
     absoluteTo,
+    defaultLanguage,
     getSizeOfAdditionalFile,
     html,
     language,
+    languages,
     to,
     urls,
     wikiData,

--- a/src/write/build-modes/live-dev-server.js
+++ b/src/write/build-modes/live-dev-server.js
@@ -15,7 +15,6 @@ import {logInfo, logWarn, progressCallAll} from '../../util/cli.js';
 import {
   getPagePathname,
   getPagePathnameAcrossLanguages,
-  getPageSubdirectoryPrefix,
   getURLsFrom,
   getURLsFromRoot,
 } from '../../util/urls.js';
@@ -245,12 +244,9 @@ export async function go({
     } = urlToPageMap[pathnameKey];
 
     const to = getURLsFrom({
-      urls,
       baseDirectory,
       pagePath: servePath,
-      subdirectoryPrefix: getPageSubdirectoryPrefix({
-        pagePath: servePath,
-      }),
+      urls,
     });
 
     const absoluteTo = getURLsFromRoot({

--- a/src/write/build-modes/live-dev-server.js
+++ b/src/write/build-modes/live-dev-server.js
@@ -11,10 +11,10 @@ import {serializeThings} from '../../data/serialize.js';
 import * as pageSpecs from '../../page/index.js';
 
 import {logInfo, logWarn, progressCallAll} from '../../util/cli.js';
-import {withEntries} from '../../util/sugar.js';
 
 import {
   getPagePathname,
+  getPagePathnameAcrossLanguages,
   getPageSubdirectoryPrefix,
   getURLsFrom,
   getURLsFromRoot,
@@ -280,20 +280,13 @@ export async function go({
 
       response.writeHead(200, contentTypeHTML);
 
-      const localizedPathnames = withEntries(languages, entries => entries
-        .filter(([key, language]) => key !== 'default' && !language.hidden)
-        .map(([_key, language]) => [
-          language.code,
-          getPagePathname({
-            baseDirectory:
-              (language === defaultLanguage
-                ? ''
-                : language.code),
-            fullKey: 'localized.' + pageSubKey,
-            urlArgs,
-            urls,
-          }),
-        ]));
+      const localizedPathnames = getPagePathnameAcrossLanguages({
+        defaultLanguage,
+        languages,
+        pageSubKey,
+        urlArgs,
+        urls,
+      });
 
       const bound = bindUtilities({
         absoluteTo,

--- a/src/write/build-modes/live-dev-server.js
+++ b/src/write/build-modes/live-dev-server.js
@@ -83,17 +83,14 @@ export async function go({
       else if (page.type === 'redirect')
         servePath = page.fromPath;
 
-      const fullKey = 'localized.' + servePath[0];
-      const urlArgs = servePath.slice(1);
-
       return Object.values(languages).map(language => {
         const baseDirectory =
           language === defaultLanguage ? '' : language.code;
 
         const pathname = getPagePathname({
           baseDirectory,
-          fullKey,
-          urlArgs,
+          pageSubKey: servePath[0],
+          urlArgs: servePath.slice(1),
           urls,
         });
 

--- a/src/write/build-modes/live-dev-server.js
+++ b/src/write/build-modes/live-dev-server.js
@@ -89,8 +89,7 @@ export async function go({
 
         const pathname = getPagePathname({
           baseDirectory,
-          pageSubKey: servePath[0],
-          urlArgs: servePath.slice(1),
+          pagePath: servePath,
           urls,
         });
 
@@ -248,9 +247,9 @@ export async function go({
     const to = getURLsFrom({
       urls,
       baseDirectory,
-      pageSubKey: servePath[0],
+      pagePath: servePath,
       subdirectoryPrefix: getPageSubdirectoryPrefix({
-        urlArgs: servePath.slice(1),
+        pagePath: servePath,
       }),
     });
 
@@ -260,9 +259,6 @@ export async function go({
     });
 
     try {
-      const pageSubKey = servePath[0];
-      const urlArgs = servePath.slice(1);
-
       if (page.type === 'redirect') {
         response.writeHead(301, contentTypeHTML);
 
@@ -280,8 +276,7 @@ export async function go({
       const localizedPathnames = getPagePathnameAcrossLanguages({
         defaultLanguage,
         languages,
-        pageSubKey,
-        urlArgs,
+        pagePath: servePath,
         urls,
       });
 
@@ -305,9 +300,8 @@ export async function go({
         languages,
         localizedPathnames,
         oEmbedJSONHref: null, // No oEmbed support for live dev server
-        pageSubKey,
+        pagePath: servePath,
         pathname,
-        urlArgs,
         to,
         transformMultiline: bound.transformMultiline,
         wikiData,

--- a/src/write/build-modes/live-dev-server.js
+++ b/src/write/build-modes/live-dev-server.js
@@ -278,8 +278,10 @@ export async function go({
 
       const bound = bindUtilities({
         absoluteTo,
+        defaultLanguage,
         getSizeOfAdditionalFile,
         language,
+        languages,
         to,
         urls,
         wikiData,
@@ -288,19 +290,13 @@ export async function go({
       const pageInfo = page.page(bound);
 
       const pageHTML = generateDocumentHTML(pageInfo, {
+        ...bound,
         cachebust,
-        defaultLanguage,
         developersComment,
-        getThemeString: bound.getThemeString,
-        language,
-        languages,
         localizedPathnames,
         oEmbedJSONHref: null, // No oEmbed support for live dev server
         pagePath: servePath,
         pathname,
-        to,
-        transformMultiline: bound.transformMultiline,
-        wikiData,
       });
 
       console.log(`${requestHead} [200] ${pathname}`);

--- a/src/write/build-modes/static-build.js
+++ b/src/write/build-modes/static-build.js
@@ -15,7 +15,7 @@ import {serializeThings} from '../../data/serialize.js';
 import * as pageSpecs from '../../page/index.js';
 
 import link from '../../util/link.js';
-import {empty, queue, withEntries} from '../../util/sugar.js';
+import {empty, queue} from '../../util/sugar.js';
 
 import {
   logError,
@@ -27,6 +27,7 @@ import {
 
 import {
   getPagePathname,
+  getPagePathnameAcrossLanguages,
   getPageSubdirectoryPrefix,
   getURLsFrom,
   getURLsFromRoot,
@@ -268,20 +269,13 @@ export async function go({
         const urlArgs = page.path.slice(1);
         const fullKey = 'localized.' + pageSubKey;
 
-        const localizedPathnames = withEntries(languages, entries => entries
-          .filter(([key, language]) => key !== 'default' && !language.hidden)
-          .map(([_key, language]) => [
-            language.code,
-            getPagePathname({
-              baseDirectory:
-                (language === defaultLanguage
-                  ? ''
-                  : language.code),
-              fullKey,
-              urlArgs,
-              urls,
-            }),
-          ]));
+        const localizedPathnames = getPagePathnameAcrossLanguages({
+          defaultLanguage,
+          languages,
+          pageSubKey,
+          urlArgs,
+          urls,
+        });
 
         const pathname = getPagePathname({
           baseDirectory,

--- a/src/write/build-modes/static-build.js
+++ b/src/write/build-modes/static-build.js
@@ -267,7 +267,6 @@ export async function go({
       ...pageWrites.map(page => () => {
         const pageSubKey = page.path[0];
         const urlArgs = page.path.slice(1);
-        const fullKey = 'localized.' + pageSubKey;
 
         const localizedPathnames = getPagePathnameAcrossLanguages({
           defaultLanguage,
@@ -279,7 +278,7 @@ export async function go({
 
         const pathname = getPagePathname({
           baseDirectory,
-          fullKey,
+          pageSubKey,
           urlArgs,
           urls,
         });
@@ -345,7 +344,7 @@ export async function go({
           outputDirectory: path.join(outputPath, getPagePathname({
             baseDirectory,
             device: true,
-            fullKey,
+            pageSubKey,
             urlArgs,
             urls,
           })),
@@ -373,7 +372,7 @@ export async function go({
           outputDirectory: path.join(outputPath, getPagePathname({
             baseDirectory,
             device: true,
-            fullKey: 'localized.' + fromPath[0],
+            pageSubKey: fromPath[0],
             urlArgs: fromPath.slice(1),
             urls,
           })),

--- a/src/write/build-modes/static-build.js
+++ b/src/write/build-modes/static-build.js
@@ -292,8 +292,10 @@ export async function go({
 
         const bound = bindUtilities({
           absoluteTo,
+          defaultLanguage,
           getSizeOfAdditionalFile,
           language,
+          languages,
           to,
           urls,
           wikiData,
@@ -315,19 +317,13 @@ export async function go({
               .to('shared.path', pathname + 'oembed.json');
 
         const pageHTML = generateDocumentHTML(pageInfo, {
+          ...bound,
           cachebust,
-          defaultLanguage,
           developersComment,
-          getThemeString: bound.getThemeString,
-          language,
-          languages,
           localizedPathnames,
           oEmbedJSONHref,
           pagePath,
           pathname,
-          to,
-          transformMultiline: bound.transformMultiline,
-          wikiData,
         });
 
         return writePage({

--- a/src/write/build-modes/static-build.js
+++ b/src/write/build-modes/static-build.js
@@ -265,30 +265,27 @@ export async function go({
 
     await progressPromiseAll(`Writing ${language.code}`, queue([
       ...pageWrites.map(page => () => {
-        const pageSubKey = page.path[0];
-        const urlArgs = page.path.slice(1);
+        const pagePath = page.path;
 
         const localizedPathnames = getPagePathnameAcrossLanguages({
           defaultLanguage,
           languages,
-          pageSubKey,
-          urlArgs,
+          pagePath,
           urls,
         });
 
         const pathname = getPagePathname({
           baseDirectory,
-          pageSubKey,
-          urlArgs,
+          pagePath,
           urls,
         });
 
         const to = getURLsFrom({
           urls,
           baseDirectory,
-          pageSubKey,
+          pagePath,
           subdirectoryPrefix: getPageSubdirectoryPrefix({
-            urlArgs: page.path.slice(1),
+            pagePath,
           }),
         });
 
@@ -330,11 +327,10 @@ export async function go({
           languages,
           localizedPathnames,
           oEmbedJSONHref,
-          pageSubKey,
+          pagePath,
           pathname,
           to,
           transformMultiline: bound.transformMultiline,
-          urlArgs,
           wikiData,
         });
 
@@ -344,8 +340,7 @@ export async function go({
           outputDirectory: path.join(outputPath, getPagePathname({
             baseDirectory,
             device: true,
-            pageSubKey,
-            urlArgs,
+            pagePath,
             urls,
           })),
         });
@@ -358,9 +353,9 @@ export async function go({
         const to = getURLsFrom({
           urls,
           baseDirectory,
-          pageSubKey: fromPath[0],
+          pagePath: fromPath,
           subdirectoryPrefix: getPageSubdirectoryPrefix({
-            urlArgs: fromPath.slice(1),
+            pagePath: fromPath,
           }),
         });
 
@@ -372,8 +367,7 @@ export async function go({
           outputDirectory: path.join(outputPath, getPagePathname({
             baseDirectory,
             device: true,
-            pageSubKey: fromPath[0],
-            urlArgs: fromPath.slice(1),
+            pagePath: fromPath,
             urls,
           })),
         });

--- a/src/write/build-modes/static-build.js
+++ b/src/write/build-modes/static-build.js
@@ -28,7 +28,6 @@ import {
 import {
   getPagePathname,
   getPagePathnameAcrossLanguages,
-  getPageSubdirectoryPrefix,
   getURLsFrom,
   getURLsFromRoot,
 } from '../../util/urls.js';
@@ -281,12 +280,9 @@ export async function go({
         });
 
         const to = getURLsFrom({
-          urls,
           baseDirectory,
           pagePath,
-          subdirectoryPrefix: getPageSubdirectoryPrefix({
-            pagePath,
-          }),
+          urls,
         });
 
         const absoluteTo = getURLsFromRoot({
@@ -351,12 +347,9 @@ export async function go({
         });
 
         const to = getURLsFrom({
-          urls,
           baseDirectory,
           pagePath: fromPath,
-          subdirectoryPrefix: getPageSubdirectoryPrefix({
-            pagePath: fromPath,
-          }),
+          urls,
         });
 
         const target = to('localized.' + toPath[0], ...toPath.slice(1));

--- a/src/write/build-modes/static-build.js
+++ b/src/write/build-modes/static-build.js
@@ -309,7 +309,7 @@ export async function go({
         const oEmbedJSONHref =
           oEmbedJSON &&
           wikiData.wikiInfo.canonicalBase &&
-          wikiData.wikiInfo.canonicalBase +
+            wikiData.wikiInfo.canonicalBase +
             urls
               .from('shared.root')
               .to('shared.path', pathname + 'oembed.json');

--- a/src/write/page-template.js
+++ b/src/write/page-template.js
@@ -1,7 +1,6 @@
 import chroma from 'chroma-js';
 
 import * as html from '../util/html.js';
-import {logWarn} from '../util/cli.js';
 import {getColors} from '../util/colors.js';
 
 import {
@@ -263,11 +262,6 @@ export function generateDocumentHTML(pageInfo, {
           ? to('localized.home')
           : cur.path
           ? to(...cur.path)
-          : cur.href
-          ? (() => {
-              logWarn`Using legacy href format nav link in ${pathname}`;
-              return cur.href;
-            })()
           : null,
       };
       if (attributes.href === null) {

--- a/src/write/page-template.js
+++ b/src/write/page-template.js
@@ -163,7 +163,7 @@ export function generateDocumentHTML(pageInfo, {
           },
           footer.content),
 
-        getFooterLocalizationLinks(pathname, {
+        getFooterLocalizationLinks({
           defaultLanguage,
           html,
           language,

--- a/src/write/page-template.js
+++ b/src/write/page-template.js
@@ -55,11 +55,10 @@ export function generateDocumentHTML(pageInfo, {
   languages,
   localizedPathnames,
   oEmbedJSONHref,
-  pageSubKey,
+  pagePath,
   pathname,
   to,
   transformMultiline,
-  urlArgs,
   wikiData,
 }) {
   const {wikiInfo} = wikiData;
@@ -169,9 +168,8 @@ export function generateDocumentHTML(pageInfo, {
           html,
           language,
           languages,
-          pageSubKey,
+          pagePath,
           to,
-          urlArgs,
         }),
       ]);
 
@@ -450,10 +448,9 @@ export function generateDocumentHTML(pageInfo, {
     {
       lang: language.intlCode,
       'data-language-code': language.code,
-      'data-url-key': 'localized.' + pageSubKey,
+      'data-url-key': 'localized.' + pagePath[0],
       ...Object.fromEntries(
-        urlArgs.map((v, i) => [['data-url-value' + i], v])
-      ),
+        pagePath.slice(1).map((v, i) => [['data-url-value' + i], v])),
       'data-rebase-localized': to('localized.root'),
       'data-rebase-shared': to('shared.root'),
       'data-rebase-media': to('media.root'),


### PR DESCRIPTION
This PR makes a whole bunch of small changes to clean up the shape and usage of URL and path utility functions, deduplicating most of the remaining blatant overlap between `static-build.js` and `live-dev-server.js`, as well as just polishing relevant code.

Individual commits are basically self-explanatory.

Special mention to the bulkiest (and first) commit 592acc152dc68e0f24300c090c9eabb9f21cef6b, which removes the `getPagePaths` utility that had already been cut down to just `static-build`-specific behavior, and moves its behavior directly into the only place still using it, `writePage`.