### PR TITLE
Live dev server: Force trailing slash for served paths

### DIFF
--- a/src/write/build-modes/live-dev-server.js
+++ b/src/write/build-modes/live-dev-server.js
@@ -236,6 +236,20 @@ export async function go({
       return;
     }
 
+    // All pages expect to be served at a URL with a trailing slash, which must
+    // be fulfilled for relative URLs (ex. href="../lofam5/") to work. Redirect
+    // if there is no trailing slash in the request URL.
+    if (!pathname.endsWith('/')) {
+      const target = pathname + '/';
+      response.writeHead(301, {
+        ...contentTypePlain,
+        'Location': target,
+      });
+      response.end(`Redirecting to: ${target}\n`);
+      console.log(`${requestHead} [301] (trl. slash) ${pathname}`);
+      return;
+    }
+
     const {
       baseDirectory,
       language,
@@ -256,9 +270,13 @@ export async function go({
 
     try {
       if (page.type === 'redirect') {
-        response.writeHead(301, contentTypeHTML);
-
         const target = to('localized.' + page.toPath[0], ...page.toPath.slice(1));
+
+        response.writeHead(301, {
+          ...contentTypeHTML,
+          'Location': target,
+        });
+
         const redirectHTML = generateRedirectHTML(page.title, target, {language});
 
         response.end(redirectHTML);


### PR DESCRIPTION
Relative URLs like `../lofam5/` are generated with the assumption that they're also being served from an adjacent subdirectory, ex. `/album/alternia/`. When the client thinks it's receiving an adjacent *file* the `..` then means "get out of the parent directory", not "get out of myself": `../lofam5/` resolves to `/lofam5/` instead of `/album/lofam5/`.

This PR uses a 301 redirect to tell clients to stick a slash at the end of the URL, dagnabbit! (I'm just copying `python3 -m http.server` lol)