### PR TITLE
"Tracks - by Date" listing fixes

### DIFF
--- a/src/listing-spec.js
+++ b/src/listing-spec.js
@@ -615,9 +615,12 @@ const listingSpec = [
     directory: 'tracks/by-date',
     stringsKey: 'listTracks.byDate',
 
-    data: ({wikiData: {trackData}}) =>
+    data: ({wikiData: {albumData}}) =>
       chunkByProperties(
-        sortChronologically(trackData.filter(t => t.date)),
+        sortByDate(
+          sortChronologically(albumData)
+            .flatMap(album => album.tracks)
+            .filter(track => track.date)),
         ['album', 'date']),
 
     html: (data, {html, language, link}) =>

--- a/src/listing-spec.js
+++ b/src/listing-spec.js
@@ -635,7 +635,7 @@ const listingSpec = [
           html.tag('dd',
             html.tag('ul',
               tracks.map(track =>
-                track.aka
+                track.originalReleaseTrack
                   ? html.tag('li',
                       {class: 'rerelease'},
                       language.$('listingPage.listTracks.byDate.track.rerelease', {


### PR DESCRIPTION
Development:

- Fixes #122 
- Fixes #136

Old sorting method: `sortChronologically` track data, indexing all tracks A-Z then sorting by date.

New sorting method: `sortChronologically` *album* data, then map each album to its track list preserving original order, and perform a final `sortByDate` to move tracks with custom dates (ex. [it's good to see you again](https://hsmusic.wiki/track/its-good-to-see-you-again/)) to the appropriate chronological placement.