### PR TITLE
Preserve <h2> class when stickyalizing it

### DIFF
--- a/src/upd8.js
+++ b/src/upd8.js
@@ -572,8 +572,14 @@ function transformMultiline(text, {
       }
 
       // for sticky headings!
-      if (elementMatch) {
-        lineContent = lineContent.replace(/<h2/, `<h2 class="content-heading"`)
+      if (elementMatch && elementMatch[1] === 'h2') {
+        lineContent = lineContent.replace(/<h2(.*?)>/g, (match, attributes) => {
+          const parsedAttributes = parseAttributes(attributes, {to});
+          return `<h2 ${html.attributes({
+            ...parsedAttributes,
+            class: [...parsedAttributes.class?.split(' ') ?? [], 'content-heading'],
+          })}>`;
+        });
       }
     }
 


### PR DESCRIPTION
Development:

- Fixes #118

Note: this code was moved in preview, so staging -> preview catch-up must be done manually (rip)