### PR TITLE
Improve CLI arguments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
                 "chroma-js": "^2.4.2",
                 "command-exists": "^1.2.9",
                 "he": "^1.2.0",
-                "js-yaml": "^4.1.0"
+                "js-yaml": "^4.1.0",
+                "word-wrap": "^1.2.3"
             },
             "bin": {
                 "hsmusic": "src/upd8.js"
@@ -1895,7 +1896,6 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
             "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3289,8 +3289,7 @@
         "word-wrap": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-            "dev": true
+            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
         },
         "wrappy": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
         "chroma-js": "^2.4.2",
         "command-exists": "^1.2.9",
         "he": "^1.2.0",
-        "js-yaml": "^4.1.0"
+        "js-yaml": "^4.1.0",
+        "word-wrap": "^1.2.3"
     },
     "license": "GPL-3.0",
     "devDependencies": {

--- a/src/page/album-commentary.js
+++ b/src/page/album-commentary.js
@@ -4,6 +4,8 @@ import {generateAlbumExtrasPageNav} from './album.js';
 import {accumulateSum} from '../util/sugar.js';
 import {filterAlbumsByCommentary} from '../util/wiki-data.js';
 
+export const description = `per-album artist commentary pages & index`
+
 export function condition({wikiData}) {
   return filterAlbumsByCommentary(wikiData.albumData).length;
 }

--- a/src/page/album.js
+++ b/src/page/album.js
@@ -12,6 +12,8 @@ import {
   getTotalDuration,
 } from '../util/wiki-data.js';
 
+export const description = `per-album info & track artwork gallery pages`;
+
 export function targets({wikiData}) {
   return wikiData.albumData;
 }

--- a/src/page/artist-alias.js
+++ b/src/page/artist-alias.js
@@ -1,6 +1,8 @@
 // Artist alias redirect pages.
 // (Makes old permalinks bring visitors to the up-to-date page.)
 
+export const description = `redirects for aliased artist names`;
+
 export function targets({wikiData}) {
   return wikiData.artistAliasData;
 }

--- a/src/page/artist.js
+++ b/src/page/artist.js
@@ -15,6 +15,8 @@ import {
   sortChronologically,
 } from '../util/wiki-data.js';
 
+export const description = `per-artist info & artwork gallery pages`;
+
 export function targets({wikiData}) {
   return wikiData.artistData;
 }

--- a/src/page/flash.js
+++ b/src/page/flash.js
@@ -3,6 +3,8 @@
 import {empty} from '../util/sugar.js';
 import {getFlashLink} from '../util/wiki-data.js';
 
+export const description = `flash & game pages`;
+
 export function condition({wikiData}) {
   return wikiData.wikiInfo.enableFlashesAndGames;
 }

--- a/src/page/group.js
+++ b/src/page/group.js
@@ -9,6 +9,8 @@ import {
   sortChronologically,
 } from '../util/wiki-data.js';
 
+export const description = `per-group info & album gallery pages`;
+
 export function targets({wikiData}) {
   return wikiData.groupData;
 }

--- a/src/page/homepage.js
+++ b/src/page/homepage.js
@@ -11,6 +11,8 @@ import {
   getNewReleases,
 } from '../util/wiki-data.js';
 
+export const description = `main wiki homepage`;
+
 export function writeTargetless({wikiData}) {
   const {newsData, homepageLayout, wikiInfo} = wikiData;
 

--- a/src/page/listing.js
+++ b/src/page/listing.js
@@ -12,6 +12,8 @@ import {empty} from '../util/sugar.js';
 
 import {getTotalDuration} from '../util/wiki-data.js';
 
+export const description = `wiki-wide listing pages & index`;
+
 export function condition({wikiData}) {
   return wikiData.wikiInfo.enableListings;
 }

--- a/src/page/news.js
+++ b/src/page/news.js
@@ -1,5 +1,7 @@
 // News entry & index page specifications.
 
+export const description = `per-entry news pages & index`;
+
 export function condition({wikiData}) {
   return wikiData.wikiInfo.enableNews;
 }

--- a/src/page/static.js
+++ b/src/page/static.js
@@ -2,6 +2,8 @@
 // wiki data folder, used for a variety of purposes, e.g. wiki info,
 // changelog, and so on.)
 
+export const description = `static wiki-wide content pages specified in data`;
+
 export function targets({wikiData}) {
   return wikiData.staticPageData;
 }

--- a/src/page/tag.js
+++ b/src/page/tag.js
@@ -1,5 +1,7 @@
 // Art tag page specification.
 
+export const description = `per-artwork-tag gallery pages`;
+
 export function condition({wikiData}) {
   return wikiData.wikiInfo.enableArtTagUI;
 }

--- a/src/page/track.js
+++ b/src/page/track.js
@@ -18,6 +18,8 @@ import {
   sortChronologically,
 } from '../util/wiki-data.js';
 
+export const description = `per-track info pages`;
+
 export function targets({wikiData}) {
   return wikiData.trackData;
 }

--- a/src/upd8.js
+++ b/src/upd8.js
@@ -101,6 +101,8 @@ if (!validateReplacerSpec(replacerSpec, {find, link})) {
 async function main() {
   Error.stackTraceLimit = Infinity;
 
+  const defaultQueueSize = 500;
+
   const buildModeFlagOptions = (
     Object.fromEntries(
       Object.keys(buildModes)
@@ -138,6 +140,7 @@ async function main() {
 
   const commonOptions = {
     'help': {
+      help: `Display usage info and basic information for the \`hsmusic\` command`,
       type: 'flag',
     },
 
@@ -145,6 +148,7 @@ async function main() {
     // and like a jillion other things too. Pretty much everything which
     // makes an individual wiki what it is goes here!
     'data-path': {
+      help: `Specify path to data directory, including YAML files that cover all info about wiki content, layout, and structure; always required for wiki building, but may be provided by the HSMUSIC_DATA environment variable instead`,
       type: 'value',
     },
 
@@ -152,6 +156,7 @@ async function main() {
     // categorized; check out MEDIA_ALBUM_ART_DIRECTORY and other constants
     // near the top of this file (upd8.js).
     'media-path': {
+      help: `Specify path to media directory, including album artwork and additional files, as well as custom site layout media and other media files for reference or linking in wiki content; always required for wiki building, but may be provided by the HSMUSIC_MEDIA environment variable instead`,
       type: 'value',
     },
 
@@ -166,6 +171,7 @@ async function main() {
     // 8uild with the default (English) strings if this path is left
     // unspecified.
     'lang-path': {
+      help: `Specify path to language directory, including JSON files that mapping internal string keys to localized language content, and various language metadata`,
       type: 'value',
     },
 
@@ -173,12 +179,14 @@ async function main() {
     // kinda a pain to run every time, since it does necessit8te reading
     // every media file at run time. Pass this to skip it.
     'skip-thumbs': {
+      help: `Skip processing and generating thumbnails in media directory (speeds up subsequent builds, but remove this option [or use --thumbs-only] and re-run once when you add or modify media files to ensure thumbnails stay up-to-date!)`,
       type: 'flag',
     },
 
     // Or, if you *only* want to gener8te newly upd8ted thum8nails, you can
     // pass this flag! It exits 8efore 8uilding the rest of the site.
     'thumbs-only': {
+      help: `Skip everything besides processing media directory and generating up-to-date thumbnails (useful when using --skip-thumbs for most runs)`,
       type: 'flag',
     },
 
@@ -186,6 +194,7 @@ async function main() {
     // generating site HTML yet? This flag will cut execution off right
     // 8efore any site 8uilding actually happens.
     'no-build': {
+      help: `Don't run a build of the site at all; only process data/media and report any errors detected`,
       type: 'flag',
     },
 
@@ -194,10 +203,12 @@ async function main() {
     // line) right to your output, 8ut also pro8a8ly give you a headache
     // 8ecause wow that is a lot of visual noise.
     'show-traces': {
+      help: `Show JavaScript source code paths for reported errors in "aggregate" error displays\n\n(Debugging use only, but please enable this if you're reporting bugs for our issue tracker!)`,
       type: 'flag',
     },
 
     'queue-size': {
+      help: `Process more or fewer disk files at once to optimize performance or avoid I/O errors, unlimited if set to 0 (between 500 and 700 is usually a safe range for building HSMusic on Windows machines)\nDefaults to ${defaultQueueSize}`,
       type: 'value',
       validate(size) {
         if (parseInt(size) !== parseFloat(size)) return 'an integer';
@@ -211,6 +222,7 @@ async function main() {
     // CacheableObject in a mode where every instance is a Proxy which will
     // keep track of invalid property accesses.
     'show-invalid-property-accesses': {
+      help: `Report accesses at runtime to nonexistant properties on wiki data objects, at a dramatic performance cost\n(Internal/development use only)`,
       type: 'flag',
     },
 
@@ -224,6 +236,7 @@ async function main() {
     // efficiency of data calculation or write generation separately instead of
     // mixed together).
     'precache-data': {
+      help: `Compute all runtime-cached values for wiki data objects before proceeding to site build (optimizes rate of content generation/serving, but waits a lot longer before build actually starts, and may compute data which is never required for this build)`,
       type: 'flag',
     },
   };
@@ -340,7 +353,7 @@ async function main() {
   // Makes writing nicer on the CPU and file I/O parts of the OS, with a
   // marginal performance deficit while waiting for file writes to finish
   // before proceeding to more page processing.
-  const queueSize = +(cliOptions['queue-size'] ?? 500);
+  const queueSize = +(cliOptions['queue-size'] ?? defaultQueueSize);
 
   {
     let errored = false;

--- a/src/upd8.js
+++ b/src/upd8.js
@@ -101,10 +101,12 @@ async function main() {
 
   const selectedBuildModeFlags = Object.keys(
     await parseOptions(process.argv.slice(2), {
+      // Ignore unknown options for now - we'll handle and error them later.
       [parseOptions.handleUnknown]: () => {},
 
-      ...Object.fromEntries(Object.keys(buildModes)
-        .map((key) => [key, {type: 'flag'}])),
+      ...Object.fromEntries(
+        Object.keys(buildModes)
+          .map((key) => [key, {type: 'flag'}])),
     }));
 
   let selectedBuildModeFlag;
@@ -130,6 +132,13 @@ async function main() {
   };
 
   const cliOptions = await parseOptions(process.argv.slice(2), {
+    // We don't want to error when we receive these options, so specify them
+    // here, even though we won't be doing anything with them later.
+    // (This is a bit of a hack.)
+    ...Object.fromEntries(
+      Object.keys(buildModes)
+        .map((key) => [key, {type: 'flag'}])),
+
     ...selectedBuildMode.getCLIOptions(),
 
     // Data files for the site, including flash, artist, and al8um data,
@@ -217,8 +226,6 @@ async function main() {
     'precache-data': {
       type: 'flag',
     },
-
-    [parseOptions.handleUnknown]: () => {},
   });
 
   const dataPath = cliOptions['data-path'] || process.env.HSMUSIC_DATA;

--- a/src/upd8.js
+++ b/src/upd8.js
@@ -252,6 +252,8 @@ async function main() {
         console.log(`(No options available)`)
       }
 
+      let justInsertedPaddingLine = false;
+
       for (const {name, descriptor} of sortedOptions) {
         if (descriptor.alias) {
           continue;
@@ -261,6 +263,16 @@ async function main() {
           .filter(([_name, {alias}]) => alias === name)
           .map(([name]) => name);
 
+        let wrappedHelp, wrappedHelpLines = 0;
+        if (descriptor.help) {
+          wrappedHelp = indentWrap(4, descriptor.help);
+          wrappedHelpLines = wrappedHelp.split('\n').length;
+        }
+
+        if (wrappedHelpLines > 1 && !justInsertedPaddingLine) {
+          console.log('');
+        }
+
         console.log(color.bright(` --` + name) +
           (aliases.length
             ? ` (or: ${aliases.map(alias => color.bright(`--` + alias)).join(', ')})`
@@ -269,12 +281,21 @@ async function main() {
             ? ''
             : color.dim('  (no help provided)')));
 
-        if (descriptor.help) {
-          console.log(indentWrap(4, descriptor.help));
+        if (wrappedHelp) {
+          console.log(wrappedHelp);
+        }
+
+        if (wrappedHelpLines > 1) {
+          console.log('');
+          justInsertedPaddingLine = true;
+        } else {
+          justInsertedPaddingLine = false;
         }
       }
 
-      console.log(``);
+      if (!justInsertedPaddingLine) {
+        console.log(``);
+      }
     };
 
     console.log(

--- a/src/write/build-modes/live-dev-server.js
+++ b/src/write/build-modes/live-dev-server.js
@@ -25,13 +25,20 @@ import {
   generateRedirectHTML,
 } from '../page-template.js';
 
+const defaultHost = '0.0.0.0';
+const defaultPort = 8002;
+
+export const description = `Hosts a local HTTP server which generates page content as it is requested, instead of all at once; reacts to changes in data files, so new reloads will be up-to-date with on-disk YAML data (<- not implemented yet, check back soon!)\n\nIntended for local development ONLY; this custom HTTP server is NOT rigorously tested and almost certainly has security flaws`;
+
 export function getCLIOptions() {
   return {
     host: {
+      help: `Hostname to which HTTP server is bound\nDefaults to ${defaultHost}`,
       type: 'value',
     },
 
     port: {
+      help: `Port to which HTTP server is bound\nDefaults to ${defaultPort}`,
       type: 'value',
       validate(size) {
         if (parseInt(size) !== parseFloat(size)) return 'an integer';
@@ -57,8 +64,8 @@ export async function go({
   developersComment,
   getSizeOfAdditionalFile,
 }) {
-  const host = cliOptions['host'] ?? '0.0.0.0';
-  const port = parseInt(cliOptions['port'] ?? 8002);
+  const host = cliOptions['host'] ?? defaultHost;
+  const port = parseInt(cliOptions['port'] ?? defaultPort);
 
   let targetSpecPairs = getPageSpecsWithTargets({wikiData});
   const pages = progressCallAll(`Computing page data & paths for ${targetSpecPairs.length} targets.`,


### PR DESCRIPTION
Development:

- Fixes #141
- Fixes #142 (not *quite* done yet)

Notable changes:

- Remove `[parseOptions.handleUnknown]: () => {}` from `parseOptions` call, reenabling default behavior to error when unknown arguments are provided
- Clean function definition for `parseOptions`, no actual behavior changed
- Adds a god-dang `--help` option, darnit!
  - Code cleanup in `upd8.js` to handle more option descriptors as first-class data in variables, "help" argument added to help descriptors throughout code
  - Three categories of options: "common options" (shared across builds), "build mode selection" (specify one to choose build mode), "build options" (unique to selected build mode)
  - Also some essential usage info for `hsmusic` command at the top