### PR TITLE
Better support "skeleton" and minimal-content wikis

### DIFF
--- a/src/data/yaml.js
+++ b/src/data/yaml.js
@@ -241,7 +241,7 @@ export const processTrackGroupDocument = makeProcessDocument(T.TrackGroup, {
 
 export const processTrackDocument = makeProcessDocument(T.Track, {
   fieldTransformations: {
-    'Duration': getDurationInSeconds,
+    'Duration': parseDuration,
 
     'Date First Released': (value) => new Date(value),
     'Cover Art Date': (value) => new Date(value),
@@ -447,13 +447,9 @@ export function processHomepageLayoutRowDocument(document) {
 
 // --> Utilities shared across document parsing functions
 
-export function getDurationInSeconds(string) {
-  if (typeof string === 'number') {
-    return string;
-  }
-
+export function parseDuration(string) {
   if (typeof string !== 'string') {
-    throw new TypeError(`Expected a string or number, got ${string}`);
+    return string;
   }
 
   const parts = string.split(':').map((n) => parseInt(n));
@@ -467,7 +463,6 @@ export function getDurationInSeconds(string) {
 }
 
 export function parseAdditionalFiles(array) {
-  if (!array) return null;
   if (!Array.isArray(array)) {
     // Error will be caught when validating against whatever this value is
     return array;
@@ -493,8 +488,11 @@ export function parseCommentary(text) {
 }
 
 export function parseContributors(contributors) {
-  if (!contributors) {
-    return null;
+  // If this isn't something we can parse, just return it as-is.
+  // The Thing object's validators will handle the data error better
+  // than we're able to here.
+  if (!Array.isArray(contributors)) {
+    return contributors;
   }
 
   if (contributors.length === 1 && contributors[0].startsWith('<i>')) {
@@ -528,8 +526,11 @@ export function parseContributors(contributors) {
 }
 
 function parseDimensions(string) {
-  if (!string) {
-    return null;
+  // It's technically possible to pass an array like [30, 40] through here.
+  // That's not really an issue because if it isn't of the appropriate shape,
+  // the Thing object's validators will handle the error.
+  if (typeof string !== 'string') {
+    return string;
   }
 
   const parts = string.split(/[x,* ]+/g);

--- a/src/page/album.js
+++ b/src/page/album.js
@@ -53,7 +53,7 @@ export function write(album, {wikiData}) {
   const displayTrackGroups =
     album.trackGroups &&
       (album.trackGroups.length > 1 ||
-        !album.trackGroups[0].isDefaultTrackGroup);
+        !album.trackGroups[0]?.isDefaultTrackGroup);
 
   const listTag = getAlbumListTag(album);
 
@@ -301,6 +301,7 @@ export function write(album, {wikiData}) {
                 })),
 
             displayTrackGroups &&
+            !empty(album.trackGroups) &&
               html.tag('dl',
                 {class: 'album-group-list'},
                 album.trackGroups.flatMap(({
@@ -323,6 +324,7 @@ export function write(album, {wikiData}) {
                 ])),
 
             !displayTrackGroups &&
+            !empty(album.tracks) &&
               html.tag(listTag,
                 album.tracks.map(trackToListItem)),
 
@@ -758,6 +760,10 @@ export function generateAlbumNavLinks(album, currentTrack, {
     ...extraLinks || [],
     randomLink,
   ].filter(Boolean);
+
+  if (empty(allLinks)) {
+    return '';
+  }
 
   return `(${language.formatUnitList(allLinks)})`;
 }

--- a/src/page/group.js
+++ b/src/page/group.js
@@ -16,8 +16,7 @@ export function targets({wikiData}) {
 export function write(group, {wikiData}) {
   const {listingSpec, wikiInfo} = wikiData;
 
-  const {albums} = group;
-  const tracks = albums.flatMap((album) => album.tracks);
+  const tracks = group.albums.flatMap((album) => album.tracks);
   const totalDuration = getTotalDuration(tracks, {originalReleasesOnly: true});
 
   const albumLines = group.albums.map((album) => ({
@@ -65,7 +64,7 @@ export function write(group, {wikiData}) {
               transformMultiline(group.description)),
 
           ...html.fragment(
-            group.albums && [
+            !empty(group.albums) && [
               html.tag('h2',
                 {class: ['content-heading']},
                 language.$('groupInfoPage.albumList.title')),
@@ -123,7 +122,7 @@ export function write(group, {wikiData}) {
     }),
   };
 
-  const galleryPage = {
+  const galleryPage = !empty(group.albums) && {
     type: 'page',
     path: ['groupGallery', group.directory],
     page: ({
@@ -165,7 +164,7 @@ export function write(group, {wikiData}) {
                   unit: true,
                 })),
               albums: html.tag('b',
-                language.countAlbums(albums.length, {
+                language.countAlbums(group.albums.length, {
                   unit: true,
                 })),
               time: html.tag('b',
@@ -222,7 +221,7 @@ export function write(group, {wikiData}) {
     }),
   };
 
-  return [infoPage, galleryPage];
+  return [infoPage, galleryPage].filter(Boolean);
 }
 
 // Utility functions
@@ -239,8 +238,6 @@ function generateGroupSidebar(currentGroup, isGallery, {
   if (!wikiInfo.enableGroupUI) {
     return null;
   }
-
-  const linkKey = isGallery ? 'groupGallery' : 'groupInfo';
 
   return {
     content: [
@@ -260,15 +257,21 @@ function generateGroupSidebar(currentGroup, isGallery, {
                 category: `<span class="group-name">${category.name}</span>`,
               })),
             html.tag('ul',
-              category.groups.map((group) =>
-                html.tag('li',
+              category.groups.map((group) => {
+                const linkKey = (
+                  isGallery && !empty(group.albums)
+                    ? 'groupGallery'
+                    : 'groupInfo');
+
+                return html.tag('li',
                   {
                     class: group === currentGroup && 'current',
                     style: getLinkThemeString(group.color),
                   },
                   language.$('groupSidebar.groupList.item', {
                     group: link[linkKey](group),
-                  })))),
+                  }));
+              })),
           ])),
     ],
   };

--- a/src/util/io.js
+++ b/src/util/io.js
@@ -12,7 +12,9 @@ export async function findFiles(dataPath, {
   try {
     files = await readdir(dataPath);
   } catch (error) {
-    throw new AggregateError([error], `Failed to list files from ${dataPath}`);
+    throw Object.assign(
+      new AggregateError([error], `Failed to list files from ${dataPath}`),
+      {code: error.code});
   }
 
   return files


### PR DESCRIPTION
This PR covers a few things to do with "skeleton" wikis and data objects with minimal content:

* 080b4fb85b6dab893865277c94a65311dfe779a2: Handle missing data files more gracefully - if an `allInOne`/`singleDocument` data file isn't present, or a `files()` call errors `ENOENT`, we just call the respective `save()` document with an appropriately empty document / array, instead of erroring.
* 9feb0ab325846ba3a659f6555d4eadeeeb654c39: Pass type mismatches through YAML field transform functions like `parseDimensions` - let the validators handle and report errors like they're designed to, instead of short-circuiting.
* d5972ffdbe482e8170538aee42ed90306f7bec09: Support trackless albums - fixes a crashing error, keeps the track list from generating at all, and removes an empty "()" in the nav bar.
* 5b5e8f61268d3fab32d3acfd73939da48628eb20: Support albumless groups - keep the album list from generating at all (we attempted and failed to detect this previously), and don't generate the gallery page for these (without breaking the sidebar links in other gallery pages).

This is a staging PR since it just fixes a bunch of bugs and edge-cases, without affecting any features or changing the internal or YAML data shapes.

This PR is related to but separate from #151, which includes changes to the overall shape of the data format (rather than the YAML→object→page flow). That one's a preview PR, accordingly.