### PR TITLE
Automatically verify expected vs. extant image files at build time

### DIFF
--- a/src/upd8.js
+++ b/src/upd8.js
@@ -40,6 +40,7 @@ import genThumbs, {
   clearThumbs,
   defaultMagickThreads,
   isThumb,
+  verifyImagePaths,
 } from './gen-thumbs.js';
 
 import bootRepl from './repl.js';
@@ -665,6 +666,8 @@ async function main() {
   }
 
   const urls = generateURLs(urlSpec);
+
+  await verifyImagePaths(mediaPath, {urls, wikiData});
 
   const fileSizePreloader = new FileSizePreloader();
 


### PR DESCRIPTION
This PR adds a new utility to `gen-thumbs` (and reorganizes the file a little to support it) called `verifyImagePaths`, which is run automatically at build time. It traverses all present image files for their paths, collects a list of expected image paths, and compares the two, reporting on any mismatches.

<img width="596" alt="Build log: Some track art is missing! (120 files)" src="https://user-images.githubusercontent.com/9948030/233787114-32091516-6457-48ff-8c81-b4281020b920.png">

<img width="517" alt="Build long: Some track art is misplaced! (135 files)" src="https://user-images.githubusercontent.com/9948030/233787120-47d025e6-456e-4b8e-b19f-cce102f7384a.png">

Image paths it checks:

* Album cover artworks
* Album banners
* Album wallpapers
* Track cover artworks
* Artist avatars
* Flash art

Image paths it *doesn't* check:

* Anything under `misc`, which includes media files referenced in commentary or otherwise generically hosted on the site
* Anything under `album-additional` (though these are reported a bit less gracefully via the image file size loader)

Most of the code here is written with custom URL specs in mind. However, it's not perfect. The algorithm for checking which extant files should actually be compared against expected files is hard-coded (e.g. so `album-art` is checked but `misc` is not). Getting rid of this hard-codedness would necessitate implementing a new "arbitrary URL string matches url-spec key" function, which (albeit cool and useful) is out of scope for this PR.