### PR TITLE
Define default wiki color in JS rather than CSS

### DIFF
--- a/src/data/things/wiki-info.js
+++ b/src/data/things/wiki-info.js
@@ -2,11 +2,16 @@ import Thing from './thing.js';
 
 import find from '../../util/find.js';
 
+// Running your own wiki? Don't change this here!
+// Set a wiki-specific color in your data directory's wiki-info.yaml file.
+const defaultWikiColor = '#0088ff';
+
 export class WikiInfo extends Thing {
   static [Thing.getPropertyDescriptors] = ({
     Group,
 
     validators: {
+      isColor,
       isLanguageCode,
       isName,
       isURL,
@@ -27,7 +32,10 @@ export class WikiInfo extends Thing {
       },
     },
 
-    color: Thing.common.color(),
+    color: ({
+      flags: {update: true, expose: true},
+      update: {validate: isColor, default: defaultWikiColor},
+    }),
 
     // One-line description used for <meta rel="description"> tag.
     description: Thing.common.simpleString(),

--- a/src/static/site3.css
+++ b/src/static/site3.css
@@ -3,13 +3,7 @@
  * no need to re-run upd8.js when tweaking values here. Handy!
  */
 
-:root {
-  --primary-color: #0088ff;
-}
-
-/* Layout - Common
- *
- */
+/* Layout - Common */
 
 body {
   margin: 10px;


### PR DESCRIPTION
Development:

- Fixes #169

I've only tested this against data-steps so far, but I believe it should work on the existing codebase too, since other pages which don't have their own color fields already expect to inherit from the WikiInfo color property - see the issue linked above.