### PR TITLE
Handle special characters in URLs more carefully

### DIFF
--- a/src/misc-templates.js
+++ b/src/misc-templates.js
@@ -552,7 +552,7 @@ function unbound_iconifyURL(url, {
     html.tag('svg', [
       html.tag('title', msg),
       html.tag('use', {
-        href: to('shared.staticFile', `icons.svg#icon-${id}`),
+        href: to('shared.staticIcon', id),
       }),
     ]));
 }

--- a/src/url-spec.js
+++ b/src/url-spec.js
@@ -60,7 +60,9 @@ const urlSpec = {
       staticRoot: 'static',
 
       utilityFile: 'util/<>',
-      staticFile: 'static/<>',
+      staticFile: 'static/<>?<>',
+
+      staticIcon: 'static/icons.svg#icon-<>',
     },
   },
 

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -132,14 +132,6 @@ export function attributes(attribs) {
         throw new Error(`Attribute value for ${key} should be primitive or array, got ${typeof val}`);
     })
     .filter(([_key, _val, keep]) => keep)
-    .map(([key, val]) => {
-      switch (key) {
-        case 'href':
-          return [key, encodeURI(val)];
-        default:
-          return [key, val];
-      }
-    })
     .map(([key, val]) =>
       typeof val === 'boolean'
         ? `${key}`

--- a/src/util/urls.js
+++ b/src/util/urls.js
@@ -94,7 +94,9 @@ export function generateURLs(urlSpec) {
             if (device) {
               return value;
             } else {
-              return encodeURIComponent(value);
+              let encoded = encodeURIComponent(value);
+              encoded = encoded.replaceAll('%2F', '/');
+              return encoded;
             }
           } else {
             missing++;

--- a/src/util/urls.js
+++ b/src/util/urls.js
@@ -79,16 +79,23 @@ export function generateURLs(urlSpec) {
     );
 
     const toHelper =
-      (delimiterMode) =>
+      ({device}) =>
       (key, ...args) => {
         const {
-          value: {[delimiterMode]: template},
+          value: {
+            [device ? 'device' : 'posix']: template,
+          },
         } = getValueForFullKey(relative, key);
 
         let missing = 0;
         let result = template.replaceAll(/<([0-9]+)>/g, (match, n) => {
           if (n < args.length) {
-            return args[n];
+            const value = args[n];
+            if (device) {
+              return value;
+            } else {
+              return encodeURIComponent(value);
+            }
           } else {
             missing++;
           }
@@ -106,8 +113,8 @@ export function generateURLs(urlSpec) {
       };
 
     return {
-      to: toHelper('posix'),
-      toDevice: toHelper('device'),
+      to: toHelper({device: false}),
+      toDevice: toHelper({device: true}),
     };
   };
 

--- a/src/write/page-template.js
+++ b/src/write/page-template.js
@@ -665,7 +665,7 @@ export function generateDocumentHTML(pageInfo, {
 
         html.tag('link', {
           rel: 'stylesheet',
-          href: to('shared.staticFile', `site3.css?${cachebust}`),
+          href: to('shared.staticFile', 'site3.css', cachebust),
         }),
 
         html.tag('style',
@@ -676,7 +676,7 @@ export function generateDocumentHTML(pageInfo, {
           ]),
 
         html.tag('script', {
-          src: to('shared.staticFile', `lazy-loading.js?${cachebust}`),
+          src: to('shared.staticFile', 'lazy-loading.js', cachebust),
         }),
       ]),
 
@@ -694,7 +694,7 @@ export function generateDocumentHTML(pageInfo, {
 
           html.tag('script', {
             type: 'module',
-            src: to('shared.staticFile', `client.js?${cachebust}`),
+            src: to('shared.staticFile', 'client.js', cachebust),
           }),
         ]),
     ]);


### PR DESCRIPTION
Development:

* Resolves #162.
* This targets `staging`. It's already merged in `data-steps`: b348289

Changes:

* Moves URI encoding into `urls.js`, instead of special-casing for `href` attribute in `html.js`.
  * URI encoding occurs only for `to()`, not `toDevice()`.
  * Slashes (`/`) are special-cased to never be encoded. These carry semantic meaning within arbitrary arguments (e.g. an image which is sourced from `to('media.path', 'misc/changelog/cool-image.png`, or listing pages, `to('localized.listing', 'albums/by-name')`).
* Changes spec for `shared.staticFile` to include cachebust directly, ex. `to('shared.staticFile', 'client.js', '413')` instead of `to('shared.staticFile', 'client.js?413')`
* Adds spec for `shared.staticIcon` which links directly to `icons.svg` with the desired icon in hash form (`to('shared.staticIcon', 'twitter')`)
  * For now, this cache does not include a cachebust. This is the same as previously.