### PR TITLE
Dot-underline "interactive" links

### DIFF
--- a/src/static/site4.css
+++ b/src/static/site4.css
@@ -364,10 +364,15 @@ body::before {
   padding-left: 5px;
 }
 
+summary > span {
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-decoration-color: var(--primary-color);
+}
+
 summary > span:hover {
   cursor: pointer;
-  text-decoration: underline;
-  text-decoration-color: var(--primary-color);
+  text-decoration-style: solid;
 }
 
 summary .group-name {


### PR DESCRIPTION
Development:

* Resolves #211.
* Draft PR: This doesn't style the ["Sorting by duration" / "Sorting by count"](https://github.com/hsmusic/hsmusic-wiki/issues/202#issuecomment-1615280596) link yet.
* ~~Draft PR: Still need to decide about styling "Jump to:" or "Has additional files:" hash links.~~
  * I think it's okay to not style *any* links for which the action verb is "go somewhere". Obviously we aren't styling links which *leave* the current page, but really that's just a more specific kind of "going somewhere" - and clicking a link to scroll you to somewhere else on the same page is just another such kind! I'd rather focus on just dot-underlining links that really *change* something about the view you're looking at. (There aren't a lot of these on the wiki yet, but more are coming.)
* ~~Draft PR: Needs some work for awkwardness in sidebar `<summary>` (see caveat below).~~
  * The `<details>` element already has a triangle icon on the side which identifies its purpose pretty clearly. I think I'd *like* it to be stylable, but it just really doesn't work with the way browsers style dot-underlines today, so I'm okay leaving it as-is without the underline!

Attempts to make normal "go to another page" links visually distinct from "change or interact with something on the current page" links. The main message of dotted underline is to indicate that you should expect some behavior besides just going to a different page when you interact with the link.

Caveat: Only Firefox handles underlines which span multiple inline elements nicely. On other browsers, you get some ickiness when a dotted-underline element has its own (inline) children. I haven't found a very nice solution to this yet besides altogether avoiding dotting elements with children (and haven't designed around that yet).

<img width="400" alt="Inconsistent gaps between dots and dashes in various browsers, as described above" src="https://github.com/hsmusic/hsmusic-wiki/assets/9948030/7d039226-e627-45cf-9eb8-aafcc581b84b">

That shows up in album sidebars:

<img width="269" alt="Sidebar of an album with dotted underline beneath the 'Main album (1–25)' section header; the underline has an unexplained and unseemly gap near the 'm' in 'album'" src="https://github.com/hsmusic/hsmusic-wiki/assets/9948030/3013f44a-55d6-4727-a165-1e37ea3959c1">
