### PR TITLE
Increased contrast (via @media query)

### DIFF
--- a/src/static/site4.css
+++ b/src/static/site4.css
@@ -7,6 +7,13 @@
   --primary-color: #0088ff;
 }
 
+:root {
+  --wiki-color: #0088ff;
+
+  --box-background: rgba(0, 0, 0, 0.6);
+  --box-border-style: dotted;
+}
+
 /* Layout - Common
  *
  */
@@ -262,10 +269,10 @@ body::before {
 #secondary-nav,
 #skippers,
 #footer {
-  background-color: rgba(0, 0, 0, 0.6);
-  border: 1px dotted var(--primary-color);
+  background: var(--box-background);
+  border: 1px var(--box-border-style) var(--primary-color);
   border-radius: 3px;
-  transition: background-color 0.2s;
+  transition: background 0.2s;
 }
 
 /*
@@ -275,7 +282,7 @@ body::before {
 #secondary-nav:focus-within,
 #skippers:focus-within,
 #footer:focus-within {
-  background-color: rgba(0, 0, 0, 0.85);
+  background: rgba(0, 0, 0, 0.85);
   border-style: solid;
 }
 */
@@ -868,7 +875,7 @@ img {
   display: inline-block;
   text-align: center;
   background-color: #111111;
-  border: 1px dotted var(--primary-color);
+  border: 1px var(--box-border-style) var(--primary-color);
   border-radius: 2px;
   padding: 5px;
   margin: 10px;
@@ -1680,5 +1687,65 @@ html[data-language-code="preview-en"][data-url-key="localized.home"] #content
 
   #header > div:not(:first-child) {
     margin-top: 0.5em;
+  }
+}
+
+/* Customizatino - Prefer increased contrast */
+
+@media (prefers-contrast: more) {
+  :root {
+    --box-background: black;
+    --box-border-style: solid;
+
+    --focus-color: #aaaaff;
+  }
+
+  #page-container {
+    border: 1px solid white;
+    border-radius: 6px;
+    background: rgba(35, 35, 35, 1);
+  }
+
+  body::before {
+    opacity: 0.3 !important;
+    filter: contrast(0.75) brightness(0.5);
+  }
+
+  .grid-item:hover, a.box:focus {
+    outline: 3px double var(--focus-color);
+  }
+
+  a:not(.box) {
+    text-decoration: underline;
+  }
+
+  a:not(.box):hover,
+  a:not(.box):focus {
+    color: var(--focus-color);
+    text-decoration-color: var(--focus-color) !important;
+  }
+
+  summary > span:hover,
+  summary:focus-visible > span {
+    text-decoration: underline;
+    text-decoration-color: var(--focus-color);
+  }
+
+  summary > span:hover .group-name,
+  summary:focus-visible > span .group-name {
+    color: var(--focus-color);
+  }
+
+  .icon:hover > svg,
+  .icon:focus > svg {
+    fill: var(--focus-color);
+  }
+
+  .rerelease,
+  .other-group-accent,
+  .reveal-interaction,
+  .grid-item > span:not(:first-of-type),
+  #image-overlay-file-size-warning {
+    opacity: 1;
   }
 }


### PR DESCRIPTION
Development:

- Resolves #228.

This updates the stylesheet to apply moderately aggressive contrast-increasing styles when the browser indicates increased contrast is desired via `@media` query.

There's room to enable these styles via a configuration screen later, but it's not a blocker. [Supported across modern browsers.](https://caniuse.com/mdn-css_at-rules_media_prefers-contrast)

<img width="1219" alt="Wiki homepage with increased contrast. Links are underlined, layout boxes have solid borders instead of dotted, and the whole page area has a white outline." src="https://github.com/hsmusic/hsmusic-wiki/assets/9948030/a63060e2-525a-4cbc-bb23-8acb8183aa36">

<img width="1231" alt="AlterniaBound album info page. Lots of underlined links. Page background is opaque grey instead of transparent and color-tinted, and layout boxes are solid black background." src="https://github.com/hsmusic/hsmusic-wiki/assets/9948030/a6672cb4-0d9e-4d9a-99f3-d4aa70c8be8f">

<img width="1208" alt="Showtime (Marching Band) track info page showing the full layout. Links in commentary, footer, etc are also underlined. The album background is also dimmer than usual." src="https://github.com/hsmusic/hsmusic-wiki/assets/9948030/a8b5b060-7d38-472c-b5e1-f7e6266ab45c">
