### PR TITLE
Pre-crop images as squares for smaller thumbnails

### DIFF
--- a/src/content/dependencies/generateWikiHomeNewsBox.js
+++ b/src/content/dependencies/generateWikiHomeNewsBox.js
@@ -64,7 +64,7 @@ export default {
                 mainLink,
               ]),
 
-              content.slot('thumb', 'medium'),
+              content,
 
               html.tag('p',
                 {[html.onlyIfContent]: true},

--- a/src/gen-thumbs.js
+++ b/src/gen-thumbs.js
@@ -81,8 +81,8 @@ const thumbnailSpec = {
   'huge': {size: 1600, quality: 90},
   'semihuge': {size: 1200, quality: 92},
   'large': {size: 800, quality: 93},
-  'medium': {size: 400, quality: 95},
-  'small': {size: 250, quality: 85},
+  'medium': {size: 400, quality: 95, square: true},
+  'small': {size: 250, quality: 85, square: true},
 };
 
 import {spawn} from 'child_process';
@@ -178,16 +178,23 @@ function generateImageThumbnails(filePath, {spawnConvert}) {
   const basename = path.basename(filePath, extname);
   const output = (name) => path.join(dirname, basename + name + '.jpg');
 
-  const convert = (name, {size, quality}) =>
+  const convert = (name, {size, quality, square}) =>
     spawnConvert([
       filePath,
-      '-strip',
-      '-resize',
-      `${size}x${size}>`,
-      '-interlace',
-      'Plane',
-      '-quality',
-      `${quality}%`,
+      ...
+        (square
+          // Scale so the smaller length matches the specified size.
+          // Then crop about the center. The result will always be
+          // a square image, scaled as to retain the best resolution
+          // in the specified dimensions.
+          ? ['-thumbnail', `${size}x${size}^`,
+             '-gravity', 'center',
+             '-extent', `${size}x${size}`]
+          // Scale so the longer length matches the specified size.
+          // The result will retain the original aspect ratio.
+          : ['-thumbnail', `${size}x${size}>`]),
+      '-interlace', 'Plane',
+      '-quality', `${quality}%`,
       output(name),
     ]);
 


### PR DESCRIPTION
Development:

* Fixes #241.
* ⚠️ Blocked on #263 - see caveat discussion below!

In effect, this PR crops images to square dimensions for smaller thumbnails so that they are already the correct resolution to fill a square presentation on the website. This affects the `medium` and `small` thumbs only, which are used for cover artworks and grid cells respectively — both square containers. This doesn't affect the larger thumbnails, which are used for commentary (or [are supposed to](https://github.com/hsmusic/hsmusic-wiki/issues/241)) and the large image preview — both intended to display images at their original aspect ratio.

Caveat: Because `medium` now crops to square, it's never appropriate for display in content. The homepage news box has been adjusted accordingly, although it's [only ever displayed one image](https://hsmusic.wiki/news/ball-drop-23/) and that news entry will be pushed out of the latest news by the time this PR lands.

That's a blocker because we now might display `medium` thumbs *even if* we asked for `large`! Specifically, for images which [never got a `large` thumb generated to begin with](https://github.com/hsmusic/hsmusic-wiki/issues/187) — that's all images under 800x800, currently.