### PR TITLE
Add "cover" and "semilarge" thumb sizes

### DIFF
--- a/src/content/dependencies/generateCoverArtwork.js
+++ b/src/content/dependencies/generateCoverArtwork.js
@@ -45,7 +45,7 @@ export default {
             .slots({
               path: slots.path,
               alt: slots.alt,
-              thumb: 'medium',
+              thumb: 'cover',
               id: 'cover-art',
               reveal: true,
               link: true,

--- a/src/content/dependencies/generateWikiHomeNewsBox.js
+++ b/src/content/dependencies/generateWikiHomeNewsBox.js
@@ -64,7 +64,7 @@ export default {
                 mainLink,
               ]),
 
-              content.slot('thumb', 'medium'),
+              content,
 
               html.tag('p',
                 {[html.onlyIfContent]: true},

--- a/src/gen-thumbs.js
+++ b/src/gen-thumbs.js
@@ -81,8 +81,8 @@ const thumbnailSpec = {
   'huge': {size: 1600, quality: 90},
   'semihuge': {size: 1200, quality: 92},
   'large': {size: 800, quality: 93},
-  'medium': {size: 400, quality: 95},
-  'small': {size: 250, quality: 85},
+  'medium': {size: 400, quality: 95, square: true},
+  'small': {size: 250, quality: 85, square: true},
 };
 
 import {spawn} from 'child_process';
@@ -178,16 +178,23 @@ function generateImageThumbnails(filePath, {spawnConvert}) {
   const basename = path.basename(filePath, extname);
   const output = (name) => path.join(dirname, basename + name + '.jpg');
 
-  const convert = (name, {size, quality}) =>
+  const convert = (name, {size, quality, square}) =>
     spawnConvert([
       filePath,
-      '-strip',
-      '-resize',
-      `${size}x${size}>`,
-      '-interlace',
-      'Plane',
-      '-quality',
-      `${quality}%`,
+      ...
+        (square
+          // Scale so the smaller length matches the specified size.
+          // Then crop about the center. The result will always be
+          // a square image, scaled as to retain the best resolution
+          // in the specified dimensions.
+          ? ['-thumbnail', `${size}x${size}^`,
+             '-gravity', 'center',
+             '-extent', `${size}x${size}`]
+          // Scale so the longer length matches the specified size.
+          // The result will retain the original aspect ratio.
+          : ['-thumbnail', `${size}x${size}>`]),
+      '-interlace', 'Plane',
+      '-quality', `${quality}%`,
       output(name),
     ]);
 

--- a/src/gen-thumbs.js
+++ b/src/gen-thumbs.js
@@ -81,6 +81,8 @@ const thumbnailSpec = {
   'huge': {size: 1600, quality: 90},
   'semihuge': {size: 1200, quality: 92},
   'large': {size: 800, quality: 93},
+  'semilarge': {size: 600, quality: 94},
+  'cover': {size: 600, quality: 94, square: true},
   'medium': {size: 400, quality: 95, square: true},
   'small': {size: 250, quality: 85, square: true},
 };

--- a/src/static/client2.js
+++ b/src/static/client2.js
@@ -756,13 +756,18 @@ function getPreferredThumbSize() {
   // device configurations.
   const visualLength = window.devicePixelRatio * constrainedLength;
 
+  const semilargeLength = 600;
   const largeLength = 800;
   const semihugeLength = 1200;
   const goodEnoughThreshold = 0.90;
 
-  if (Math.floor(visualLength * goodEnoughThreshold) <= largeLength) {
+  const goodEnoughLength = Math.floor(visualLength * goodEnoughThreshold);
+
+  if (goodEnoughLength <= semilargeLength) {
+    return 'semilarge';
+  } else if (goodEnoughLength <= largeLength) {
     return 'large';
-  } else if (Math.floor(visualLength * goodEnoughThreshold) <= semihugeLength) {
+  } else if (goodEnoughLength <= semihugeLength) {
     return 'semihuge';
   } else {
     return 'huge';

--- a/src/util/urls.js
+++ b/src/util/urls.js
@@ -143,6 +143,7 @@ const thumbnailHelper = (name) => (file) =>
 
 export const thumb = {
   large: thumbnailHelper('.large'),
+  cover: thumbnailHelper('.cover'),
   medium: thumbnailHelper('.medium'),
   small: thumbnailHelper('.small'),
 };


### PR DESCRIPTION
Development:

* Resolves #244.
* Based on #243.
* This is a draft PR for discussion below, as well as for an implementation detail (selectively loading thumbs based on display DPI, if possible via HTML alone). Expecting to return to this a bit later.

Both 600x600, but `cover` is square-cropping and `semilarge` is not. `cover` is intended for use in `generateCoverArtwork` of course (i.e. the main art image on album, track, flash pages and such). `semilarge` is a corresponding smaller "right-fit" available for the client-side large image preview.

The motivator for this change is that the 400x400 `medium` thumbs currently used for cover artworks result in mildly blurry upscaling on high-DPI displays in the wide layout, as well as on about 450–600px wide displays of even normal CSS-matches-display-pixel DPI in the thin layout.

A 400x400 image doesn't exactly look awful rendered at about 600x600, though, or even when upscaled to about 800x800 on high-DPI displays in the thin layout. From some unscientific sampling, 600x600 at quality 94 results in about 40% larger files than 400x400 at quality 95. That's a moderately large tradeoff for mobile and slower network access, and you can always opt in to getting the best-fit size on particular covers just by clicking and showing the client-side image preview.

I've left this as a draft, besides the uncertainty, because I want to investigate if it's possible to restrict loading higher resolution images to high-DPI devices purely in HTML (no JavaScript nonsense).