### PR TITLE
Rework "has cover art" type fields

### DIFF
--- a/src/data/things/album.js
+++ b/src/data/things/album.js
@@ -104,7 +104,6 @@ export class Album extends Thing {
       update: {validate: isDimensions},
     },
 
-    hasTrackArt: Thing.common.flag(true),
     hasTrackNumbers: Thing.common.flag(true),
     isListedOnHomepage: Thing.common.flag(true),
     isListedInGalleries: Thing.common.flag(true),

--- a/src/data/things/track.js
+++ b/src/data/things/track.js
@@ -1,9 +1,10 @@
 import Thing from './thing.js';
 
 import {inspect} from 'util';
-import {color} from '../../util/cli.js';
 
+import {color} from '../../util/cli.js';
 import find from '../../util/find.js';
+import {empty} from '../../util/sugar.js';
 
 export class Track extends Thing {
   static [Thing.referenceType] = 'track';
@@ -332,36 +333,44 @@ export class Track extends Thing {
     albumData?.find((album) => album.tracks.includes(track));
 
   // Another reused utility function. This one's logic is a bit more complicated.
-  static hasCoverArt = (
+  static hasCoverArt(
     track,
     albumData,
     coverArtistContribsByRef,
     hasCoverArt
-  ) => (
-    hasCoverArt ??
-    (coverArtistContribsByRef?.length > 0 || null) ??
-    Track.findAlbum(track, albumData)?.hasTrackArt ??
-    true
-  );
+  ) {
+    if (!empty(coverArtistContribsByRef)) {
+      return true;
+    }
 
-  // Now this is a doozy!
+    const album = Track.findAlbum(track, albumData);
+    if (album && !empty(album.trackCoverArtistContribsByRef)) {
+      return true;
+    }
+
+    return false;
+  }
+
   static hasUniqueCoverArt(
     track,
     albumData,
     coverArtistContribsByRef,
     hasCoverArt
   ) {
-    if (coverArtistContribsByRef?.length > 0) {
+    if (!empty(coverArtistContribsByRef)) {
       return true;
-    } else if (coverArtistContribsByRef) {
-      return false;
-    } else if (hasCoverArt === false) {
-      return false;
-    } else if (Track.findAlbum(track, albumData)?.hasTrackArt) {
-      return true;
-    } else {
+    }
+
+    if (hasCoverArt === false) {
       return false;
     }
+
+    const album = Track.findAlbum(track, albumData);
+    if (album && !empty(album.trackCoverArtistContribsByRef)) {
+      return true;
+    }
+
+    return false;
   }
 
   [inspect.custom]() {

--- a/src/data/yaml.js
+++ b/src/data/yaml.js
@@ -193,7 +193,6 @@ export const processAlbumDocument = makeProcessDocument(T.Album, {
     color: 'Color',
     urls: 'URLs',
 
-    hasTrackArt: 'Has Track Art',
     hasTrackNumbers: 'Has Track Numbers',
     isListedOnHomepage: 'Listed on Homepage',
     isListedInGalleries: 'Listed in Galleries',

--- a/src/upd8.js
+++ b/src/upd8.js
@@ -40,6 +40,7 @@ import genThumbs, {
   clearThumbs,
   defaultMagickThreads,
   isThumb,
+  verifyImagePaths,
 } from './gen-thumbs.js';
 
 import bootRepl from './repl.js';
@@ -665,6 +666,8 @@ async function main() {
   }
 
   const urls = generateURLs(urlSpec);
+
+  await verifyImagePaths(mediaPath, {urls, wikiData});
 
   const fileSizePreloader = new FileSizePreloader();
 

--- a/src/util/wiki-data.js
+++ b/src/util/wiki-data.js
@@ -715,7 +715,7 @@ export function getTrackCover(track, {to}) {
   // just inherits the album's own cover art. Note that since cover art isn't
   // guaranteed on albums either, it's possible that this function returns
   // null!
-  if (!track.hasCoverArt) {
+  if (!track.hasUniqueCoverArt) {
     return getAlbumCover(track.album, {to});
   } else {
     return to('media.trackCover', track.album.directory, track.directory, track.coverArtFileExtension);


### PR DESCRIPTION
Development:

* Resolves #250.
* Resolves #176.
* Merge alongside https://github.com/hsmusic/hsmusic-data/pull/237.
* Based on #173.

Implements the new behavior for `Track.hasUniqueCoverArt` described in #250, which nullifies the need for `Has Track Art` on any albums as well as for `Has Cover Art` on most tracks. Simply leaving `Cover Artists` unset is usually sufficient. (Exception being when the album has `Default Track Cover Artists` set, e.g. Hiveswap Friendsim, INHOSPITABLE DELISTED.)

This is essentially a follow-up to #175, focusing on minimizing the "bulk" of data files by gleaning more information from statements that are always true. (Namely: "Cover art is always associated with cover artist credits. So always depend on the presence of credits to indicate the existence of cover art, rather than getting distracted with secondary fields and default values and similar bullshit.")