### PR TITLE
Fix how thumbnail generation is queued

### DIFF
--- a/src/upd8.js
+++ b/src/upd8.js
@@ -233,6 +233,12 @@ async function main() {
 
     'magick-threads': {
       help: `Process more or fewer thumbnail files at once with ImageMagick when generating thumbnails. (Each ImageMagick thread may also make use of multi-core processing at its own utility.)`,
+      type: 'value',
+      validate(threads) {
+        if (parseInt(threads) !== parseFloat(threads)) return 'an integer';
+        if (parseInt(threads) < 0) return 'a counting number or zero';
+        return true;
+      }
     },
     magick: {alias: 'magick-threads'},
 


### PR DESCRIPTION
Development:

* Resolves #158.
* Based on #192. One merged, this PR will be rebased to `preview`.

Previously, thumbnail generation is technically queued with `magickThreads`, but each queued call potentially spawns many threads. This PR flattens the calls passed to queue, so `magickThreads` controls the queuing of individual threads instead of the group of threads associated with a particular file path. It makes adjustments to surrounding code to fit this in with cache-updating, and also fixes a bug where `--magick-threads` wasn't actually being used in upd8.js's CLI args.