### PR TITLE
Defend much harder against missing thumbnail info

### DIFF
--- a/src/gen-thumbs.js
+++ b/src/gen-thumbs.js
@@ -168,10 +168,22 @@ getThumbnailsAvailableForDimensions.all =
     .map(([name, {size}]) => [name, size])
     .sort((a, b) => b[1] - a[1]);
 
+export function checkIfImagePathHasCachedThumbnails(imagePath, cache) {
+  // Generic utility for checking if the thumbnail cache includes any info for
+  // the provided image path, so that the other functions don't hard-code the
+  // cache format.
+
+  return !!cache[imagePath];
+}
+
 export function getDimensionsOfImagePath(imagePath, cache) {
   // This function is really generic. It takes the gen-thumbs image cache and
   // returns the dimensions in that cache, so that other functions don't need
   // to hard-code the cache format.
+
+  if (!cache[imagePath]) {
+    throw new Error(`Expected imagePath to be included in cache, got ${imagePath}`);
+  }
 
   const [width, height] = cache[imagePath].slice(1);
   return [width, height];
@@ -184,6 +196,10 @@ export function getThumbnailEqualOrSmaller(preferred, imagePath, cache) {
   // than the provided size. Since the path provided might not be the actual
   // one which is being thumbnail-ified, this just returns the name of the
   // selected thumbnail size.
+
+  if (!cache[imagePath]) {
+    throw new Error(`Expected imagePath to be included in cache, got ${imagePath}`);
+  }
 
   const {size: preferredSize} = thumbnailSpec[preferred];
   const [width, height] = getDimensionsOfImagePath(imagePath, cache);

--- a/src/static/client2.js
+++ b/src/static/client2.js
@@ -717,18 +717,32 @@ function handleImageLinkClicked(evt) {
 
   updateFileSizeInformation(originalFileSize);
 
-  const {thumb: mainThumb, length: mainLength} = getPreferredThumbSize(availableThumbList);
-  const {thumb: smallThumb, length: smallLength} = getSmallestThumbSize(availableThumbList);
+  let mainSrc = null;
+  let thumbSrc = null;
 
-  const mainSrc = originalSrc.replace(/\.(jpg|png)$/, `.${mainThumb}.jpg`);
-  const thumbSrc = originalSrc.replace(/\.(jpg|png)$/, `.${smallThumb}.jpg`);
+  if (availableThumbList) {
+    const {thumb: mainThumb, length: mainLength} = getPreferredThumbSize(availableThumbList);
+    const {thumb: smallThumb, length: smallLength} = getSmallestThumbSize(availableThumbList);
+    mainSrc = originalSrc.replace(/\.(jpg|png)$/, `.${mainThumb}.jpg`);
+    thumbSrc = originalSrc.replace(/\.(jpg|png)$/, `.${smallThumb}.jpg`);
+    // Show the thumbnail size on each <img> element's data attributes.
+    // Y'know, just for debugging convenience.
+    mainImage.dataset.displayingThumb = `${mainThumb}:${mainLength}`;
+    thumbImage.dataset.displayingThumb = `${smallThumb}:${smallLength}`;
+  } else {
+    mainSrc = originalSrc;
+    thumbSrc = null;
+    mainImage.dataset.displayingThumb = '';
+    thumbImage.dataset.displayingThumb = '';
+  }
 
-  thumbImage.src = thumbSrc;
-
-  // Show the thumbnail size on each <img> element's data attributes.
-  // Y'know, just for debugging convenience.
-  mainImage.dataset.displayingThumb = `${mainThumb}:${mainLength}`;
-  thumbImage.dataset.displayingThumb = `${smallThumb}:${smallLength}`;
+  if (thumbSrc) {
+    thumbImage.src = thumbSrc;
+    thumbImage.style.display = null;
+  } else {
+    thumbImage.src = '';
+    thumbImage.style.display = 'none';
+  }
 
   for (const viewOriginal of allViewOriginal) {
     viewOriginal.href = originalSrc;

--- a/src/write/bind-utilities.js
+++ b/src/write/bind-utilities.js
@@ -11,6 +11,7 @@ import {bindOpts} from '#sugar';
 import {thumb} from '#urls';
 
 import {
+  checkIfImagePathHasCachedThumbnails,
   getDimensionsOfImagePath,
   getThumbnailEqualOrSmaller,
   getThumbnailsAvailableForDimensions,
@@ -53,6 +54,10 @@ export function bindUtilities({
   bound.getColors = bindOpts(getColors, {chroma});
 
   bound.find = bindFind(wikiData, {mode: 'warn'});
+
+  bound.checkIfImagePathHasCachedThumbnails =
+    (imagePath) =>
+      checkIfImagePathHasCachedThumbnails(imagePath, thumbsCache);
 
   bound.getDimensionsOfImagePath =
     (imagePath) =>

--- a/tap-snapshots/test/snapshot/image.js.test.cjs
+++ b/tap-snapshots/test/snapshot/image.js.test.cjs
@@ -7,7 +7,7 @@
 'use strict'
 exports[`test/snapshot/image.js TAP image (snapshot) > content warnings via tags 1`] = `
 <div class="reveal">
-    <div class="image-container"><div class="image-inner-area"><img data-original-length="600" data-thumbs="large:800 medium:400 small:250" src="media/album-art/beyond-canon/cover.medium.jpg"></div></div>
+    <div class="image-container"><div class="image-inner-area"><img src="media/album-art/beyond-canon/cover.png"></div></div>
     <span class="reveal-text-container">
         <span class="reveal-text">
             cw: too cool for school
@@ -19,24 +19,24 @@ exports[`test/snapshot/image.js TAP image (snapshot) > content warnings via tags
 `
 
 exports[`test/snapshot/image.js TAP image (snapshot) > id with link 1`] = `
-<a id="banana" class="box image-link" href="foobar"><div class="image-container"><div class="image-inner-area"><img></div></div></a>
+<a id="banana" class="box image-link" href="foobar"><div class="image-container"><div class="image-inner-area"><img src="foobar"></div></div></a>
 `
 
 exports[`test/snapshot/image.js TAP image (snapshot) > id with square 1`] = `
-<div class="square"><div class="square-content"><div class="image-container"><div class="image-inner-area"><img id="banana"></div></div></div></div>
+<div class="square"><div class="square-content"><div class="image-container"><div class="image-inner-area"><img id="banana" src="foobar"></div></div></div></div>
 `
 
 exports[`test/snapshot/image.js TAP image (snapshot) > id without link 1`] = `
-<div class="image-container"><div class="image-inner-area"><img id="banana"></div></div>
+<div class="image-container"><div class="image-inner-area"><img id="banana" src="foobar"></div></div>
 `
 
 exports[`test/snapshot/image.js TAP image (snapshot) > lazy with square 1`] = `
-<noscript><div class="square"><div class="square-content"><div class="image-container"><div class="image-inner-area"><img></div></div></div></div></noscript>
-<div class="square js-hide"><div class="square-content"><div class="image-container"><div class="image-inner-area"><img class="lazy"></div></div></div></div>
+<noscript><div class="square"><div class="square-content"><div class="image-container"><div class="image-inner-area"><img src="foobar"></div></div></div></div></noscript>
+<div class="square js-hide"><div class="square-content"><div class="image-container"><div class="image-inner-area"><img class="lazy" data-original="foobar"></div></div></div></div>
 `
 
 exports[`test/snapshot/image.js TAP image (snapshot) > link with file size 1`] = `
-<a class="box image-link" href="media/album-art/pingas/cover.png"><div class="image-container"><div class="image-inner-area"><img data-original-size="1000000" data-original-length="600" data-thumbs="large:800 medium:400 small:250" src="media/album-art/pingas/cover.medium.jpg"></div></div></a>
+<a class="box image-link" href="media/album-art/pingas/cover.png"><div class="image-container"><div class="image-inner-area"><img src="media/album-art/pingas/cover.png"></div></div></a>
 `
 
 exports[`test/snapshot/image.js TAP image (snapshot) > source missing 1`] = `
@@ -44,15 +44,19 @@ exports[`test/snapshot/image.js TAP image (snapshot) > source missing 1`] = `
 `
 
 exports[`test/snapshot/image.js TAP image (snapshot) > source via path 1`] = `
-<div class="image-container"><div class="image-inner-area"><img data-original-length="600" data-thumbs="large:800 medium:400 small:250" src="media/album-art/beyond-canon/cover.medium.jpg"></div></div>
+<div class="image-container"><div class="image-inner-area"><img src="media/album-art/beyond-canon/cover.png"></div></div>
 `
 
 exports[`test/snapshot/image.js TAP image (snapshot) > source via src 1`] = `
-<div class="image-container"><div class="image-inner-area"><img></div></div>
+<div class="image-container"><div class="image-inner-area"><img src="https://example.com/bananas.gif"></div></div>
 `
 
 exports[`test/snapshot/image.js TAP image (snapshot) > square 1`] = `
-<div class="square"><div class="square-content"><div class="image-container"><div class="image-inner-area"><img></div></div></div></div>
+<div class="square"><div class="square-content"><div class="image-container"><div class="image-inner-area"><img src="foobar"></div></div></div></div>
+`
+
+exports[`test/snapshot/image.js TAP image (snapshot) > thumb requested but source is gif 1`] = `
+<div class="image-container"><div class="image-inner-area"><img src="media/flash-art/5426.gif"></div></div>
 `
 
 exports[`test/snapshot/image.js TAP image (snapshot) > thumbnail details 1`] = `
@@ -60,5 +64,5 @@ exports[`test/snapshot/image.js TAP image (snapshot) > thumbnail details 1`] = `
 `
 
 exports[`test/snapshot/image.js TAP image (snapshot) > width & height 1`] = `
-<div class="image-container"><div class="image-inner-area"><img width="600" height="400"></div></div>
+<div class="image-container"><div class="image-inner-area"><img width="600" height="400" src="foobar"></div></div>
 `

--- a/test/snapshot/image.js
+++ b/test/snapshot/image.js
@@ -4,15 +4,17 @@ import {testContentFunctions} from '#test-lib';
 testContentFunctions(t, 'image (snapshot)', async (t, evaluate) => {
   await evaluate.load();
 
-  const quickSnapshot = (message, opts) =>
+  const quickSnapshot = (message, {extraDependencies, ...opts}) =>
     evaluate.snapshot(message, {
       name: 'image',
       extraDependencies: {
+        checkIfImagePathHasCachedThumbnails: path => !path.endsWith('.gif'),
         getSizeOfImagePath: () => 0,
         getDimensionsOfImagePath: () => [600, 600],
         getThumbnailEqualOrSmaller: () => 'medium',
         getThumbnailsAvailableForDimensions: () =>
           [['large', 800], ['medium', 400], ['small', 250]],
+        ...extraDependencies,
       },
       ...opts,
     });
@@ -106,6 +108,7 @@ testContentFunctions(t, 'image (snapshot)', async (t, evaluate) => {
   evaluate.snapshot('thumbnail details', {
     name: 'image',
     extraDependencies: {
+      checkIfImagePathHasCachedThumbnails: () => true,
       getSizeOfImagePath: () => 0,
       getDimensionsOfImagePath: () => [900, 1200],
       getThumbnailsAvailableForDimensions: () =>
@@ -115,6 +118,13 @@ testContentFunctions(t, 'image (snapshot)', async (t, evaluate) => {
     slots: {
       thumb: 'gargantuan',
       path: ['media.albumCover', 'beyond-canon', 'png'],
+    },
+  });
+
+  quickSnapshot('thumb requested but source is gif', {
+    slots: {
+      thumb: 'medium',
+      path: ['media.flashArt', '5426', 'gif'],
     },
   });
 });


### PR DESCRIPTION
Follow-up to #192. These issues weren't filed but were caught during a following full-site build.

* Generally behaves more particularly and predictably for images when an image which was requested to display a thumbnail is not present in the thumbnail metadata (md5/dimensions) cache.
* `gen-thumbs.js` utilities: Adds a new `checkIfImagePathHasCachedThumbnails` function which just checks if the provided image path is present in the thumbnail cache. Makes the existing cache-dependant utilities, `getDimensionsOfImagePath` and `getThumbnailEqualOrSmaller`, throw (more explicitly) for paths which aren't present in the cache.
* Content (`image`): Defends against images without thumbnails. This is expected for .gifs, as well as for images which aren't based in the media directory at all, but otherwise, if a thumbnail is requested (`slots.thumb`), cleanly logs an error message indicating the cache information was missing. Without thumbs, the original source is returned as-is, and thumbnail-related `data` attributes (used for client-side code) are not set.
* Client (image overlay): Defends against images without thumbnail `data` attributes. The `#image-overlay-image-thumb` smallest-thumb image is outright hidden - so the overlay is just a blank, square box until the main image loads the *original* source (instead of a larger right-sized thumbnail). But this should usually be immediate, since the original image would also have been sourced for the place in the page where the clicked-on image was embedded.
  * Note that this effectively removes the file size info next to "View original file." for gifs embedded in the image preview. That's on purpose, since you will already have loaded the full-fat original file by loading even the image embedded in the page.

Also updates test cases. Not really sure how the previous test cases went through - they were clearly not behaving properly. New ones are better.
