### PR TITLE
Fix various snapshot tests with new "stubContentFunction" utility

### DIFF
--- a/tap-snapshots/test/snapshot/generateAlbumCoverArtwork.js.test.cjs
+++ b/tap-snapshots/test/snapshot/generateAlbumCoverArtwork.js.test.cjs
@@ -7,26 +7,29 @@
 'use strict'
 exports[`test/snapshot/generateAlbumCoverArtwork.js TAP generateAlbumCoverArtwork (snapshot) > display: primary 1`] = `
 <div id="cover-art-container">
-    <a id="cover-art" class="box image-link" href="media/album-art/bee-forus-seatbelt-safebee/cover.png">
-        <div class="square">
-            <div class="square-content">
-                <div class="reveal">
-                    <div class="image-container"><div class="image-inner-area"><img data-original-size="0" src="media/album-art/bee-forus-seatbelt-safebee/cover.medium.jpg"></div></div>
-                    <span class="reveal-text-container">
-                        <span class="reveal-text">
-                            cw: creepy crawlies
-                            <br>
-                            <span class="reveal-interaction">click to show</span>
-                        </span>
-                    </span>
-                </div>
-            </div>
-        </div>
-    </a>
+    [mocked: image
+     args: [
+       [
+         { name: 'Damara', directory: 'damara', isContentWarning: false },
+         { name: 'Cronus', directory: 'cronus', isContentWarning: false },
+         { name: 'Bees', directory: 'bees', isContentWarning: false },
+         { name: 'creepy crawlies', isContentWarning: true }
+       ]
+     ]
+     slots: { path: [ 'media.albumCover', 'bee-forus-seatbelt-safebee', 'png' ], thumb: 'medium', id: 'cover-art', reveal: true, link: true, square: true }]
     <p>Tags: <a href="tag/damara/">Damara</a>, <a href="tag/cronus/">Cronus</a>, <a href="tag/bees/">Bees</a></p>
 </div>
 `
 
 exports[`test/snapshot/generateAlbumCoverArtwork.js TAP generateAlbumCoverArtwork (snapshot) > display: thumbnail 1`] = `
-<div class="square"><div class="square-content"><div class="image-container"><div class="image-inner-area"><img src="media/album-art/bee-forus-seatbelt-safebee/cover.small.jpg"></div></div></div></div>
+[mocked: image
+ args: [
+   [
+     { name: 'Damara', directory: 'damara', isContentWarning: false },
+     { name: 'Cronus', directory: 'cronus', isContentWarning: false },
+     { name: 'Bees', directory: 'bees', isContentWarning: false },
+     { name: 'creepy crawlies', isContentWarning: true }
+   ]
+ ]
+ slots: { path: [ 'media.albumCover', 'bee-forus-seatbelt-safebee', 'png' ], thumb: 'small', reveal: false, link: false, square: true }]
 `

--- a/tap-snapshots/test/snapshot/generateAlbumSecondaryNav.js.test.cjs
+++ b/tap-snapshots/test/snapshot/generateAlbumSecondaryNav.js.test.cjs
@@ -7,27 +7,27 @@
 'use strict'
 exports[`test/snapshot/generateAlbumSecondaryNav.js TAP generateAlbumSecondaryNav (snapshot) > basic behavior, mode: album 1`] = `
 <nav id="secondary-nav" class="nav-links-groups">
-    <span>
+    <span style="--primary-color: #abcdef; --dark-color: #21272e; --dim-color: #818181; --dim-ghost-color: #818181cc; --bg-color: #161616cc; --bg-black-color: #06090bcc; --shadow-color: #0d0d0dcc">
         <a href="group/vcg/">VCG</a>
-        (<a href="album/first/">Previous</a>, <a href="album/last/">Next</a>)
+        (<a href="album/first/" title="First">Previous</a>, <a href="album/last/" title="Last">Next</a>)
     </span>
-    <span>
+    <span style="--primary-color: #123456; --dark-color: #0e2842; --dim-color: #000000; --dim-ghost-color: #000000cc; --bg-color: #161616cc; --bg-black-color: #000913cc; --shadow-color: #0d0d0dcc">
         <a href="group/bepis/">Bepis</a>
-        (<a href="album/second/">Next</a>)
+        (<a href="album/second/" title="Second">Next</a>)
     </span>
 </nav>
 `
 
 exports[`test/snapshot/generateAlbumSecondaryNav.js TAP generateAlbumSecondaryNav (snapshot) > basic behavior, mode: track 1`] = `
 <nav id="secondary-nav" class="nav-links-groups">
-    <a href="group/vcg/">VCG</a>
-    <a href="group/bepis/">Bepis</a>
+    <a href="group/vcg/" style="--primary-color: #abcdef; --dim-color: #818181">VCG</a>
+    <a href="group/bepis/" style="--primary-color: #123456; --dim-color: #000000">Bepis</a>
 </nav>
 `
 
 exports[`test/snapshot/generateAlbumSecondaryNav.js TAP generateAlbumSecondaryNav (snapshot) > dateless album in mixed group 1`] = `
 <nav id="secondary-nav" class="nav-links-groups">
-    <a href="group/vcg/">VCG</a>
-    <a href="group/bepis/">Bepis</a>
+    <a href="group/vcg/" style="--primary-color: #abcdef; --dim-color: #818181">VCG</a>
+    <a href="group/bepis/" style="--primary-color: #123456; --dim-color: #000000">Bepis</a>
 </nav>
 `

--- a/tap-snapshots/test/snapshot/generateCoverArtwork.js.test.cjs
+++ b/tap-snapshots/test/snapshot/generateCoverArtwork.js.test.cjs
@@ -7,26 +7,29 @@
 'use strict'
 exports[`test/snapshot/generateCoverArtwork.js TAP generateCoverArtwork (snapshot) > display: primary 1`] = `
 <div id="cover-art-container">
-    <a id="cover-art" class="box image-link" href="media/album-art/bee-forus-seatbelt-safebee/cover.png">
-        <div class="square">
-            <div class="square-content">
-                <div class="reveal">
-                    <div class="image-container"><div class="image-inner-area"><img data-original-size="0" src="media/album-art/bee-forus-seatbelt-safebee/cover.medium.jpg"></div></div>
-                    <span class="reveal-text-container">
-                        <span class="reveal-text">
-                            cw: creepy crawlies
-                            <br>
-                            <span class="reveal-interaction">click to show</span>
-                        </span>
-                    </span>
-                </div>
-            </div>
-        </div>
-    </a>
+    [mocked: image
+     args: [
+       [
+         { name: 'Damara', directory: 'damara', isContentWarning: false },
+         { name: 'Cronus', directory: 'cronus', isContentWarning: false },
+         { name: 'Bees', directory: 'bees', isContentWarning: false },
+         { name: 'creepy crawlies', isContentWarning: true }
+       ]
+     ]
+     slots: { path: [ 'media.albumCover', 'bee-forus-seatbelt-safebee', 'png' ], thumb: 'medium', id: 'cover-art', reveal: true, link: true, square: true }]
     <p>Tags: <a href="tag/damara/">Damara</a>, <a href="tag/cronus/">Cronus</a>, <a href="tag/bees/">Bees</a></p>
 </div>
 `
 
 exports[`test/snapshot/generateCoverArtwork.js TAP generateCoverArtwork (snapshot) > display: thumbnail 1`] = `
-<div class="square"><div class="square-content"><div class="image-container"><div class="image-inner-area"><img src="media/album-art/bee-forus-seatbelt-safebee/cover.small.jpg"></div></div></div></div>
+[mocked: image
+ args: [
+   [
+     { name: 'Damara', directory: 'damara', isContentWarning: false },
+     { name: 'Cronus', directory: 'cronus', isContentWarning: false },
+     { name: 'Bees', directory: 'bees', isContentWarning: false },
+     { name: 'creepy crawlies', isContentWarning: true }
+   ]
+ ]
+ slots: { path: [ 'media.albumCover', 'bee-forus-seatbelt-safebee', 'png' ], thumb: 'small', reveal: false, link: false, square: true }]
 `

--- a/tap-snapshots/test/snapshot/generatePreviousNextLinks.js.test.cjs
+++ b/tap-snapshots/test/snapshot/generatePreviousNextLinks.js.test.cjs
@@ -6,13 +6,13 @@
  */
 'use strict'
 exports[`test/snapshot/generatePreviousNextLinks.js TAP generatePreviousNextLinks (snapshot) > basic behavior 1`] = `
-previous: {"tooltip":true,"color":false,"attributes":{"id":"previous-button"},"content":"Previous"}
-next: {"tooltip":true,"color":false,"attributes":{"id":"next-button"},"content":"Next"}
+previous: { tooltip: true, color: false, attributes: { id: 'previous-button' }, content: 'Previous' }
+next: { tooltip: true, color: false, attributes: { id: 'next-button' }, content: 'Next' }
 `
 
 exports[`test/snapshot/generatePreviousNextLinks.js TAP generatePreviousNextLinks (snapshot) > disable id 1`] = `
-previous: {"tooltip":true,"color":false,"attributes":{"id":false},"content":"Previous"}
-next: {"tooltip":true,"color":false,"attributes":{"id":false},"content":"Next"}
+previous: { tooltip: true, color: false, attributes: { id: false }, content: 'Previous' }
+next: { tooltip: true, color: false, attributes: { id: false }, content: 'Next' }
 `
 
 exports[`test/snapshot/generatePreviousNextLinks.js TAP generatePreviousNextLinks (snapshot) > neither link present 1`] = `
@@ -20,9 +20,9 @@ exports[`test/snapshot/generatePreviousNextLinks.js TAP generatePreviousNextLink
 `
 
 exports[`test/snapshot/generatePreviousNextLinks.js TAP generatePreviousNextLinks (snapshot) > next missing 1`] = `
-previous: {"tooltip":true,"color":false,"attributes":{"id":"previous-button"},"content":"Previous"}
+previous: { tooltip: true, color: false, attributes: { id: 'previous-button' }, content: 'Previous' }
 `
 
 exports[`test/snapshot/generatePreviousNextLinks.js TAP generatePreviousNextLinks (snapshot) > previous missing 1`] = `
-next: {"tooltip":true,"color":false,"attributes":{"id":"next-button"},"content":"Next"}
+next: { tooltip: true, color: false, attributes: { id: 'next-button' }, content: 'Next' }
 `

--- a/tap-snapshots/test/snapshot/generateTrackCoverArtwork.js.test.cjs
+++ b/tap-snapshots/test/snapshot/generateTrackCoverArtwork.js.test.cjs
@@ -7,37 +7,44 @@
 'use strict'
 exports[`test/snapshot/generateTrackCoverArtwork.js TAP generateTrackCoverArtwork (snapshot) > display: primary - no unique art 1`] = `
 <div id="cover-art-container">
-    <a id="cover-art" class="box image-link" href="media/album-art/bee-forus-seatbelt-safebee/cover.png">
-        <div class="square">
-            <div class="square-content">
-                <div class="reveal">
-                    <div class="image-container"><div class="image-inner-area"><img data-original-size="0" src="media/album-art/bee-forus-seatbelt-safebee/cover.medium.jpg"></div></div>
-                    <span class="reveal-text-container">
-                        <span class="reveal-text">
-                            cw: creepy crawlies
-                            <br>
-                            <span class="reveal-interaction">click to show</span>
-                        </span>
-                    </span>
-                </div>
-            </div>
-        </div>
-    </a>
+    [mocked: image
+     args: [
+       [
+         { name: 'Damara', directory: 'damara', isContentWarning: false },
+         { name: 'Cronus', directory: 'cronus', isContentWarning: false },
+         { name: 'Bees', directory: 'bees', isContentWarning: false },
+         { name: 'creepy crawlies', isContentWarning: true }
+       ]
+     ]
+     slots: { path: [ 'media.albumCover', 'bee-forus-seatbelt-safebee', 'png' ], thumb: 'medium', id: 'cover-art', reveal: true, link: true, square: true }]
     <p>Tags: <a href="tag/damara/">Damara</a>, <a href="tag/cronus/">Cronus</a>, <a href="tag/bees/">Bees</a></p>
 </div>
 `
 
 exports[`test/snapshot/generateTrackCoverArtwork.js TAP generateTrackCoverArtwork (snapshot) > display: primary - unique art 1`] = `
 <div id="cover-art-container">
-    <a id="cover-art" class="box image-link" href="media/album-art/bee-forus-seatbelt-safebee/beesmp3.jpg"><div class="square"><div class="square-content"><div class="image-container"><div class="image-inner-area"><img data-original-size="0" src="media/album-art/bee-forus-seatbelt-safebee/beesmp3.medium.jpg"></div></div></div></div></a>
+    [mocked: image
+     args: [ [ { name: 'Bees', directory: 'bees', isContentWarning: false } ] ]
+     slots: { path: [ 'media.trackCover', 'bee-forus-seatbelt-safebee', 'beesmp3', 'jpg' ], thumb: 'medium', id: 'cover-art', reveal: true, link: true, square: true }]
     <p>Tags: <a href="tag/bees/">Bees</a></p>
 </div>
 `
 
 exports[`test/snapshot/generateTrackCoverArtwork.js TAP generateTrackCoverArtwork (snapshot) > display: thumbnail - no unique art 1`] = `
-<div class="square"><div class="square-content"><div class="image-container"><div class="image-inner-area"><img src="media/album-art/bee-forus-seatbelt-safebee/cover.small.jpg"></div></div></div></div>
+[mocked: image
+ args: [
+   [
+     { name: 'Damara', directory: 'damara', isContentWarning: false },
+     { name: 'Cronus', directory: 'cronus', isContentWarning: false },
+     { name: 'Bees', directory: 'bees', isContentWarning: false },
+     { name: 'creepy crawlies', isContentWarning: true }
+   ]
+ ]
+ slots: { path: [ 'media.albumCover', 'bee-forus-seatbelt-safebee', 'png' ], thumb: 'small', reveal: false, link: false, square: true }]
 `
 
 exports[`test/snapshot/generateTrackCoverArtwork.js TAP generateTrackCoverArtwork (snapshot) > display: thumbnail - unique art 1`] = `
-<div class="square"><div class="square-content"><div class="image-container"><div class="image-inner-area"><img src="media/album-art/bee-forus-seatbelt-safebee/beesmp3.small.jpg"></div></div></div></div>
+[mocked: image
+ args: [ [ { name: 'Bees', directory: 'bees', isContentWarning: false } ] ]
+ slots: { path: [ 'media.trackCover', 'bee-forus-seatbelt-safebee', 'beesmp3', 'jpg' ], thumb: 'small', reveal: false, link: false, square: true }]
 `

--- a/tap-snapshots/test/snapshot/transformContent.js.test.cjs
+++ b/tap-snapshots/test/snapshot/transformContent.js.test.cjs
@@ -53,16 +53,16 @@ How it goes</p>
 `
 
 exports[`test/snapshot/transformContent.js TAP transformContent (snapshot) > non-inline image #1 1`] = `
-<div class="content-image"><a class="box image-link" href="spark.png"><div class="image-container"><div class="image-inner-area"><img src="spark.large.jpg"></div></div></a></div>
+<div class="content-image">[mocked: image - slots: { src: 'spark.png', link: true, thumb: 'large' }]</div>
 `
 
 exports[`test/snapshot/transformContent.js TAP transformContent (snapshot) > non-inline image #2 1`] = `
 <p>Rad.</p>
-<div class="content-image"><a class="box image-link" href="spark.png"><div class="image-container"><div class="image-inner-area"><img src="spark.large.jpg"></div></div></a></div>
+<div class="content-image">[mocked: image - slots: { src: 'spark.png', link: true, thumb: 'large' }]</div>
 `
 
 exports[`test/snapshot/transformContent.js TAP transformContent (snapshot) > non-inline image #3 1`] = `
-<div class="content-image"><a class="box image-link" href="spark.png"><div class="image-container"><div class="image-inner-area"><img src="spark.large.jpg"></div></div></a></div>
+<div class="content-image">[mocked: image - slots: { src: 'spark.png', link: true, thumb: 'large' }]</div>
 <p>Baller.</p>
 `
 

--- a/test/lib/content-function.js
+++ b/test/lib/content-function.js
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 import {fileURLToPath} from 'node:url';
+import {inspect} from 'node:util';
 
 import chroma from 'chroma-js';
 
@@ -99,7 +100,7 @@ export function testContentFunctions(t, message, fn) {
 
         constructor() {
           super({
-            content: () => `${name}: ${JSON.stringify(this.#slotValues)}`,
+            content: () => this.#getContent(this),
           });
         }
 
@@ -109,6 +110,24 @@ export function testContentFunctions(t, message, fn) {
 
         setSlot(slotName, slotValue) {
           this.#slotValues[slotName] = slotValue;
+        }
+
+        #getContent() {
+          const toInspect =
+            Object.fromEntries(
+              Object.entries(this.#slotValues)
+                .filter(([key, value]) => value !== null));
+
+          const inspected =
+            inspect(toInspect, {
+              breakLength: Infinity,
+              colors: false,
+              compact: true,
+              depth: Infinity,
+              sort: true,
+            });
+
+          return `${name}: ${inspected}`;
         }
       });
     };

--- a/test/snapshot/generateAlbumCoverArtwork.js
+++ b/test/snapshot/generateAlbumCoverArtwork.js
@@ -1,12 +1,14 @@
 import t from 'tap';
+
+import contentFunction from '#content-function';
 import {testContentFunctions} from '#test-lib';
 
 testContentFunctions(t, 'generateAlbumCoverArtwork (snapshot)', async (t, evaluate) => {
-  await evaluate.load();
-
-  const extraDependencies = {
-    getSizeOfImageFile: () => 0,
-  };
+  await evaluate.load({
+    mock: {
+      image: evaluate.stubContentFunction('image'),
+    },
+  });
 
   const album = {
     directory: 'bee-forus-seatbelt-safebee',
@@ -23,13 +25,11 @@ testContentFunctions(t, 'generateAlbumCoverArtwork (snapshot)', async (t, evalua
     name: 'generateAlbumCoverArtwork',
     args: [album],
     slots: {mode: 'primary'},
-    extraDependencies,
   });
 
   evaluate.snapshot('display: thumbnail', {
     name: 'generateAlbumCoverArtwork',
     args: [album],
     slots: {mode: 'thumbnail'},
-    extraDependencies,
   });
 });

--- a/test/snapshot/generateAlbumSecondaryNav.js
+++ b/test/snapshot/generateAlbumSecondaryNav.js
@@ -6,8 +6,8 @@ testContentFunctions(t, 'generateAlbumSecondaryNav (snapshot)', async (t, evalua
 
   let album, group1, group2;
 
-  group1 = {name: 'VCG', directory: 'vcg'};
-  group2 = {name: 'Bepis', directory: 'bepis'};
+  group1 = {name: 'VCG', directory: 'vcg', color: '#abcdef'};
+  group2 = {name: 'Bepis', directory: 'bepis', color: '#123456'};
 
   album = {
     date: new Date('2010-04-13'),

--- a/test/snapshot/generateCoverArtwork.js
+++ b/test/snapshot/generateCoverArtwork.js
@@ -2,11 +2,11 @@ import t from 'tap';
 import {testContentFunctions} from '#test-lib';
 
 testContentFunctions(t, 'generateCoverArtwork (snapshot)', async (t, evaluate) => {
-  await evaluate.load();
-
-  const extraDependencies = {
-    getSizeOfImageFile: () => 0,
-  };
+  await evaluate.load({
+    mock: {
+      image: evaluate.stubContentFunction('image', {mock: true}),
+    },
+  });
 
   const artTags = [
     {name: 'Damara', directory: 'damara', isContentWarning: false},
@@ -21,13 +21,11 @@ testContentFunctions(t, 'generateCoverArtwork (snapshot)', async (t, evaluate) =
     name: 'generateCoverArtwork',
     args: [artTags],
     slots: {path, mode: 'primary'},
-    extraDependencies,
   });
 
   evaluate.snapshot('display: thumbnail', {
     name: 'generateCoverArtwork',
     args: [artTags],
     slots: {path, mode: 'thumbnail'},
-    extraDependencies,
   });
 });

--- a/test/snapshot/generateTrackCoverArtwork.js
+++ b/test/snapshot/generateTrackCoverArtwork.js
@@ -2,11 +2,11 @@ import t from 'tap';
 import {testContentFunctions} from '#test-lib';
 
 testContentFunctions(t, 'generateTrackCoverArtwork (snapshot)', async (t, evaluate) => {
-  await evaluate.load();
-
-  const extraDependencies = {
-    getSizeOfImageFile: () => 0,
-  };
+  await evaluate.load({
+    mock: {
+      image: evaluate.stubContentFunction('image'),
+    },
+  });
 
   const album = {
     directory: 'bee-forus-seatbelt-safebee',
@@ -37,27 +37,23 @@ testContentFunctions(t, 'generateTrackCoverArtwork (snapshot)', async (t, evalua
     name: 'generateTrackCoverArtwork',
     args: [track1],
     slots: {mode: 'primary'},
-    extraDependencies,
   });
 
   evaluate.snapshot('display: thumbnail - unique art', {
     name: 'generateTrackCoverArtwork',
     args: [track1],
     slots: {mode: 'thumbnail'},
-    extraDependencies,
   });
 
   evaluate.snapshot('display: primary - no unique art', {
     name: 'generateTrackCoverArtwork',
     args: [track2],
     slots: {mode: 'primary'},
-    extraDependencies,
   });
 
   evaluate.snapshot('display: thumbnail - no unique art', {
     name: 'generateTrackCoverArtwork',
     args: [track2],
     slots: {mode: 'thumbnail'},
-    extraDependencies,
   });
 });

--- a/test/snapshot/transformContent.js
+++ b/test/snapshot/transformContent.js
@@ -2,7 +2,11 @@ import t from 'tap';
 import {testContentFunctions} from '#test-lib';
 
 testContentFunctions(t, 'transformContent (snapshot)', async (t, evaluate) => {
-  await evaluate.load();
+  await evaluate.load({
+    mock: {
+      image: evaluate.stubContentFunction('image'),
+    },
+  });
 
   const extraDependencies = {
     wikiData: {
@@ -10,8 +14,6 @@ testContentFunctions(t, 'transformContent (snapshot)', async (t, evaluate) => {
         {directory: 'cool-album', name: 'Cool Album', color: '#123456'},
       ],
     },
-
-    getSizeOfImageFile: () => 0,
 
     to: (key, ...args) => `to-${key}/${args.join('/')}`,
   };
@@ -50,15 +52,18 @@ testContentFunctions(t, 'transformContent (snapshot)', async (t, evaluate) => {
 
   quickSnapshot(
     'non-inline image #2',
-      `Rad.\n<img src="spark.png">`);
+      `Rad.\n` +
+      `<img src="spark.png">`);
 
   quickSnapshot(
     'non-inline image #3',
-      `<img src="spark.png">\nBaller.`);
+      `<img src="spark.png">\n` +
+      `Baller.`);
 
   quickSnapshot(
     'dates',
-      `[[date:2023-04-13]] Yep!\nVery nice: [[date:25 October 2413]]`);
+      `[[date:2023-04-13]] Yep!\n` +
+      `Very nice: [[date:25 October 2413]]`);
 
   quickSnapshot(
     'super basic string',


### PR DESCRIPTION
Fixes some upstanding issues in erroring snapshot tests.

* Makes `evaluate.stubTemplate` utility use `util.inspect` for cleaner output.
* Adds new `evaluate.stubContentFunction` utility, which slots cleanly into `evaluate.load({mock: ...})` and reports both template slots and content function (i.e. relational) arguments.
* Updates existing snapshot tests to stub the `image` dependency, instead of manually overriding specific `extraDependencies` entries which `image` depends on to function in the first place.

Like with `stubTemplate`, which has so far only been utilized in one test, the `stubContentFunction` utility added here may well be useful in other snapshot tests. It's important to note that `stubTemplate` expressly *reduces* the vertical "height" of the test, i.e. it should only be used in contexts where *no matter what content the dependency returns, it will certainly be correct and appropriate to display here.* In other words, it doesn't put the actual content of that dependency in the context of the rest of the snapshot. This is appropriate for certain more volatile dependencies (such as `image`), but usually wouldn't fit for more context-oriented or specialized dependencies.

This PR doesn't address existing data-related unit test errors, which are being handled (to a much deeper degree) in #256.