### PR TITLE
Handle null href with hash link properly (linkTemplate)

### DIFF
--- a/src/content/dependencies/linkTemplate.js
+++ b/src/content/dependencies/linkTemplate.js
@@ -29,14 +29,16 @@ export default {
     language,
     to,
   }) {
-    let href = slots.href;
+    let href;
     let style;
     let title;
 
-    if (href) {
-      href = encodeURI(href);
+    if (slots.href) {
+      href = encodeURI(slots.href);
     } else if (!empty(slots.path)) {
       href = to(...slots.path);
+    } else {
+      href = '';
     }
 
     if (appendIndexHTML) {


### PR DESCRIPTION
As far as I can tell, this has just always been broken. [The commit](https://github.com/hsmusic/hsmusic-wiki/commit/93fd751aeb3a9c0b60889db0073e7907c87f90fe) which adds the failing test case in question *also fails the test case.* I can only assume I wrote in the (indeed) expected result, deliberately left it failing as a note to just dang fix it, and then... never fixed it.

Well, this PR fixes it!

As far as I can tell no content code was depending on this, but I'm targeting `staging` since I don't want to leave broken behavior available in the "stable" codebase. Code would have to call `linkTemplate` and provide neither `hash` nor `href`, which isn't the case in current code. (It *is* in the "skip to section" element in #254, though, which also alerted me to this bug recently!)