### PR TITLE
Add "Always Reference By Directory" field and implication

### DIFF
--- a/src/data/things/track.js
+++ b/src/data/things/track.js
@@ -36,6 +36,41 @@ export class Track extends Thing {
     urls: Thing.common.urls(),
     dateFirstReleased: Thing.common.simpleDate(),
 
+    // Controls how find.track works - it'll never be matched by a reference
+    // just to the track's name, which means you don't have to always reference
+    // some *other* (much more commonly referenced) track by directory instead
+    // of more naturally by name.
+    alwaysReferenceByDirectory: {
+      flags: {update: true, expose: true},
+
+      // Deliberately defaults to null - this will fall back to false in most
+      // cases.
+      update: {validate: isBoolean, default: null},
+
+      expose: {
+        dependencies: ['name', 'originalReleaseTrackByRef', 'trackData'],
+
+        transform(value, {
+          name,
+          originalReleaseTrackByRef,
+          trackData,
+          [Track.instance]: thisTrack,
+        }) {
+          if (value !== null) return value;
+
+          const original =
+            find.track(
+              originalReleaseTrackByRef,
+              trackData.filter(track => track !== thisTrack),
+              {quiet: true});
+
+          if (!original) return false;
+
+          return name === original.name;
+        }
+      },
+    },
+
     artistContribsByRef: Thing.common.contribsByRef(),
     contributorContribsByRef: Thing.common.contribsByRef(),
     coverArtistContribsByRef: Thing.common.contribsByRef(),

--- a/src/data/yaml.js
+++ b/src/data/yaml.js
@@ -338,6 +338,8 @@ export const processTrackDocument = makeProcessDocument(T.Track, {
     coverArtFileExtension: 'Cover Art File Extension',
     hasCoverArt: 'Has Cover Art',
 
+    alwaysReferenceByDirectory: 'Always Reference By Directory',
+
     lyrics: 'Lyrics',
     commentary: 'Commentary',
     additionalFiles: 'Additional Files',

--- a/src/find.js
+++ b/src/find.js
@@ -80,17 +80,19 @@ function matchDirectory(ref, data) {
 }
 
 function matchName(ref, data, mode) {
-  const matches = data.filter(
-    ({name}) => name.toLowerCase() === ref.toLowerCase()
-  );
+  const matches =
+    data
+      .filter(({name}) => name.toLowerCase() === ref.toLowerCase())
+      .filter(thing =>
+        (Object.hasOwn(thing, 'alwaysReferenceByDirectory')
+          ? !thing.alwaysReferenceByDirectory
+          : true));
 
   if (matches.length > 1) {
-    return warnOrThrow(
-      mode,
+    return warnOrThrow(mode,
       `Multiple matches for reference "${ref}". Please resolve:\n` +
-        matches.map((match) => `- ${inspect(match)}\n`).join('') +
-        `Returning null for this reference.`
-    );
+      matches.map(match => `- ${inspect(match)}\n`).join('') +
+      `Returning null for this reference.`);
   }
 
   if (matches.length === 0) {
@@ -100,10 +102,8 @@ function matchName(ref, data, mode) {
   const thing = matches[0];
 
   if (ref !== thing.name) {
-    warnOrThrow(
-      mode,
-      `Bad capitalization: ${color.red(ref)} -> ${color.green(thing.name)}`
-    );
+    warnOrThrow(mode,
+      `Bad capitalization: ${color.red(ref)} -> ${color.green(thing.name)}`);
   }
 
   return thing;


### PR DESCRIPTION
There's apparently no issue opened for this, but it's a feature which Makin helped discuss a while ago.

* Adds an `alwaysReferenceByDirectory` property to tracks, which removes it from the pool of valid targets for `find.track`'s underlying `matchName` function. This means it won't count as an ambiguity.
* Adds a matching `Always Reference By Directory` YAML field.
* The default for `alwaysReferenceByDirectory` is usually false, but is true for re-releases *whose name matches that of the original.*

Merge alongside (i.e. before) hsmusic/hsmusic-data#272. Related to but separate from #274.