### PR TITLE
Sanitize name in links to things; add basic snapshot tests

### DIFF
--- a/src/content/dependencies/linkThing.js
+++ b/src/content/dependencies/linkThing.js
@@ -1,6 +1,6 @@
 export default {
   contentDependencies: ['linkTemplate'],
-  extraDependencies: ['html'],
+  extraDependencies: ['html', 'language'],
 
   relations(relation) {
     return {
@@ -41,7 +41,7 @@ export default {
     hash: {type: 'string'},
   },
 
-  generate(data, relations, slots, {html}) {
+  generate(data, relations, slots, {html, language}) {
     const path = [data.pathKey, data.directory];
 
     const name =
@@ -51,7 +51,7 @@ export default {
 
     const content =
       (html.isBlank(slots.content)
-        ? name
+        ? language.sanitize(name)
         : slots.content);
 
     let color = null;

--- a/tap-snapshots/test/snapshot/linkThing.js.test.cjs
+++ b/tap-snapshots/test/snapshot/linkThing.js.test.cjs
@@ -1,0 +1,35 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/snapshot/linkThing.js TAP linkThing (snapshot) > basic behavior 1`] = `
+<a href="track/foo/" style="--primary-color: #abcdef; --dim-color: #818181">Cool track!</a>
+`
+
+exports[`test/snapshot/linkThing.js TAP linkThing (snapshot) > color 1`] = `
+<a href="track/showtime-piano-refrain/">Showtime (Piano Refrain)</a>
+<a href="track/showtime-piano-refrain/" style="--primary-color: #38f43d; --dim-color: #389f33">Showtime (Piano Refrain)</a>
+<a href="track/showtime-piano-refrain/" style="--primary-color: #aaccff; --dim-color: #828282">Showtime (Piano Refrain)</a>
+`
+
+exports[`test/snapshot/linkThing.js TAP linkThing (snapshot) > preferShortName 1`] = `
+<a href="tag/five-oceanfalls/">Five</a>
+`
+
+exports[`test/snapshot/linkThing.js TAP linkThing (snapshot) > tags in name escaped 1`] = `
+<a href="track/foo/">&lt;a href=&quot;SNOOPING&quot;&gt;AS USUAL&lt;/a&gt; I SEE</a>
+<a href="track/bar/">&lt;b&gt;boldface&lt;/b&gt;</a>
+<a href="album/exile/">&gt;Exile&lt;</a>
+<a href="track/heart/">&lt;3</a>
+`
+
+exports[`test/snapshot/linkThing.js TAP linkThing (snapshot) > tooltip & content 1`] = `
+<a href="album/beyond-canon/">Beyond Canon</a>
+<a href="album/beyond-canon/" title="Beyond Canon">Beyond Canon</a>
+<a href="album/beyond-canon/" title="Beyond Canon">Next</a>
+<a href="album/beyond-canon/" title="Apple">Banana</a>
+<a href="album/beyond-canon/">Banana</a>
+`

--- a/tap-snapshots/test/snapshot/linkThing.js.test.cjs
+++ b/tap-snapshots/test/snapshot/linkThing.js.test.cjs
@@ -15,6 +15,10 @@ exports[`test/snapshot/linkThing.js TAP linkThing (snapshot) > color 1`] = `
 <a href="track/showtime-piano-refrain/" style="--primary-color: #aaccff; --dim-color: #828282">Showtime (Piano Refrain)</a>
 `
 
+exports[`test/snapshot/linkThing.js TAP linkThing (snapshot) > nested links in content stripped 1`] = `
+<a href="foo/"><b>Oooo! Very spooky.</b></a>
+`
+
 exports[`test/snapshot/linkThing.js TAP linkThing (snapshot) > preferShortName 1`] = `
 <a href="tag/five-oceanfalls/">Five</a>
 `

--- a/test/snapshot/linkThing.js
+++ b/test/snapshot/linkThing.js
@@ -1,0 +1,76 @@
+import t from 'tap';
+import * as html from '#html';
+import {testContentFunctions} from '#test-lib';
+
+testContentFunctions(t, 'linkThing (snapshot)', async (t, evaluate) => {
+  await evaluate.load();
+
+  const quickSnapshot = (message, oneOrMultiple) =>
+    evaluate.snapshot(message,
+      (Array.isArray(oneOrMultiple)
+        ? {name: 'linkThing', multiple: oneOrMultiple}
+        : {name: 'linkThing', ...oneOrMultiple}));
+
+  quickSnapshot('basic behavior', {
+    args: ['localized.track', {
+      directory: 'foo',
+      color: '#abcdef',
+      name: `Cool track!`,
+    }],
+  });
+
+  quickSnapshot('preferShortName', {
+    args: ['localized.tag', {
+      directory: 'five-oceanfalls',
+      name: 'Five (Oceanfalls)',
+      nameShort: 'Five',
+    }],
+    slots: {preferShortName: true},
+  });
+
+  quickSnapshot('tooltip & content', {
+    args: ['localized.album', {
+      directory: 'beyond-canon',
+      name: 'Beyond Canon',
+    }],
+    multiple: [
+      {slots: {tooltip: false}},
+      {slots: {tooltip: true}},
+      {slots: {tooltip: true, content: 'Next'}},
+      {slots: {tooltip: 'Apple', content: 'Banana'}},
+      {slots: {content: 'Banana'}},
+    ],
+  });
+
+  quickSnapshot('color', {
+    args: ['localized.track', {
+      directory: 'showtime-piano-refrain',
+      name: 'Showtime (Piano Refrain)',
+      color: '#38f43d',
+    }],
+    multiple: [
+      {slots: {color: false}},
+      {slots: {color: true}},
+      {slots: {color: '#aaccff'}},
+    ],
+  });
+
+  quickSnapshot('tags in name escaped', [
+    {args: ['localized.track', {
+      directory: 'foo',
+      name: `<a href="SNOOPING">AS USUAL</a> I SEE`,
+    }]},
+    {args: ['localized.track', {
+      directory: 'bar',
+      name: `<b>boldface</b>`,
+    }]},
+    {args: ['localized.album', {
+      directory: 'exile',
+      name: '>Exile<',
+    }]},
+    {args: ['localized.track', {
+      directory: 'heart',
+      name: '<3',
+    }]},
+  ]);
+});

--- a/test/snapshot/linkThing.js
+++ b/test/snapshot/linkThing.js
@@ -73,4 +73,15 @@ testContentFunctions(t, 'linkThing (snapshot)', async (t, evaluate) => {
       name: '<3',
     }]},
   ]);
+
+  quickSnapshot('nested links in content stripped', {
+    args: ['localized.staticPage', {directory: 'foo', name: 'Foo'}],
+    slots: {
+      content:
+        html.tag('b', {[html.joinChildren]: ''}, [
+          html.tag('a', {href: 'bar'}, `Oooo!`),
+          ` Very spooky.`,
+        ]),
+    },
+  });
 });


### PR DESCRIPTION
As title. Development:

* Fixes #277.

Includes snapshot tests for the above fix, and a few tests for distinctly "thing-related" slots. No tests for the more "meta" slots like `attributes`, `hash`, and `anchor` in this PR, though.
