### PR TITLE
Don't generate a redirect at the directory of an alias if it matches the original artist

### DIFF
--- a/src/page/artist-alias.js
+++ b/src/page/artist-alias.js
@@ -7,6 +7,12 @@ export function targets({wikiData}) {
 export function pathsForTarget(aliasArtist) {
   const {aliasedArtist} = aliasArtist;
 
+  // Don't generate a redirect page if this aliased name resolves to the same
+  // directory as the original artist! See issue #280.
+  if (aliasArtist.directory === aliasedArtist.directory) {
+    return [];
+  }
+
   return [
     {
       type: 'redirect',


### PR DESCRIPTION
One-line fix, as described in the title!

* Fixes #280.

Tested by hand by adding `Directory: viko-rifeo` to Viko Riféo's alias (and keeping the `Viko Rifeo` alias there).
