### PR TITLE
Fast find implementation

### DIFF
--- a/src/data/composite/things/track/withAlwaysReferenceByDirectory.js
+++ b/src/data/composite/things/track/withAlwaysReferenceByDirectory.js
@@ -2,15 +2,22 @@
 // just to the track's name, which means you don't have to always reference
 // some *other* (much more commonly referenced) track by directory instead
 // of more naturally by name.
+//
+// See the implementation for an important caveat about matching the original
+// track against other tracks, which uses a custom implementation pulling (and
+// duplicating) details from #find instead of using withOriginalRelease and the
+// usual withResolvedReference / find.track() utilities.
+//
 
 import {input, templateCompositeFrom} from '#composite';
 import {isBoolean} from '#validators';
 
 import {exitWithoutDependency, exposeUpdateValueOrContinue}
   from '#composite/control-flow';
-import {excludeFromList, withPropertyFromObject} from '#composite/data';
+import {withPropertyFromObject} from '#composite/data';
 
-import withOriginalRelease from './withOriginalRelease.js';
+// TODO: Kludge. (The usage of this, not so much the import.)
+import CacheableObject from '../../../things/cacheable-object.js';
 
 export default templateCompositeFrom({
   annotation: `withAlwaysReferenceByDirectory`,
@@ -22,14 +29,44 @@ export default templateCompositeFrom({
       validate: input.value(isBoolean),
     }),
 
-    excludeFromList({
-      list: 'trackData',
-      item: input.myself(),
+    // Remaining code is for defaulting to true if this track is a rerelease of
+    // another with the same name, so everything further depends on access to
+    // trackData as well as originalReleaseTrack.
+
+    exitWithoutDependency({
+      dependency: 'trackData',
+      mode: input.value('empty'),
+      value: input.value(false),
     }),
 
-    withOriginalRelease({
-      data: '#trackData',
+    exitWithoutDependency({
+      dependency: 'originalReleaseTrack',
+      value: input.value(false),
     }),
+
+    // "Slow" / uncached, manual search from trackData (with this track
+    // excluded). Otherwise there end up being pretty bad recursion issues
+    // (track1.alwaysReferencedByDirectory depends on searching through data
+    // including track2, which depends on evaluating track2.alwaysReferenced-
+    // ByDirectory, which depends on searcing through data including track1...)
+    // That said, this is 100% a kludge, since it involves duplicating find
+    // logic on a completely unrelated context.
+    {
+      dependencies: [input.myself(), 'trackData', 'originalReleaseTrack'],
+      compute: (continuation, {
+        [input.myself()]: thisTrack,
+        ['trackData']: trackData,
+        ['originalReleaseTrack']: ref,
+      }) => continuation({
+        ['#originalRelease']:
+          (ref.startsWith('track:')
+            ? trackData.find(track => track.directory === ref.slice('track:'.length))
+            : trackData.find(track =>
+                track !== thisTrack &&
+                !CacheableObject.getUpdateValue(track, 'originalReleaseTrack') &&
+                track.name.toLowerCase() === ref.toLowerCase())),
+      })
+    },
 
     exitWithoutDependency({
       dependency: '#originalRelease',

--- a/src/find.js
+++ b/src/find.js
@@ -1,6 +1,7 @@
 import {inspect} from 'node:util';
 
 import {colors, logWarn} from '#cli';
+import {typeAppearance} from '#sugar';
 
 function warnOrThrow(mode, message) {
   if (mode === 'error') {
@@ -14,253 +15,151 @@ function warnOrThrow(mode, message) {
   return null;
 }
 
-function findHelper(keys, findFns = {}) {
+export function processAllAvailableMatches(data, {
+  getMatchableNames = thing => [thing.name],
+} = {}) {
+  const byName = Object.create(null);
+  const byDirectory = Object.create(null);
+  const multipleNameMatches = Object.create(null);
+
+  for (const thing of data) {
+    for (const name of getMatchableNames(thing)) {
+      const normalizedName = name.toLowerCase();
+      if (normalizedName in byName) {
+        byName[normalizedName] = null;
+        if (normalizedName in multipleNameMatches) {
+          multipleNameMatches[normalizedName].push(thing);
+        } else {
+          multipleNameMatches[normalizedName] = [thing];
+        }
+      } else {
+        byName[normalizedName] = thing;
+      }
+    }
+
+    byDirectory[thing.directory] = thing;
+  }
+
+  return {byName, byDirectory, multipleNameMatches};
+}
+
+function findHelper({
+  referenceTypes,
+
+  getMatchableNames = undefined,
+}) {
+  const keyRefRegex =
+    new RegExp(String.raw`^(?:(${referenceTypes.join('|')}):(?=\S))?(.*)$`);
+
   // Note: This cache explicitly *doesn't* support mutable data arrays. If the
   // data array is modified, make sure it's actually a new array object, not
   // the original, or the cache here will break and act as though the data
   // hasn't changed!
   const cache = new WeakMap();
 
-  const byDirectory = findFns.byDirectory || matchDirectory;
-  const byName = findFns.byName || matchName;
-
-  const keyRefRegex = new RegExp(String.raw`^(?:(${keys.join('|')}):(?=\S))?(.*)$`);
-
   // The mode argument here may be 'warn', 'error', or 'quiet'. 'error' throws
   // errors for null matches (with details about the error), while 'warn' and
   // 'quiet' both return null, with 'warn' logging details directly to the
   // console.
-  return (fullRef, data, {mode = 'warn'} = {}) => {
+  return (fullRef, data, {mode = 'warn'}) => {
     if (!fullRef) return null;
-
-    if (typeof fullRef !== 'string' && !Array.isArray(fullRef)) {
-      throw new Error(`Got a reference that is ${typeof fullRef}, not string or array: ${fullRef}`);
+    if (typeof fullRef !== 'string') {
+      throw new TypeError(`Expected a string, got ${typeAppearance(fullRef)}`);
     }
 
     if (!data) {
-      throw new Error(`Expected data to be present`);
+      throw new TypeError(`Expected data to be present`);
     }
 
-    let cacheForThisData = cache.get(data);
-    if (!cacheForThisData) {
-      cacheForThisData = Object.create(null);
-      cache.set(data, cacheForThisData);
+    let subcache = cache.get(data);
+    if (!subcache) {
+      subcache =
+        processAllAvailableMatches(data, {
+          getMatchableNames,
+        });
+
+      cache.set(data, subcache);
     }
 
-    const parseFullRef = fullRef => {
-      const regexMatch = fullRef.match(keyRefRegex);
-      if (!regexMatch) {
-        warnOrThrow(mode, `Malformed link reference: "${fullRef[i]}"`);
-        return {error: true, key: null, ref: null};
-      }
-
-      const key = regexMatch[1];
-      const ref = regexMatch[2];
-
-      return {error: false, key, ref};
-    };
-
-    if (typeof fullRef === 'string') {
-      const cachedMatch = cacheForThisData[fullRef];
-      if (cachedMatch) return cachedMatch;
-
-      const {error: regexError, key, ref} = parseFullRef(fullRef);
-      if (regexError) return null;
-
-      const match =
-        (key
-          ? byDirectory(ref, data, mode)
-          : byName(ref, data, mode));
-
-      if (!match) {
-        warnOrThrow(mode, `Didn't match anything for ${colors.bright(fullRef)}`);
-      }
-
-      cacheForThisData[fullRef] = match;
-
-      return match;
+    const regexMatch = fullRef.match(keyRefRegex);
+    if (!regexMatch) {
+      warnOrThrow(mode, `Malformed link reference: "${fullRef}"`);
     }
 
-    const fullRefList = fullRef;
-    if (Array.isArray(fullRefList)) {
-      const byDirectoryUncachedIndices = [];
-      const byDirectoryUncachedRefs = [];
-      const byNameUncachedIndices = [];
-      const byNameUncachedRefs = [];
+    const typePart = regexMatch[1];
+    const refPart = regexMatch[2];
 
-      for (let index = 0; index < fullRefList.length; index++) {
-        const cachedMatch = cacheForThisData[fullRefList[index]];
-        if (cachedMatch) return cachedMatch;
+    const match =
+      (typePart
+        ? subcache.byDirectory[refPart]
+        : subcache.byName[refPart.toLowerCase()]);
 
-        const {error: regexError, key, ref} = parseFullRef(fullRefList[index]);
-        if (regexError) return null;
-
-        if (key) {
-          byDirectoryUncachedIndices.push(index);
-          byDirectoryUncachedRefs.push(ref);
-        } else {
-          byNameUncachedIndices.push(index);
-          byNameUncachedRefs.push(ref);
-        }
-      }
-
-      const byDirectoryMatches = byDirectory(byDirectoryUncachedRefs, data, mode);
-      const byNameMatches = byName(byNameUncachedRefs, data, mode);
-
-      const results = [];
-
-      const processMatch = (match, sourceIndex) => {
-        if (match) {
-          cacheForThisData[fullRefList[sourceIndex]] = match;
-          results[sourceIndex] = match;
-        } else {
-          // TODO: Aggregate errors
-          warnOrThrow(mode, `Didn't match anything for ${fullRefList[sourceIndex]}`);
-          results[sourceIndex] = null;
-        }
-      };
-
-      for (let index = 0; index < byDirectoryMatches.length; index++) {
-        const sourceIndex = byDirectoryUncachedIndices[index];
-        const match = byDirectoryMatches[index];
-        processMatch(match, sourceIndex);
-      }
-
-      for (let index = 0; index < byNameMatches.length; index++) {
-        const sourceIndex = byNameUncachedIndices[index];
-        const match = byNameMatches[index];
-        processMatch(match, sourceIndex);
-      }
-
-      return results;
-    }
-  };
-}
-
-function matchDirectory(ref, data) {
-  if (typeof ref === 'string') {
-    return data.find(({directory}) => directory === ref);
-  }
-
-  const refList = ref;
-  if (Array.isArray(refList)) {
-    const refSet = new Set(refList);
-    const refMap = new Map();
-
-    for (const thing of data) {
-      const {directory} = thing;
-      if (refSet.has(directory)) {
-        refMap.set(directory, thing);
+    if (!match && !typePart) {
+      if (subcache.multipleNameMatches[refPart]) {
+        return warnOrThrow(mode,
+          `Multiple matches for reference "${fullRef}". Please resolve:\n` +
+          subcache.multipleNameMatches[refPart]
+            .map(match => `- ${inspect(match)}\n`)
+            .join('') +
+          `Returning null for this reference.`);
       }
     }
 
-    return refList.map(ref => refMap.get(ref) ?? null);
-  }
-}
-
-function matchName(ref, data, mode) {
-  if (typeof ref === 'string') {
-    const matches =
-      data
-        .filter(({name}) => name.toLowerCase() === ref.toLowerCase())
-        .filter(thing =>
-          (Object.hasOwn(thing, 'alwaysReferenceByDirectory')
-            ? !thing.alwaysReferenceByDirectory
-            : true));
-
-    if (matches.length > 1) {
-      return warnOrThrow(mode,
-        `Multiple matches for reference "${ref}". Please resolve:\n` +
-        matches.map(match => `- ${inspect(match)}\n`).join('') +
-        `Returning null for this reference.`);
-    }
-
-    if (matches.length === 0) {
+    if (!match) {
+      warnOrThrow(mode, `Didn't match anything for ${colors.bright(fullRef)}`);
       return null;
     }
 
-    const match = matches[0];
-
-    if (ref !== match.name) {
-      warnOrThrow(mode,
-        `Bad capitalization: ${colors.red(ref)} -> ${colors.green(match.name)}`);
-    }
-
     return match;
-  }
-
-  const refList = ref;
-  if (Array.isArray(refList)) {
-    const refSet = new Set(refList.map(name => name.toLowerCase()));
-    const refMap = new Map();
-    const multipleMatchesMap = new Map();
-
-    for (const thing of data) {
-      if (thing.alwaysReferenceByDirectory) continue;
-      const name = thing.name.toLowerCase();
-      if (refSet.has(name)) {
-        if (refMap.has(name)) {
-          refMap.set(name, null); // .has() will still return true
-          if (multipleMatchesMap.has(name)) {
-            multipleMatchesMap.get(name).push(thing);
-          } else {
-            multipleMatchesMap.set(name, [thing]);
-          }
-        } else {
-          refMap.set(name, thing);
-        }
-      }
-    }
-
-    // TODO: Aggregate errors
-    for (const [name, matches] of multipleMatchesMap.entries()) {
-      warnOrThrow(mode,
-        `Multiple matches for reference "${ref}". Please resolve:\n` +
-        matches.map(match => `- ${inspect(match)}\n`).join('') +
-        `Returning null for this reference.`);
-    }
-
-    return refList.map(ref => {
-      const match = refMap.get(ref);
-      if (!match) return null;
-
-      // TODO: Aggregate errors
-      if (ref !== match.name) {
-        warnOrThrow(mode,
-          `Bad capitalization: ${colors.red(ref)} -> ${colors.green(match.name)}`);
-      }
-
-      return match;
-    });
-  }
-}
-
-function matchTagName(ref, data, mode) {
-  if (typeof ref === 'string') {
-    return matchName(
-      ref.startsWith('cw: ') ? ref.slice(4) : ref,
-      data,
-      mode);
-  }
-
-  if (Array.isArray(ref)) {
-    return matchName(
-      ref.map(ref => ref.startsWith('cw: ') ? ref.slice(4) : ref),
-      data,
-      mode);
-  }
+  };
 }
 
 const find = {
-  album: findHelper(['album', 'album-commentary', 'album-gallery']),
-  artist: findHelper(['artist', 'artist-gallery']),
-  artTag: findHelper(['tag'], {byName: matchTagName}),
-  flash: findHelper(['flash']),
-  group: findHelper(['group', 'group-gallery']),
-  listing: findHelper(['listing']),
-  newsEntry: findHelper(['news-entry']),
-  staticPage: findHelper(['static']),
-  track: findHelper(['track']),
+  album: findHelper({
+    referenceTypes: ['album', 'album-commentary', 'album-gallery'],
+  }),
+
+  artist: findHelper({
+    referenceTypes: ['artist', 'artist-gallery'],
+  }),
+
+  artTag: findHelper({
+    referenceTypes: ['tag'],
+
+    getMatchableNames: tag =>
+      (tag.isContentWarning
+        ? [`cw: ${tag.name}`]
+        : [tag.name]),
+  }),
+
+  flash: findHelper({
+    referenceTypes: ['flash'],
+  }),
+
+  group: findHelper({
+    referenceTypes: ['group', 'group-gallery'],
+  }),
+
+  listing: findHelper({
+    referenceTypes: ['listing'],
+  }),
+
+  newsEntry: findHelper({
+    referenceTypes: ['news-entry'],
+  }),
+
+  staticPage: findHelper({
+    referenceTypes: ['static'],
+  }),
+
+  track: findHelper({
+    referenceTypes: ['track'],
+
+    getMatchableNames: track =>
+      (track.alwaysReferenceByDirectory
+        ? []
+        : [track.name]),
+  }),
 };
 
 export default find;

--- a/src/find.js
+++ b/src/find.js
@@ -16,7 +16,10 @@ function warnOrThrow(mode, message) {
 }
 
 export function processAllAvailableMatches(data, {
-  getMatchableNames = thing => [thing.name],
+  getMatchableNames = thing =>
+    (Object.hasOwn(thing, 'name')
+      ? [thing.name]
+      : []),
 } = {}) {
   const byName = Object.create(null);
   const byDirectory = Object.create(null);
@@ -24,6 +27,11 @@ export function processAllAvailableMatches(data, {
 
   for (const thing of data) {
     for (const name of getMatchableNames(thing)) {
+      if (typeof name !== 'string') {
+        logWarn`Unexpected ${typeAppearance(name)} returned in names for ${inspect(thing)}`;
+        continue;
+      }
+
       const normalizedName = name.toLowerCase();
       if (normalizedName in byName) {
         byName[normalizedName] = null;

--- a/src/find.js
+++ b/src/find.js
@@ -32,85 +32,223 @@ function findHelper(keys, findFns = {}) {
   // console.
   return (fullRef, data, {mode = 'warn'} = {}) => {
     if (!fullRef) return null;
-    if (typeof fullRef !== 'string') {
-      throw new Error(`Got a reference that is ${typeof fullRef}, not string: ${fullRef}`);
+
+    if (typeof fullRef !== 'string' && !Array.isArray(fullRef)) {
+      throw new Error(`Got a reference that is ${typeof fullRef}, not string or array: ${fullRef}`);
     }
 
     if (!data) {
       throw new Error(`Expected data to be present`);
     }
 
-    if (!Array.isArray(data) && data.wikiData) {
-      throw new Error(`Old {wikiData: {...}} format provided`);
-    }
-
     let cacheForThisData = cache.get(data);
-    const cachedValue = cacheForThisData?.[fullRef];
-    if (cachedValue) {
-      globalThis.NUM_CACHE = (globalThis.NUM_CACHE || 0) + 1;
-      return cachedValue;
-    }
     if (!cacheForThisData) {
       cacheForThisData = Object.create(null);
       cache.set(data, cacheForThisData);
     }
 
-    const match = fullRef.match(keyRefRegex);
-    if (!match) {
-      return warnOrThrow(mode, `Malformed link reference: "${fullRef}"`);
+    const parseFullRef = fullRef => {
+      const regexMatch = fullRef.match(keyRefRegex);
+      if (!regexMatch) {
+        warnOrThrow(mode, `Malformed link reference: "${fullRef[i]}"`);
+        return {error: true, key: null, ref: null};
+      }
+
+      const key = regexMatch[1];
+      const ref = regexMatch[2];
+
+      return {error: false, key, ref};
+    };
+
+    if (typeof fullRef === 'string') {
+      const cachedMatch = cacheForThisData[fullRef];
+      if (cachedMatch) return cachedMatch;
+
+      const {error: regexError, key, ref} = parseFullRef(fullRef);
+      if (regexError) return null;
+
+      const match =
+        (key
+          ? byDirectory(ref, data, mode)
+          : byName(ref, data, mode));
+
+      if (!match) {
+        warnOrThrow(mode, `Didn't match anything for ${colors.bright(fullRef)}`);
+      }
+
+      cacheForThisData[fullRef] = match;
+
+      return match;
     }
 
-    const key = match[1];
-    const ref = match[2];
+    const fullRefList = fullRef;
+    if (Array.isArray(fullRefList)) {
+      const byDirectoryUncachedIndices = [];
+      const byDirectoryUncachedRefs = [];
+      const byNameUncachedIndices = [];
+      const byNameUncachedRefs = [];
 
-    const found = key ? byDirectory(ref, data, mode) : byName(ref, data, mode);
+      for (let index = 0; index < fullRefList.length; index++) {
+        const cachedMatch = cacheForThisData[fullRefList[index]];
+        if (cachedMatch) return cachedMatch;
 
-    if (!found) {
-      warnOrThrow(mode, `Didn't match anything for ${colors.bright(fullRef)}`);
+        const {error: regexError, key, ref} = parseFullRef(fullRefList[index]);
+        if (regexError) return null;
+
+        if (key) {
+          byDirectoryUncachedIndices.push(index);
+          byDirectoryUncachedRefs.push(ref);
+        } else {
+          byNameUncachedIndices.push(index);
+          byNameUncachedRefs.push(ref);
+        }
+      }
+
+      const byDirectoryMatches = byDirectory(byDirectoryUncachedRefs, data, mode);
+      const byNameMatches = byName(byNameUncachedRefs, data, mode);
+
+      const results = [];
+
+      const processMatch = (match, sourceIndex) => {
+        if (match) {
+          cacheForThisData[fullRefList[sourceIndex]] = match;
+          results[sourceIndex] = match;
+        } else {
+          // TODO: Aggregate errors
+          warnOrThrow(mode, `Didn't match anything for ${fullRefList[sourceIndex]}`);
+          results[sourceIndex] = null;
+        }
+      };
+
+      for (let index = 0; index < byDirectoryMatches.length; index++) {
+        const sourceIndex = byDirectoryUncachedIndices[index];
+        const match = byDirectoryMatches[index];
+        processMatch(match, sourceIndex);
+      }
+
+      for (let index = 0; index < byNameMatches.length; index++) {
+        const sourceIndex = byNameUncachedIndices[index];
+        const match = byNameMatches[index];
+        processMatch(match, sourceIndex);
+      }
+
+      return results;
     }
-
-    cacheForThisData[fullRef] = found;
-
-    return found;
   };
 }
 
 function matchDirectory(ref, data) {
-  return data.find(({directory}) => directory === ref);
+  if (typeof ref === 'string') {
+    return data.find(({directory}) => directory === ref);
+  }
+
+  const refList = ref;
+  if (Array.isArray(refList)) {
+    const refSet = new Set(refList);
+    const refMap = new Map();
+
+    for (const thing of data) {
+      const {directory} = thing;
+      if (refSet.has(directory)) {
+        refMap.set(directory, thing);
+      }
+    }
+
+    return refList.map(ref => refMap.get(ref) ?? null);
+  }
 }
 
 function matchName(ref, data, mode) {
-  const matches =
-    data
-      .filter(({name}) => name.toLowerCase() === ref.toLowerCase())
-      .filter(thing =>
-        (Object.hasOwn(thing, 'alwaysReferenceByDirectory')
-          ? !thing.alwaysReferenceByDirectory
-          : true));
+  if (typeof ref === 'string') {
+    const matches =
+      data
+        .filter(({name}) => name.toLowerCase() === ref.toLowerCase())
+        .filter(thing =>
+          (Object.hasOwn(thing, 'alwaysReferenceByDirectory')
+            ? !thing.alwaysReferenceByDirectory
+            : true));
 
-  if (matches.length > 1) {
-    return warnOrThrow(mode,
-      `Multiple matches for reference "${ref}". Please resolve:\n` +
-      matches.map(match => `- ${inspect(match)}\n`).join('') +
-      `Returning null for this reference.`);
+    if (matches.length > 1) {
+      return warnOrThrow(mode,
+        `Multiple matches for reference "${ref}". Please resolve:\n` +
+        matches.map(match => `- ${inspect(match)}\n`).join('') +
+        `Returning null for this reference.`);
+    }
+
+    if (matches.length === 0) {
+      return null;
+    }
+
+    const match = matches[0];
+
+    if (ref !== match.name) {
+      warnOrThrow(mode,
+        `Bad capitalization: ${colors.red(ref)} -> ${colors.green(match.name)}`);
+    }
+
+    return match;
   }
 
-  if (matches.length === 0) {
-    return null;
+  const refList = ref;
+  if (Array.isArray(refList)) {
+    const refSet = new Set(refList.map(name => name.toLowerCase()));
+    const refMap = new Map();
+    const multipleMatchesMap = new Map();
+
+    for (const thing of data) {
+      if (thing.alwaysReferenceByDirectory) continue;
+      const name = thing.name.toLowerCase();
+      if (refSet.has(name)) {
+        if (refMap.has(name)) {
+          refMap.set(name, null); // .has() will still return true
+          if (multipleMatchesMap.has(name)) {
+            multipleMatchesMap.get(name).push(thing);
+          } else {
+            multipleMatchesMap.set(name, [thing]);
+          }
+        } else {
+          refMap.set(name, thing);
+        }
+      }
+    }
+
+    // TODO: Aggregate errors
+    for (const [name, matches] of multipleMatchesMap.entries()) {
+      warnOrThrow(mode,
+        `Multiple matches for reference "${ref}". Please resolve:\n` +
+        matches.map(match => `- ${inspect(match)}\n`).join('') +
+        `Returning null for this reference.`);
+    }
+
+    return refList.map(ref => {
+      const match = refMap.get(ref);
+      if (!match) return null;
+
+      // TODO: Aggregate errors
+      if (ref !== match.name) {
+        warnOrThrow(mode,
+          `Bad capitalization: ${colors.red(ref)} -> ${colors.green(match.name)}`);
+      }
+
+      return match;
+    });
   }
-
-  const thing = matches[0];
-
-  if (ref !== thing.name) {
-    warnOrThrow(mode,
-      `Bad capitalization: ${colors.red(ref)} -> ${colors.green(thing.name)}`);
-  }
-
-  return thing;
 }
 
-function matchTagName(ref, data, quiet) {
-  return matchName(ref.startsWith('cw: ') ? ref.slice(4) : ref, data, quiet);
+function matchTagName(ref, data, mode) {
+  if (typeof ref === 'string') {
+    return matchName(
+      ref.startsWith('cw: ') ? ref.slice(4) : ref,
+      data,
+      mode);
+  }
+
+  if (Array.isArray(ref)) {
+    return matchName(
+      ref.map(ref => ref.startsWith('cw: ') ? ref.slice(4) : ref),
+      data,
+      mode);
+  }
 }
 
 const find = {
@@ -155,7 +293,9 @@ export function bindFind(wikiData, opts1) {
                 ? findFn(ref, thingData, {...opts1, ...opts2})
                 : findFn(ref, thingData, opts1)
           : (ref, opts2) =>
-              opts2 ? findFn(ref, thingData, opts2) : findFn(ref, thingData),
+              opts2
+                ? findFn(ref, thingData, opts2)
+                : findFn(ref, thingData),
       ];
     })
   );


### PR DESCRIPTION
This introduces a new, fast `findHelper` implementation, which operates by fully preparing a hash map of names and directories to things the very first time it's provided with a new (by identity) data array.

This is a trade-off between lazy and preemptive evaluation, and for the kind of processing done on the wiki, preemptive is by far the more efficient route.

This also significantly simplifies the logic throughout `find.js`, making it quite a bit easier to follow and more clearly dividing the purposes of each section of code there.

This does not change the surface-level behavior of `find.track`, `find.album`, etc - it just makes them a whole lot faster!

I'd like to do more benchmarks, but overall the changes in this PR account for about 25 seconds of time gained going from the start of run to the point where a specific build mode (live-dev-server or static-build) takes over. Versus `--skip-thumbs --no-build` run previously (about 35 seconds) on one machine (M1 Mac mini), that's about a 70% speed increase, which is... pretty big!

Also includes:

* 72cc4d62a32e40c1dcb75e868c51991075cc03e7 - Somewhat awkward solution to avoid an infinite recursion loop to do with `originalReleaseTrack` and `alwaysReferenceByDirectory`, which wasn't seemingly an issue with the prior lazy approach.
* 44e47fb3316c5452d277166215bc7522b404047f - Unrelated (sorry) optimization for the `validateWikiData` utility function, which is relatively heavily. This is surprisingly consistently responsible for about 1.5-2 seconds of the speed-up quantified above.