### PR TITLE
Atomic composition implementations

### DIFF
--- a/src/data/composite/wiki-data/withResolvedReferenceList.js
+++ b/src/data/composite/wiki-data/withResolvedReferenceList.js
@@ -3,6 +3,10 @@
 // data dependency is null (even if the reference list is empty). By default
 // it will filter out references which don't match, but this can be changed
 // to early exit ({notFoundMode: 'exit'}) or leave null in place ('null').
+//
+// Reference code for:
+//  - (atomic) referenceList
+//
 
 import {input, templateCompositeFrom} from '#composite';
 import {is, isString, validateArrayItems} from '#validators';

--- a/src/data/composite/wiki-data/withReverseReferenceList.js
+++ b/src/data/composite/wiki-data/withReverseReferenceList.js
@@ -10,6 +10,10 @@
 //
 // Note that this implementation is mirrored in withReverseContributionList,
 // so any changes should be reflected there (until these are combined).
+//
+// Reference code for:
+//  - (atomic) reverseReferenceList
+//
 
 import {input, templateCompositeFrom} from '#composite';
 

--- a/src/data/composite/wiki-properties/atomic/referenceList.js
+++ b/src/data/composite/wiki-properties/atomic/referenceList.js
@@ -1,0 +1,70 @@
+// Atomic implementation for referenceList.
+//
+// Expects these input token shapes:
+//  - class: input.value(a constructor)
+//  - find: input.value(a function)
+//  - data: a string dependency name
+//
+// Embeds behavior of:
+//  - referenceList
+//  - withResolvedReferenceList
+//
+
+import {getInputTokenValue} from '#composite';
+import {empty} from '#sugar';
+import {validateReferenceList} from '#validators';
+
+// TODO: Kludge.
+import Thing from '../../../things/thing.js';
+
+export default function({
+  class: classToken,
+  find: findToken,
+  data: dataToken,
+}) {
+  /* ref: referenceList */
+  const thingClass = getInputTokenValue(classToken);
+  const findFunction = getInputTokenValue(findToken);
+  const dataProperty = dataToken;
+
+  /* ref: referenceList */
+  const {[Thing.referenceType]: referenceType} = thingClass;
+
+  return {
+    flags: {update: true, expose: true, compose: false},
+
+    /* ref: referenceList */
+    update: {
+      validate: validateReferenceList(referenceType),
+    },
+
+    expose: {
+      dependencies: [dataProperty],
+
+      transform(referenceList, {[dataProperty]: data}) {
+        /* ref: withResolvedReferenceList step #1 (exitWithoutDependency) */
+        if (!data) {
+          return [];
+        }
+
+        /* ref: withResolvedReferenceList step #2 (raiseOutputWithoutDependency) */
+        if (referenceList === undefined || empty(referenceList)) {
+          return [];
+        }
+
+        /* ref: withResolvedReferenceList step #3 (custom) */
+        const matches =
+          referenceList.map(ref => findFunction(ref, data, {mode: 'quiet'}));
+
+        /* ref: withResolvedReferenceList step #4 (custom)        *
+         * ref: withResolvedReferenceList step #5 (custom)        *
+         * ref: referenceList step #1 (withResolvedReferenceList) *
+         * notFoundMode is 'filter' (default).                    */
+        const filteredMatches =
+          matches.filter(match => match);
+
+        return filteredMatches;
+      },
+    },
+  };
+}

--- a/src/data/composite/wiki-properties/atomic/reverseReferenceList.js
+++ b/src/data/composite/wiki-properties/atomic/reverseReferenceList.js
@@ -1,0 +1,69 @@
+// Atomic implementation for reverseReferenceList.
+//
+// Expects these input token shapes:
+//  - data: a string dependency name
+//  - list: input.value(a string)
+//
+// Embeds behavior of:
+//  - reverseReferenceList
+//  - withReverseReferenceList
+//
+
+import {getInputTokenValue} from '#composite';
+import {empty} from '#sugar';
+
+/* ref: withReverseReferenceList */
+const caches = new Map();
+
+export default function({
+  data: dataToken,
+  list: listToken,
+}) {
+  /* ref: reverseReferenceList */
+  const dataProperty = dataToken;
+  const refListProperty = getInputTokenValue(listToken);
+
+  return {
+    flags: {update: false, expose: true, compose: true},
+
+    expose: {
+      dependencies: ['this', dataProperty],
+
+      compute({this: myself, [dataProperty]: data}) {
+        /* ref: withReverseReferenceList step #1 (exitWithoutDependency) */
+        if (data === undefined || empty(data)) {
+          return [];
+        }
+
+        /* ref: withReverseReferenceList step #2 (custom) */
+
+        const list = refListProperty;
+
+        if (!caches.has(list)) {
+          caches.set(list, new WeakMap());
+        }
+
+        const cache = caches.get(list);
+
+        if (!cache.has(data)) {
+          const cacheRecord = new WeakMap();
+
+          for (const referencingThing of data) {
+            const referenceList = referencingThing[list];
+            for (const referencedThing of referenceList) {
+              if (cacheRecord.has(referencedThing)) {
+                cacheRecord.get(referencedThing).push(referencingThing);
+              } else {
+                cacheRecord.set(referencedThing, [referencingThing]);
+              }
+            }
+          }
+
+          cache.set(data, cacheRecord);
+        }
+
+        return cache.get(data).get(myself) ?? [];
+      },
+    }
+  };
+}

--- a/src/data/composite/wiki-properties/referenceList.js
+++ b/src/data/composite/wiki-properties/referenceList.js
@@ -1,6 +1,9 @@
 // Stores and exposes a list of references to other data objects; all items
 // must be references to the same type, which is specified on the class input.
 //
+// Reference code for:
+//  - (atomic) referenceList
+//
 // See also:
 //  - singleReference
 //  - withResolvedReferenceList
@@ -16,7 +19,7 @@ import {inputThingClass, inputWikiData, withResolvedReferenceList}
 // TODO: Kludge.
 import Thing from '../../things/thing.js';
 
-export default templateCompositeFrom({
+export const REFERENCE = templateCompositeFrom({
   annotation: `referenceList`,
 
   compose: false,
@@ -45,3 +48,5 @@ export default templateCompositeFrom({
     exposeDependency({dependency: '#resolvedReferenceList'}),
   ],
 });
+
+export {default} from './atomic/referenceList.js';

--- a/src/data/composite/wiki-properties/reverseReferenceList.js
+++ b/src/data/composite/wiki-properties/reverseReferenceList.js
@@ -3,13 +3,17 @@
 // you would use this to compute a corresponding "referenced *by* tracks"
 // property. Naturally, the passed ref list property is of the things in the
 // wiki data provided, not the requesting Thing itself.
+//
+// Reference code for:
+//  - (atomic) reverseReferenceList
+//
 
 import {input, templateCompositeFrom} from '#composite';
 
 import {exposeDependency} from '#composite/control-flow';
 import {inputWikiData, withReverseReferenceList} from '#composite/wiki-data';
 
-export default templateCompositeFrom({
+export const REFERENCE = templateCompositeFrom({
   annotation: `reverseReferenceList`,
 
   compose: false,
@@ -28,3 +32,5 @@ export default templateCompositeFrom({
     exposeDependency({dependency: '#reverseReferenceList'}),
   ],
 });
+
+export {default} from './atomic/reverseReferenceList.js';

--- a/src/data/things/composite.js
+++ b/src/data/things/composite.js
@@ -42,7 +42,7 @@ input.updateValue = _valueIntoToken('input.updateValue');
 input.staticDependency = _valueIntoToken('input.staticDependency');
 input.staticValue = _valueIntoToken('input.staticValue');
 
-function isInputToken(token) {
+export function isInputToken(token) {
   if (token === null) {
     return false;
   } else if (typeof token === 'object') {
@@ -54,7 +54,7 @@ function isInputToken(token) {
   }
 }
 
-function getInputTokenShape(token) {
+export function getInputTokenShape(token) {
   if (!isInputToken(token)) {
     throw new TypeError(`Expected an input token, got ${typeAppearance(token)}`);
   }
@@ -66,7 +66,7 @@ function getInputTokenShape(token) {
   }
 }
 
-function getInputTokenValue(token) {
+export function getInputTokenValue(token) {
   if (!isInputToken(token)) {
     throw new TypeError(`Expected an input token, got ${typeAppearance(token)}`);
   }


### PR DESCRIPTION
Experimental! This replaces certain compositions with "atomic" implementations, which means they themselves aren't compositions at all, serving as a complete property descriptor instead. The *atomic implementations* are strictly in terms of a *reference implementation,* that being the existing composition which the atomic implementation stands in for.

Notes:
* This may or may not provide any significant performance improvement, and since this is purely a perf pull request, that improvement needs to be established.
* This doesn't replace *dynamic* caching of individual composition steps (or compositions as a whole), but that's a to-do for another time. This is generally a higher level optimization because it bypasses 100% of the composition overhead and can fully stand in for a complete property descriptor.
* This completely bypasses both static and dynamic validation checks, which is a big downside, especially if we want to try making atomic compositional steps (`{flags: {compose: true}}`).
* Also required for compositional steps is making sure that the `.outputs({})` system (for renaming outputs) continues to work as intended! We're thinking the neatest way to handle both this point and the one above is *basically* to factor out the useful behaviors of both `templateCompositeFrom` and `compositeFrom`, and employ those in a lighter-weight wrapper - one which always only expects a single compute/transform. However, this needs to be compared - in terms of performance - against just using the *existing* `templateCompositeFrom` and creating single-step compositions, which are perfectly well supported already.
  * Likewise, if single-step composition templates are basically as performant as an unwrapped atomic implementation (*and* both of those are substantially faster than the compositional implementation in the first place), then the existing atomic implementations should be redefined as single-step templates, so they can benefit from the same static conveniences (mostly input validation) as other composition templates.
