### PR TITLE
Better YAML error reporting!

### DIFF
--- a/src/data/things/album.js
+++ b/src/data/things/album.js
@@ -181,6 +181,8 @@ export class Album extends Thing {
 }
 
 export class TrackSectionHelper extends Thing {
+  static [Thing.friendlyName] = `Track Section`;
+
   static [Thing.getPropertyDescriptors] = () => ({
     name: name('Unnamed Track Section'),
     color: color(),

--- a/src/data/things/art-tag.js
+++ b/src/data/things/art-tag.js
@@ -16,6 +16,7 @@ import Thing from './thing.js';
 
 export class ArtTag extends Thing {
   static [Thing.referenceType] = 'tag';
+  static [Thing.friendlyName] = `Art Tag`;
 
   static [Thing.getPropertyDescriptors] = ({Album, Track}) => ({
     // Update & expose

--- a/src/data/things/cacheable-object.js
+++ b/src/data/things/cacheable-object.js
@@ -179,13 +179,8 @@ export default class CacheableObject {
           } else if (result !== true) {
             throw new TypeError(`Validation failed for value ${newValue}`);
           }
-        } catch (error) {
-          error.message = [
-            `Property ${colors.green(property)}`,
-            `(${inspect(this[property])} -> ${inspect(newValue)}):`,
-            error.message
-          ].join(' ');
-          throw error;
+        } catch (caughtError) {
+          throw new CacheableObjectPropertyValueError(property, this[property], newValue, caughtError);
         }
       }
 
@@ -357,5 +352,15 @@ export default class CacheableObject {
     }
 
     return object.#propertyUpdateValues[key] ?? null;
+  }
+}
+
+export class CacheableObjectPropertyValueError extends Error {
+  constructor(property, oldValue, newValue, error) {
+    super(
+      `Error setting ${colors.green(property)} (${inspect(oldValue)} -> ${inspect(newValue)})`,
+      {cause: error});
+
+    this.property = property;
   }
 }

--- a/src/data/things/flash.js
+++ b/src/data/things/flash.js
@@ -119,6 +119,7 @@ export class Flash extends Thing {
 
 export class FlashAct extends Thing {
   static [Thing.referenceType] = 'flash-act';
+  static [Thing.friendlyName] = `Flash Act`;
 
   static [Thing.getPropertyDescriptors] = () => ({
     // Update & expose

--- a/src/data/things/group.js
+++ b/src/data/things/group.js
@@ -83,6 +83,8 @@ export class Group extends Thing {
 }
 
 export class GroupCategory extends Thing {
+  static [Thing.friendlyName] = `Group Category`;
+
   static [Thing.getPropertyDescriptors] = ({Group}) => ({
     // Update & expose
 

--- a/src/data/things/homepage-layout.js
+++ b/src/data/things/homepage-layout.js
@@ -26,6 +26,8 @@ import {
 import Thing from './thing.js';
 
 export class HomepageLayout extends Thing {
+  static [Thing.friendlyName] = `Homepage Layout`;
+
   static [Thing.getPropertyDescriptors] = ({HomepageLayoutRow}) => ({
     // Update & expose
 
@@ -47,6 +49,8 @@ export class HomepageLayout extends Thing {
 }
 
 export class HomepageLayoutRow extends Thing {
+  static [Thing.friendlyName] = `Homepage Row`;
+
   static [Thing.getPropertyDescriptors] = ({Album, Group}) => ({
     // Update & expose
 
@@ -75,6 +79,8 @@ export class HomepageLayoutRow extends Thing {
 }
 
 export class HomepageLayoutAlbumsRow extends HomepageLayoutRow {
+  static [Thing.friendlyName] = `Homepage Albums Row`;
+
   static [Thing.getPropertyDescriptors] = (opts, {Album, Group} = opts) => ({
     ...HomepageLayoutRow[Thing.getPropertyDescriptors](opts),
 

--- a/src/data/things/index.js
+++ b/src/data/things/index.js
@@ -21,7 +21,11 @@ import * as trackClasses from './track.js';
 import * as wikiInfoClasses from './wiki-info.js';
 
 export {default as Thing} from './thing.js';
-export {default as CacheableObject} from './cacheable-object.js';
+
+export {
+  default as CacheableObject,
+  CacheableObjectPropertyValueError,
+} from './cacheable-object.js';
 
 const allClassLists = {
   'album.js': albumClasses,

--- a/src/data/things/news-entry.js
+++ b/src/data/things/news-entry.js
@@ -9,6 +9,7 @@ import Thing from './thing.js';
 
 export class NewsEntry extends Thing {
   static [Thing.referenceType] = 'news-entry';
+  static [Thing.friendlyName] = `News Entry`;
 
   static [Thing.getPropertyDescriptors] = () => ({
     // Update & expose

--- a/src/data/things/static-page.js
+++ b/src/data/things/static-page.js
@@ -10,6 +10,7 @@ import Thing from './thing.js';
 
 export class StaticPage extends Thing {
   static [Thing.referenceType] = 'static';
+  static [Thing.friendlyName] = `Static Page`;
 
   static [Thing.getPropertyDescriptors] = () => ({
     // Update & expose

--- a/src/data/things/thing.js
+++ b/src/data/things/thing.js
@@ -9,6 +9,7 @@ import CacheableObject from './cacheable-object.js';
 
 export default class Thing extends CacheableObject {
   static referenceType = Symbol.for('Thing.referenceType');
+  static friendlyName = Symbol.for(`Thing.friendlyName`);
 
   static getPropertyDescriptors = Symbol('Thing.getPropertyDescriptors');
   static getSerializeDescriptors = Symbol('Thing.getSerializeDescriptors');

--- a/src/data/things/wiki-info.js
+++ b/src/data/things/wiki-info.js
@@ -14,6 +14,8 @@ import {
 import Thing from './thing.js';
 
 export class WikiInfo extends Thing {
+  static [Thing.friendlyName] = `Wiki Info`;
+
   static [Thing.getPropertyDescriptors] = ({Group}) => ({
     // Update & expose
 

--- a/src/util/sugar.js
+++ b/src/util/sugar.js
@@ -168,7 +168,9 @@ export function setIntersection(set1, set2) {
   return intersection;
 }
 
-export function filterProperties(object, properties) {
+export function filterProperties(object, properties, {
+  preserveOriginalOrder = false,
+} = {}) {
   if (typeof object !== 'object' || object === null) {
     throw new TypeError(`Expected object to be an object, got ${typeAppearance(object)}`);
   }
@@ -179,9 +181,17 @@ export function filterProperties(object, properties) {
 
   const filteredObject = {};
 
-  for (const property of properties) {
-    if (Object.hasOwn(object, property)) {
-      filteredObject[property] = object[property];
+  if (preserveOriginalOrder) {
+    for (const property of Object.keys(object)) {
+      if (properties.includes(property)) {
+        filteredObject[property] = object[property];
+      }
+    }
+  } else {
+    for (const property of properties) {
+      if (Object.hasOwn(object, property)) {
+        filteredObject[property] = object[property];
+      }
     }
   }
 

--- a/test/unit/data/cacheable-object.js
+++ b/test/unit/data/cacheable-object.js
@@ -195,13 +195,10 @@ t.test(`CacheableObject validate on update`, t => {
   obj.directory = 'megalovania';
   t.equal(obj.directory, 'megalovania');
 
-  try {
-    obj.directory = 25;
-  } catch (err) {
-    thrownError = err;
-  }
+  t.throws(
+    () => { obj.directory = 25; },
+    {cause: mockError});
 
-  t.equal(thrownError, mockError);
   t.equal(obj.directory, 'megalovania');
 
   const date = new Date(`25 December 2009`);
@@ -209,13 +206,10 @@ t.test(`CacheableObject validate on update`, t => {
   obj.date = date;
   t.equal(obj.date, date);
 
-  try {
-    obj.date = `TWELFTH PERIGEE'S EVE`;
-  } catch (err) {
-    thrownError = err;
-  }
+  t.throws(
+    () => { obj.date = `TWELFTH PERIGEE'S EVE`; },
+    {cause: TypeError});
 
-  t.equal(thrownError?.constructor, TypeError);
   t.equal(obj.date, date);
 });
 
@@ -244,8 +238,8 @@ t.test(`CacheableObject default property throws if invalid`, t => {
 
   let thrownError;
 
-  try {
-    newCacheableObject({
+  t.throws(
+    () => newCacheableObject({
       string: {
         flags: {
           update: true
@@ -261,10 +255,6 @@ t.test(`CacheableObject default property throws if invalid`, t => {
           }
         }
       }
-    });
-  } catch (err) {
-    thrownError = err;
-  }
-
-  t.equal(thrownError, mockError);
+    }),
+    {cause: mockError});
 });

--- a/test/unit/data/things/track.js
+++ b/test/unit/data/things/track.js
@@ -208,7 +208,8 @@ t.test(`Track.color`, t => {
   t.equal(track.color, '#123456',
     `color #4: is own value`);
 
-  t.throws(() => { track.color = '#aeiouw'; }, TypeError,
+  t.throws(() => { track.color = '#aeiouw'; },
+    {cause: TypeError},
     `color #5: must be set to valid color`);
 });
 


### PR DESCRIPTION
Development:

* Resolves #300.
* Closes #50.

Wow! Cool!

The major change in this pull request is that if individual fields fail to apply (for any of a variety of reasons), the whole containing document will *not* be excluded from output data for further processing / site generation ("skipped") - only the offending fields. This makes for dramatically cleaner error output, because there's no more hard-to-understand collateral damage from outright skipping wiki objects.

The meat of that change is in `makeProcessDocument`, but because it now returns a (possibly empty) aggregate *and* a (possibly partial) thing, we also had to update the data steps processing code for each of the `documentModes`. Most notably, `documentMode.headerAndEntries` (used for albums and tracks) no longer skips all the *entry* documents if anything in the *header* document fails, which keeps a whole heckin' album from going poof. That's only possible because we're still retaining a presumably *mostly* complete header document - entries are expected not to be self-sufficient without the header, which is why they were previously getting skipped outright. Wins all around!

This PR also does a bunch to tidy up individual spot error reporting, which should all come together to leave errors quite a bit cleaner and clearer.