### PR TITLE
Separate media (thumbnail) cache!

### DIFF
--- a/src/content/dependencies/image.js
+++ b/src/content/dependencies/image.js
@@ -77,6 +77,11 @@ export default {
       originalSrc = '';
     }
 
+    // TODO: This feels janky. It's necessary to deal with static content that
+    // includes strings like <img src="media/misc/foo.png">, but processing the
+    // src string directly when a parts-formed path *is* available seems wrong.
+    // It should be possible to do urls.from(slots.path[0]).to(...slots.path),
+    // for example, but will require reworking the control flow here a little.
     let mediaSrc = null;
     if (originalSrc.startsWith(to('media.root'))) {
       mediaSrc =
@@ -160,7 +165,7 @@ export default {
       // which is the HTML output-appropriate path including `../../` or
       // another alternate base path.
       const selectedSize = getThumbnailEqualOrSmaller(slots.thumb, mediaSrc);
-      thumbSrc = originalSrc.replace(/\.(jpg|png)$/, `.${selectedSize}.jpg`);
+      thumbSrc = to('thumb.path', mediaSrc.replace(/\.(png|jpg)$/, `.${selectedSize}.jpg`));
 
       const dimensions = getDimensionsOfImagePath(mediaSrc);
       availableThumbs = getThumbnailsAvailableForDimensions(dimensions);

--- a/src/static/client2.js
+++ b/src/static/client2.js
@@ -954,10 +954,14 @@ function handleImageLinkClicked(evt) {
   const thumbImage = document.getElementById('image-overlay-image-thumb');
 
   const {href: originalSrc} = evt.target.closest('a');
-  const {dataset: {
-    originalSize: originalFileSize,
-    thumbs: availableThumbList,
-  }} = evt.target.closest('a').querySelector('img');
+
+  const {
+    src: embeddedSrc,
+    dataset: {
+      originalSize: originalFileSize,
+      thumbs: availableThumbList,
+    },
+  } = evt.target.closest('a').querySelector('img');
 
   updateFileSizeInformation(originalFileSize);
 
@@ -967,8 +971,8 @@ function handleImageLinkClicked(evt) {
   if (availableThumbList) {
     const {thumb: mainThumb, length: mainLength} = getPreferredThumbSize(availableThumbList);
     const {thumb: smallThumb, length: smallLength} = getSmallestThumbSize(availableThumbList);
-    mainSrc = originalSrc.replace(/\.(jpg|png)$/, `.${mainThumb}.jpg`);
-    thumbSrc = originalSrc.replace(/\.(jpg|png)$/, `.${smallThumb}.jpg`);
+    mainSrc = embeddedSrc.replace(/\.[a-z]+\.(jpg|png)$/, `.${mainThumb}.jpg`);
+    thumbSrc = embeddedSrc.replace(/\.[a-z]+\.(jpg|png)$/, `.${smallThumb}.jpg`);
     // Show the thumbnail size on each <img> element's data attributes.
     // Y'know, just for debugging convenience.
     mainImage.dataset.displayingThumb = `${mainThumb}:${mainLength}`;

--- a/src/upd8.js
+++ b/src/upd8.js
@@ -61,7 +61,6 @@ import {
 
 import genThumbs, {
   CACHE_FILE as thumbsCacheFile,
-  clearThumbs,
   defaultMagickThreads,
   determineMediaCachePath,
   isThumb,

--- a/src/url-spec.js
+++ b/src/url-spec.js
@@ -79,10 +79,23 @@ const urlSpec = {
       albumCover: 'album-art/<>/cover.<>',
       albumWallpaper: 'album-art/<>/bg.<>',
       albumBanner: 'album-art/<>/banner.<>',
+
       trackCover: 'album-art/<>/<>.<>',
+
       artistAvatar: 'artist-avatar/<>.<>',
+
       flashArt: 'flash-art/<>.<>',
+
       albumAdditionalFile: 'album-additional/<>/<>',
+    },
+  },
+
+  thumb: {
+    prefix: 'thumb/',
+
+    paths: {
+      root: '',
+      path: '<>',
     },
   },
 };

--- a/src/write/build-modes/live-dev-server.js
+++ b/src/write/build-modes/live-dev-server.js
@@ -51,6 +51,7 @@ export async function go({
   cliOptions,
   _dataPath,
   mediaPath,
+  mediaCachePath,
 
   defaultLanguage,
   languages,
@@ -171,7 +172,7 @@ export async function go({
     const {
       area: localFileArea,
       path: localFilePath
-    } = pathname.match(/^\/(?<area>static|util|media)\/(?<path>.*)/)?.groups ?? {};
+    } = pathname.match(/^\/(?<area>static|util|media|thumb)\/(?<path>.*)/)?.groups ?? {};
 
     if (localFileArea) {
       // Not security tested, man, this is a dev server!!
@@ -182,6 +183,8 @@ export async function go({
         localDirectory = path.join(srcRootPath, localFileArea);
       } else if (localFileArea === 'media') {
         localDirectory = mediaPath;
+      } else if (localFileArea === 'thumb') {
+        localDirectory = mediaCachePath;
       }
 
       let filePath;

--- a/src/write/build-modes/static-build.js
+++ b/src/write/build-modes/static-build.js
@@ -84,6 +84,7 @@ export async function go({
   cliOptions,
   _dataPath,
   mediaPath,
+  mediaCachePath,
   queueSize,
 
   defaultLanguage,
@@ -133,6 +134,7 @@ export async function go({
   await writeSymlinks({
     srcRootPath,
     mediaPath,
+    mediaCachePath,
     outputPath,
     urls,
   });
@@ -414,6 +416,7 @@ async function writePage({
 function writeSymlinks({
   srcRootPath,
   mediaPath,
+  mediaCachePath,
   outputPath,
   urls,
 }) {
@@ -421,6 +424,7 @@ function writeSymlinks({
     link(path.join(srcRootPath, 'util'), 'shared.utilityRoot'),
     link(path.join(srcRootPath, 'static'), 'shared.staticRoot'),
     link(mediaPath, 'media.root'),
+    link(mediaCachePath, 'thumb.root'),
   ]);
 
   async function link(directory, urlKey) {


### PR DESCRIPTION
This PR changes the way `gen-thumbs.js` works to output thumbnails into a separate directory (by default `mediaPath + "-cache"`), organized with the same subtree as `mediaPath`, and updates a variety of systems to work with this.

This serves two ends, both of which will come from (automatically) mirroring the `hsmusic-media` repository into a cache repository:

* Most workflows built with GitHub Actions won't have to worry about regenerating *all* the thumbnails for every run (i.e. change to data); in practice, this takes around 30-35 minutes, whereas fetching a repository about the size of the cache will take around 2-4 minutes. They'll still need to generate thumbnails as introduced in a corresponding media PR, but they'll be able to work off of the existing "canonical" cache repository, saving a lot of time (and headache over, say, gigantic-file-artifacts - those turned out to be unviable). See discussion of this general idea [in #infra-sysadmin](https://discord.com/channels/749042497610842152/1142813759560241194/1167879106856226937).
* For folk just getting started with working on the wiki locally, it'll be possible to download a copy of the canonical cache (once it's up and auto-generating), rather than generating all those thumbnails on their own device. This saves a lot of duplicate compute work overall, and will likely save setup time too, if downloading a ~3GB zip from GitHub takes less than however long thumbnails generate on a given personal machine.
* This also makes the `media` folder generally easier to work with, particularly when you're using a graphical file browser (Finder, etc). Having only the originals in the `media` directory means you're looking at pretty much only what git has tracked, and don't have to scroll through a ton of smaller renders of images to get a clear overview, or perform awkward filters to copy and share only the originals.

Implementation and feature details:

* The `--clear-thumbs` option is removed and replaced with a new `--migrate-thumbs` option, which transfers all existing generated thumbnails (and the `thumbnail-cache.json` file) into the media cache path (inferred or manually specified - see below). This *isn't* necessary to run right away, as the wiki doesn't have any issues with `mediaCachePath` and `mediaPath` one and the same. But it is a quick way to get the advantages and organization of a separate cache directory, rather than running `--clear-thumbs` and then regenerating everything in the new directory.
* A new `--media-cache-path` option is added (and corresponding environment variable `HSMUSIC_MEDIA_CACHE`), but it's not usually necessary to use this. When *not* specified, a new utility `determineMediaCachePath` will attempt to infer the correct path - reusing `mediaPath` if it already includes `thumbnail-cache.json`, or appending "-cache" and checking that inferred path, using it if it doesn't exist or if it includes `thumbnail-cache.json`. (If it exists but *doesn't* include `thumbnail-cache.json`, it won't return any path and will display a related message, and you'll have to investigate this manually. If you don't mind overwriting the contents, manually specifying `--media-cache-path` will override / skip past this error.)
* `url-spec.js` gets a new `thumb` group key (ala `localized`, `media`, `shared`). The default prefix for this is `thumb/`. The initial implementation had `media`-corresponding paths (like `albumCover` or `flashArt`) grouped here, but we went away from that since it was unnecessary complexity and path duplication - the `thumb` tree always has a corresponding tree to `media`. So only `thumb.root` and `thumb.path` are used (the former for linking as in `static-build`, latter for the `image` content function).
* The build modes, `static-build` and `live-dev-server`, are updated. Nothing special here. `static-build` works nicely, creating a symlink from `thumb.root` to `mediaCachePath` (like it does for `media.root` to `mediaPath`). `live-dev-server` is more hard-coded re: URL spec, but it's already been so for the other symlinks it simulates, so this isn't any worse than before.
* The content function `image` is updated. There was some difficulty here, mainly re: processing proper URL subkeys under `thumb.`, which turned out to be fruitless - good in principle, but commentary / static content may refer to arbitrary `media/foo/bar/baz/thing.png` type paths, and accommodating that gives us a free way to process `slots.path`-provided paths, too - even if it's a bit clunky in the first place.
* Client-side code is updated. This actually avoids introducing any kludges *or* discompatibilities of its own - the displayed, larger thumbnail is based on the source of the content-embedded image, while the `originalSrc` variable is left as the href of the image link, as it's supposed to be. (In the overlay, by definition, "view original" links to the same URL as the image link.)

All the work was done and mostly finalized before committing, but the commits below are more or less split up to divide the effort into discrete chunks. They basically match the order the code was worked on.