### PR TITLE
Refine and optimize wikiData property

### DIFF
--- a/src/data/composite/wiki-properties/wikiData.js
+++ b/src/data/composite/wiki-properties/wikiData.js
@@ -1,17 +1,20 @@
 // General purpose wiki data constructor, for properties like artistData,
 // trackData, etc.
 
-import {validateArrayItems, validateInstanceOf} from '#validators';
+import {validateWikiData} from '#validators';
+
+// TODO: Kludge.
+import Thing from '../../things/thing.js';
 
 // TODO: Not templateCompositeFrom.
 
-// TODO: This should validate with validateWikiData.
-
 export default function(thingClass) {
+  const referenceType = thingClass[Thing.referenceType];
+
   return {
     flags: {update: true},
     update: {
-      validate: validateArrayItems(validateInstanceOf(thingClass)),
+      validate: validateWikiData({referenceType}),
     },
   };
 }

--- a/src/data/composite/wiki-properties/wikiData.js
+++ b/src/data/composite/wiki-properties/wikiData.js
@@ -1,20 +1,29 @@
 // General purpose wiki data constructor, for properties like artistData,
 // trackData, etc.
 
+import {input, templateCompositeFrom} from '#composite';
 import {validateWikiData} from '#validators';
+
+import {inputThingClass} from '#composite/wiki-data';
 
 // TODO: Kludge.
 import Thing from '../../things/thing.js';
 
-// TODO: Not templateCompositeFrom.
+export default templateCompositeFrom({
+  annotation: `wikiData`,
 
-export default function(thingClass) {
-  const referenceType = thingClass[Thing.referenceType];
+  compose: false,
 
-  return {
-    flags: {update: true},
-    update: {
-      validate: validateWikiData({referenceType}),
-    },
-  };
-}
+  inputs: {
+    class: inputThingClass(),
+  },
+
+  update: ({
+    [input.staticValue('class')]: thingClass,
+  }) => {
+    const referenceType = thingClass[Thing.referenceType];
+    return {validate: validateWikiData({referenceType})};
+  },
+
+  steps: () => [],
+});

--- a/src/data/things/album.js
+++ b/src/data/things/album.js
@@ -121,10 +121,21 @@ export class Album extends Thing {
 
     // Update only
 
-    artistData: wikiData(Artist),
-    artTagData: wikiData(ArtTag),
-    groupData: wikiData(Group),
-    trackData: wikiData(Track),
+    artistData: wikiData({
+      class: input.value(Artist),
+    }),
+
+    artTagData: wikiData({
+      class: input.value(ArtTag),
+    }),
+
+    groupData: wikiData({
+      class: input.value(Group),
+    }),
+
+    trackData: wikiData({
+      class: input.value(Track),
+    }),
 
     // Expose only
 

--- a/src/data/things/art-tag.js
+++ b/src/data/things/art-tag.js
@@ -40,8 +40,13 @@ export class ArtTag extends Thing {
 
     // Update only
 
-    albumData: wikiData(Album),
-    trackData: wikiData(Track),
+    albumData: wikiData({
+      class: input.value(Album),
+    }),
+
+    trackData: wikiData({
+      class: input.value(Track),
+    }),
 
     // Expose only
 

--- a/src/data/things/artist.js
+++ b/src/data/things/artist.js
@@ -45,10 +45,21 @@ export class Artist extends Thing {
 
     // Update only
 
-    albumData: wikiData(Album),
-    artistData: wikiData(Artist),
-    flashData: wikiData(Flash),
-    trackData: wikiData(Track),
+    albumData: wikiData({
+      class: input.value(Album),
+    }),
+
+    artistData: wikiData({
+      class: input.value(Artist),
+    }),
+
+    flashData: wikiData({
+      class: input.value(Flash),
+    }),
+
+    trackData: wikiData({
+      class: input.value(Track),
+    }),
 
     // Expose only
 

--- a/src/data/things/composite.js
+++ b/src/data/things/composite.js
@@ -637,6 +637,10 @@ export function compositeFrom(description) {
 
   const compositionNests = description.compose ?? true;
 
+  if (compositionNests && empty(steps)) {
+    aggregate.push(new TypeError(`Expected at least one step`));
+  }
+
   // Steps default to exposing if using a shorthand syntax where flags aren't
   // specified at all.
   const stepsExpose =

--- a/src/data/things/composite.js
+++ b/src/data/things/composite.js
@@ -802,8 +802,8 @@ export function compositeFrom(description) {
     });
   }
 
-  if (!compositionNests && !anyStepsCompute && !anyStepsTransform) {
-    aggregate.push(new TypeError(`Expected at least one step to compute or transform`));
+  if (!compositionNests && !compositionUpdates && !anyStepsCompute) {
+    aggregate.push(new TypeError(`Expected at least one step to compute`));
   }
 
   aggregate.close();
@@ -1241,8 +1241,10 @@ export function compositeFrom(description) {
         expose.cache = base.cacheComposition;
       }
     } else if (compositionUpdates) {
-      expose.transform = (value, dependencies) =>
-        _wrapper(value, null, dependencies);
+      if (!empty(steps)) {
+        expose.transform = (value, dependencies) =>
+          _wrapper(value, null, dependencies);
+      }
     } else {
       expose.compute = (dependencies) =>
         _wrapper(noTransformSymbol, null, dependencies);

--- a/src/data/things/flash.js
+++ b/src/data/things/flash.js
@@ -95,9 +95,17 @@ export class Flash extends Thing {
 
     // Update only
 
-    artistData: wikiData(Artist),
-    trackData: wikiData(Track),
-    flashActData: wikiData(FlashAct),
+    artistData: wikiData({
+      class: input.value(Artist),
+    }),
+
+    trackData: wikiData({
+      class: input.value(Track),
+    }),
+
+    flashActData: wikiData({
+      class: input.value(FlashAct),
+    }),
 
     // Expose only
 
@@ -159,6 +167,8 @@ export class FlashAct extends Thing {
 
     // Update only
 
-    flashData: wikiData(Flash),
+    flashData: wikiData({
+      class: input.value(Flash),
+    }),
   })
 }

--- a/src/data/things/group.js
+++ b/src/data/things/group.js
@@ -34,8 +34,13 @@ export class Group extends Thing {
 
     // Update only
 
-    albumData: wikiData(Album),
-    groupCategoryData: wikiData(GroupCategory),
+    albumData: wikiData({
+      class: input.value(Album),
+    }),
+
+    groupCategoryData: wikiData({
+      class: input.value(GroupCategory),
+    }),
 
     // Expose only
 
@@ -102,6 +107,8 @@ export class GroupCategory extends Thing {
 
     // Update only
 
-    groupData: wikiData(Group),
+    groupData: wikiData({
+      class: input.value(Group),
+    }),
   });
 }

--- a/src/data/things/group.js
+++ b/src/data/things/group.js
@@ -83,12 +83,15 @@ export class Group extends Thing {
 }
 
 export class GroupCategory extends Thing {
+  static [Thing.referenceType] = 'group-category';
   static [Thing.friendlyName] = `Group Category`;
 
   static [Thing.getPropertyDescriptors] = ({Group}) => ({
     // Update & expose
 
     name: name('Unnamed Group Category'),
+    directory: directory(),
+
     color: color(),
 
     groups: referenceList({

--- a/src/data/things/homepage-layout.js
+++ b/src/data/things/homepage-layout.js
@@ -70,11 +70,17 @@ export class HomepageLayoutRow extends Thing {
 
     // Update only
 
-    // These aren't necessarily used by every HomepageLayoutRow subclass, but
-    // for convenience of providing this data, every row accepts all wiki data
-    // arrays depended upon by any subclass's behavior.
-    albumData: wikiData(Album),
-    groupData: wikiData(Group),
+    // These wiki data arrays aren't necessarily used by every subclass, but
+    // to the convenience of providing these, the superclass accepts all wiki
+    // data arrays depended upon by any subclass.
+
+    albumData: wikiData({
+      class: input.value(Album),
+    }),
+
+    groupData: wikiData({
+      class: input.value(Group),
+    }),
   });
 }
 

--- a/src/data/things/track.js
+++ b/src/data/things/track.js
@@ -256,11 +256,25 @@ export class Track extends Thing {
 
     // Update only
 
-    albumData: wikiData(Album),
-    artistData: wikiData(Artist),
-    artTagData: wikiData(ArtTag),
-    flashData: wikiData(Flash),
-    trackData: wikiData(Track),
+    albumData: wikiData({
+      class: input.value(Album),
+    }),
+
+    artistData: wikiData({
+      class: input.value(Artist),
+    }),
+
+    artTagData: wikiData({
+      class: input.value(ArtTag),
+    }),
+
+    flashData: wikiData({
+      class: input.value(Flash),
+    }),
+
+    trackData: wikiData({
+      class: input.value(Track),
+    }),
 
     // Expose only
 

--- a/src/data/things/validators.js
+++ b/src/data/things/validators.js
@@ -484,8 +484,10 @@ export function validateWikiData({
         throw new TypeError(`Expected array of unmixed reference types, got multiple: ${types()}`);
       }
 
-      if (referenceType && !allRefTypes.has(referenceType)) {
-        throw new TypeError(`Expected array of ${referenceType}, got array of ${allRefTypes[0]}`)
+      const onlyRefType = Array.from(allRefTypes)[0];
+
+      if (referenceType && onlyRefType !== referenceType) {
+        throw new TypeError(`Expected array of ${referenceType}, got array of ${onlyRefType}`)
       }
 
       OK = true; return true;

--- a/src/data/things/wiki-info.js
+++ b/src/data/things/wiki-info.js
@@ -64,6 +64,8 @@ export class WikiInfo extends Thing {
 
     // Update only
 
-    groupData: wikiData(Group),
+    groupData: wikiData({
+      class: input.value(Group),
+    }),
   });
 }


### PR DESCRIPTION
This tidies up the `wikiData()` utility (ex. `trackData: wikiData(Track)`) in a few different ways:

* It's a composition now, so inputs are provided the same way as usual: `({class: input.value(Track)})` instead of `(Track)`.
* The class input is now (statically) validated and makes use of the existing `inputThingClass()` utility.
* Validation is done with the existing (but relatively new) `validateWikiData` utility.

The last part is the most important change, because it dramatically improves the performance of setting properties based on `wikiData` (namely the `linkWikiDataArrays` function which is required for *any* operations with data, including all builds, the REPL, and tests — these changes save about 3.5 seconds during *every* build, as a result).

`validateWikiData` provides more comprehensive validation and smarter error reporting, and does *not* depend on `validateInstanceOf` (or any instanceof checks). It early-exits for mixed things-and-not-things (new to this PR), and operates on a set of passed reference types, invalidating for mixed reference types first, then finally checking if the single reference type in the list matches what's expected. (In principle it's possible to early-exit for mixed reference types, but the passing case involves iterating over all objects anyway, so it wasn't a priority *above* having the full list of reference types for use in the error messaging.)

This PR makes two related changes:

* Compositions properly support an empty `steps` list for compositions which update - in this case, the constructed descriptor's `expose.transform` won't be set at all, meaning the property's update value is returned as-is.
  * This is only currently intended for compositions which aren't themselves compositional steps; compositions which are will always error if the `steps` list is empty. This can be revisited later, but should be unit tested.
* Since `wikiData` explicitly depends upon reference types, group categories now get the reference type "group-category", as well as a standard `directory` property. These aren't used for any other data processing or content generation (yet).
