### PR TITLE
Various step summary improvements

### DIFF
--- a/src/upd8.js
+++ b/src/upd8.js
@@ -488,6 +488,53 @@ async function main() {
     });
   }
 
+  // Prepare not-applicable steps before anything else.
+
+  if (skipThumbs) {
+    Object.assign(stepStatusSummary.generateThumbnails, {
+      status: STATUS_NOT_APPLICABLE,
+      annotation: `provided --skip-thumbs`,
+    });
+  } else {
+    Object.assign(stepStatusSummary.loadThumbnailCache, {
+      status: STATUS_NOT_APPLICABLE,
+      annotation: `using cache from thumbnail generation`,
+    });
+  }
+
+  if (!migrateThumbs) {
+    Object.assign(stepStatusSummary.migrateThumbnails, {
+      status: STATUS_NOT_APPLICABLE,
+      annotation: `--migrate-thumbs not provided`,
+    });
+  }
+
+  if (!precacheData) {
+    Object.assign(stepStatusSummary.precacheData, {
+      status: STATUS_NOT_APPLICABLE,
+      annotation: `--precache-data not provided`,
+    });
+  }
+
+  if (!langPath) {
+    Object.assign(stepStatusSummary.loadLanguageFiles, {
+      status: STATUS_NOT_APPLICABLE,
+      annotation: `neither --lang-path nor HSMUSIC_LANG provided`,
+    });
+  }
+
+  if (noBuild) {
+    Object.assign(stepStatusSummary.performBuild, {
+      status: STATUS_NOT_APPLICABLE,
+      annotation: `--no-build provided`,
+    });
+  }
+
+  if (skipThumbs && thumbsOnly) {
+    logInfo`Well, you've put yourself rather between a roc and a hard place, hmmmm?`;
+    return false;
+  }
+
   stepStatusSummary.determineMediaCachePath.status = STATUS_STARTED_NOT_DONE;
 
   const {mediaCachePath, annotation: mediaCachePathAnnotation} =
@@ -557,11 +604,6 @@ async function main() {
     logInfo`Good to go! Run hsmusic again without ${'--migrate-thumbs'} to start`;
     logInfo`using the migrated media cache.`;
     return true;
-  } else {
-    Object.assign(stepStatusSummary.migrateThumbnails, {
-      status: STATUS_NOT_APPLICABLE,
-      annotation: `--migrate-thumbs not provided`,
-    });
   }
 
   const niceShowAggregate = (error, ...opts) => {
@@ -572,19 +614,9 @@ async function main() {
     });
   };
 
-  if (skipThumbs && thumbsOnly) {
-    logInfo`Well, you've put yourself rather between a roc and a hard place, hmmmm?`;
-    return false;
-  }
-
   let thumbsCache;
 
   if (skipThumbs) {
-    Object.assign(stepStatusSummary.generateThumbnails, {
-      status: STATUS_NOT_APPLICABLE,
-      annotation: `provided --skip-thumbs`,
-    });
-
     stepStatusSummary.loadThumbnailCache.status = STATUS_STARTED_NOT_DONE;
 
     const thumbsCachePath = path.join(mediaCachePath, thumbsCacheFile);
@@ -627,11 +659,6 @@ async function main() {
 
     logInfo`Skipping thumbnail generation.`;
   } else {
-    Object.assign(stepStatusSummary.loadThumbnailCache, {
-      status: STATUS_NOT_APPLICABLE,
-      annotation: `using cache from thumbnail generation`,
-    });
-
     stepStatusSummary.generateThumbnails.status = STATUS_STARTED_NOT_DONE;
 
     logInfo`Begin thumbnail generation... -----+`;
@@ -852,19 +879,9 @@ async function main() {
       .map(thing => () => CacheableObject.cacheAllExposedProperties(thing)));
 
     stepStatusSummary.precacheData.status = STATUS_DONE_CLEAN;
-  } else {
-    Object.assign(stepStatusSummary.precacheData, {
-      status: STATUS_NOT_APPLICABLE,
-      annotation: `--precache-data not provided`,
-    });
   }
 
   if (noBuild) {
-    Object.assign(stepStatusSummary.performBuild, {
-      status: STATUS_NOT_APPLICABLE,
-      annotation: `--no-build provided`,
-    });
-
     displayCompositeCacheAnalysis();
 
     if (precacheData) {
@@ -931,11 +948,6 @@ async function main() {
     stepStatusSummary.loadLanguageFiles.status = STATUS_DONE_CLEAN;
   } else {
     languages = {};
-
-    Object.assign(stepStatusSummary.loadLanguageFiles, {
-      status: STATUS_NOT_APPLICABLE,
-      annotation: `neither --lang-path nor HSMUSIC_LANG provided`,
-    });
   }
 
   stepStatusSummary.initializeDefaultLanguage.status = STATUS_STARTED_NOT_DONE;

--- a/src/upd8.js
+++ b/src/upd8.js
@@ -1428,6 +1428,9 @@ if (true || isMain(import.meta.url) || path.basename(process.argv[1]) === 'hsmus
     } catch (error) {
       if (error instanceof AggregateError) {
         showAggregate(error);
+      } else if (error.cause) {
+        console.error(error);
+        showAggregate(error);
       } else {
         console.error(error);
       }

--- a/src/write/build-modes/live-dev-server.js
+++ b/src/write/build-modes/live-dev-server.js
@@ -44,6 +44,11 @@ export function getCLIOptions() {
       help: `Enables outputting [200] and [404] responses in the server log, which are suppressed by default`,
       type: 'flag',
     },
+
+    'skip-serving': {
+      help: `Causes the build to exit when it would start serving over HTTP instead\n\nMainly useful for testing performance`,
+      type: 'flag',
+    },
   };
 }
 
@@ -78,6 +83,7 @@ export async function go({
   const host = cliOptions['host'] ?? defaultHost;
   const port = parseInt(cliOptions['port'] ?? defaultPort);
   const loudResponses = cliOptions['loud-responses'] ?? false;
+  const skipServing = cliOptions['skip-serving'] ?? false;
 
   const contentDependenciesWatcher = await watchContentDependencies();
   const {contentDependencies} = contentDependenciesWatcher;
@@ -396,10 +402,14 @@ export async function go({
     }
   });
 
-  server.listen(port, host);
+  if (skipServing) {
+    logInfo`Ready to serve! But --skip-serving was passed, so all done.`;
+  } else {
+    server.listen(port, host);
 
-  // Just keep going... forever!!!
-  await new Promise(() => {});
+    // Just keep going... forever!!!
+    await new Promise(() => {});
+  }
 
   return true;
 }


### PR DESCRIPTION
This PR makes a bunch of improvements, primarily in `upd8.js`, to the "step summary" system. While that system was originally created to make outputs for GitHub Actions clearer and easier to work with (existing with code 1 if any step has warnings, for example), it also turns out to be a natural fit for tracking which parts of the build process take the most time. This PR generally focuses on helping its capability to that end.

* All "not applicable" checks are moved to the very start of upd8 evaluation - so if some step has a fatal error, the summary won't inappropriately display certain steps as "not yet started" (seeing as it was never going to evaluate them in the first place).
* The step summary now shows the time that each step takes, as well as the total build duration. Durations less than 0.1 second are treated as "instant" here.
* A new `--skip-reference-validation` option is added, which does what it says on the tin. In practice, this doesn't actually result in better performance, so it may eventually be removed... but if you like to live dangerously (and get a stern warning for it), then this is the option for you.
* A new `--skip-serving` option is added when using the `--live-dev-server` build mode - this causes the build mode to exit when it would start serving instead. It's useful for performance testing, and not much more.
* A new `--precache-mode` option is added; its three possible values are `all` (née `--precache-data`, which is removed), `common` (completely new, and the default), and `none` (previous default behavior). `common` precaches only a certain subset of data - only properties which are used for sorting and computing page paths, which are hard-coded, sorry! It's intended to help delineate the performance costs of "getting stuff that's gonna need to be cached eventually anyway" and "actually sorting data / computing page paths". (For sorting, most of the costs turn out to be in the former.)

Apart from the new `--precache-mode common` (default) option, this PR *doesn't* actually change or introduce new data processing, so performance is about the same before and after. What it does is provide a neat set of tooling that make improving performance easier!