### PR TITLE
Fast & tidy find.track / withAlwaysReferenceByDirectory implementation

### DIFF
--- a/src/data/composite/things/track/withAlwaysReferenceByDirectory.js
+++ b/src/data/composite/things/track/withAlwaysReferenceByDirectory.js
@@ -53,19 +53,28 @@ export default templateCompositeFrom({
     // logic on a completely unrelated context.
     {
       dependencies: [input.myself(), 'trackData', 'originalReleaseTrack'],
-      compute: (continuation, {
+      compute(continuation, {
         [input.myself()]: thisTrack,
         ['trackData']: trackData,
         ['originalReleaseTrack']: ref,
-      }) => continuation({
-        ['#originalRelease']:
-          (ref.startsWith('track:')
-            ? trackData.find(track => track.directory === ref.slice('track:'.length))
-            : trackData.find(track =>
-                track !== thisTrack &&
-                !CacheableObject.getUpdateValue(track, 'originalReleaseTrack') &&
-                track.name.toLowerCase() === ref.toLowerCase())),
-      })
+      }) {
+        let originalRelease;
+
+        if (ref.startsWith('track:')) {
+          const refDirectory = ref.slice('track:'.length);
+          originalRelease =
+            trackData.find(track => track.directory === refDirectory);
+        } else {
+          const refName = ref.toLowerCase();
+          originalRelease =
+            trackData.find(track =>
+              track.name.toLowerCase() === refName &&
+              track !== thisTrack &&
+              !CacheableObject.getUpdateValue(track, 'originalReleaseTrack'));
+        }
+
+        return continuation({['#originalRelease']: originalRelease});
+      },
     },
 
     exitWithoutDependency({

--- a/src/data/composite/things/track/withAlwaysReferenceByDirectory.js
+++ b/src/data/composite/things/track/withAlwaysReferenceByDirectory.js
@@ -2,22 +2,15 @@
 // just to the track's name, which means you don't have to always reference
 // some *other* (much more commonly referenced) track by directory instead
 // of more naturally by name.
-//
-// See the implementation for an important caveat about matching the original
-// track against other tracks, which uses a custom implementation pulling (and
-// duplicating) details from #find instead of using withOriginalRelease and the
-// usual withResolvedReference / find.track() utilities.
-//
 
 import {input, templateCompositeFrom} from '#composite';
+import find from '#find';
 import {isBoolean} from '#validators';
 
 import {exitWithoutDependency, exposeUpdateValueOrContinue}
   from '#composite/control-flow';
 import {withPropertyFromObject} from '#composite/data';
-
-// TODO: Kludge. (The usage of this, not so much the import.)
-import CacheableObject from '../../../things/cacheable-object.js';
+import {withResolvedReference} from '#composite/wiki-data';
 
 export default templateCompositeFrom({
   annotation: `withAlwaysReferenceByDirectory`,
@@ -44,38 +37,23 @@ export default templateCompositeFrom({
       value: input.value(false),
     }),
 
-    // "Slow" / uncached, manual search from trackData (with this track
-    // excluded). Otherwise there end up being pretty bad recursion issues
-    // (track1.alwaysReferencedByDirectory depends on searching through data
-    // including track2, which depends on evaluating track2.alwaysReferenced-
-    // ByDirectory, which depends on searcing through data including track1...)
-    // That said, this is 100% a kludge, since it involves duplicating find
-    // logic on a completely unrelated context.
-    {
-      dependencies: [input.myself(), 'trackData', 'originalReleaseTrack'],
-      compute(continuation, {
-        [input.myself()]: thisTrack,
-        ['trackData']: trackData,
-        ['originalReleaseTrack']: ref,
-      }) {
-        let originalRelease;
-
-        if (ref.startsWith('track:')) {
-          const refDirectory = ref.slice('track:'.length);
-          originalRelease =
-            trackData.find(track => track.directory === refDirectory);
-        } else {
-          const refName = ref.toLowerCase();
-          originalRelease =
-            trackData.find(track =>
-              track.name.toLowerCase() === refName &&
-              track !== thisTrack &&
-              !CacheableObject.getUpdateValue(track, 'originalReleaseTrack'));
-        }
-
-        return continuation({['#originalRelease']: originalRelease});
-      },
-    },
+    // It's necessary to use the custom trackOriginalReleasesOnly find function
+    // here, so as to avoid recursion issues - the find.track() function depends
+    // on accessing each track's alwaysReferenceByDirectory, which means it'll
+    // hit *this track* - and thus this step - and end up recursing infinitely.
+    // By definition, find.trackOriginalReleasesOnly excludes tracks which have
+    // an originalReleaseTrack update value set, which means even though it does
+    // still access each of tracks' `alwaysReferenceByDirectory` property, it
+    // won't access that of *this* track - it will never proceed past the
+    // `exitWithoutDependency` step directly above, so there's no opportunity
+    // for recursion.
+    withResolvedReference({
+      ref: 'originalReleaseTrack',
+      data: 'trackData',
+      find: input.value(find.trackOriginalReleasesOnly),
+    }).outputs({
+      '#resolvedReference': '#originalRelease',
+    }),
 
     exitWithoutDependency({
       dependency: '#originalRelease',

--- a/src/find.js
+++ b/src/find.js
@@ -16,6 +16,8 @@ function warnOrThrow(mode, message) {
 }
 
 export function processAllAvailableMatches(data, {
+  include = thing => true,
+
   getMatchableNames = thing =>
     (Object.hasOwn(thing, 'name')
       ? [thing.name]
@@ -26,6 +28,10 @@ export function processAllAvailableMatches(data, {
   const multipleNameMatches = Object.create(null);
 
   for (const thing of data) {
+    if (!include(thing)) continue;
+
+    byDirectory[thing.directory] = thing;
+
     for (const name of getMatchableNames(thing)) {
       if (typeof name !== 'string') {
         logWarn`Unexpected ${typeAppearance(name)} returned in names for ${inspect(thing)}`;
@@ -33,6 +39,7 @@ export function processAllAvailableMatches(data, {
       }
 
       const normalizedName = name.toLowerCase();
+
       if (normalizedName in byName) {
         const alreadyMatchesByName = byName[normalizedName];
         byName[normalizedName] = null;
@@ -45,8 +52,6 @@ export function processAllAvailableMatches(data, {
         byName[normalizedName] = thing;
       }
     }
-
-    byDirectory[thing.directory] = thing;
   }
 
   return {byName, byDirectory, multipleNameMatches};
@@ -55,6 +60,7 @@ export function processAllAvailableMatches(data, {
 function findHelper({
   referenceTypes,
 
+  include = undefined,
   getMatchableNames = undefined,
 }) {
   const keyRefRegex =
@@ -84,6 +90,7 @@ function findHelper({
     if (!subcache) {
       subcache =
         processAllAvailableMatches(data, {
+          include,
           getMatchableNames,
         });
 

--- a/src/find.js
+++ b/src/find.js
@@ -2,6 +2,7 @@ import {inspect} from 'node:util';
 
 import {colors, logWarn} from '#cli';
 import {typeAppearance} from '#sugar';
+import {CacheableObject} from '#things';
 
 function warnOrThrow(mode, message) {
   if (mode === 'error') {
@@ -185,6 +186,22 @@ const find = {
         ? []
         : [track.name]),
   }),
+
+  trackOriginalReleasesOnly: findHelper({
+    referenceTypes: ['track'],
+
+    include: track =>
+      !CacheableObject.getUpdateValue(track, 'originalReleaseTrack'),
+
+    // It's still necessary to check alwaysReferenceByDirectory here, since it
+    // may be set manually (with the `Always Reference By Directory` field), and
+    // these shouldn't be matched by name (as per usual). See the definition for
+    // that property for more information.
+    getMatchableNames: track =>
+      (track.alwaysReferenceByDirectory
+        ? []
+        : [track.name]),
+  }),
 };
 
 export default find;
@@ -207,6 +224,7 @@ export function bindFind(wikiData, opts1) {
       newsEntry: 'newsData',
       staticPage: 'staticPageData',
       track: 'trackData',
+      trackOriginalReleasesOnly: 'trackData',
     }).map(([key, value]) => {
       const findFn = find[key];
       const thingData = wikiData[value];


### PR DESCRIPTION
This PR replaces the badly kludged section of `withAlwaysReferenceByDirectory` with a new, cleanly-integrated step using `withResolvedReference` and a new `find.trackOriginalReleasesOnly` utility. That new find function is itself also quite clean, utilizing a simple custom `include` function now supported by `processAllAvailableMatches` (and `findHelper`).

Because `find.trackOriginalReleasesOnly` is cached in the same way as any other find function, this PR makes for a major performance boost to `find.track` (which depends on computing `alwaysReferenceByDirectory` for every track) - compared to before, this saves around 0.6 to 0.8 seconds on every build.

Since `find.trackOriginalReleasesOnly` is only used for `alwaysReferenceByDirectory` and the association between that property and `find.track` isn't very obvious at first glance, this PR also includes new comments to provide implementation context.