### PR TITLE
Add annotateError utilities and tidy related code in yaml.js

### DIFF
--- a/src/util/sugar.js
+++ b/src/util/sugar.js
@@ -637,13 +637,31 @@ export function showAggregate(topError, {
   }
 }
 
+export function annotateError(error, ...callbacks) {
+  for (const callback of callbacks) {
+    error = callback(error) ?? error;
+  }
+
+  return error;
+}
+
+export function annotateErrorWithIndex(error, index) {
+  return Object.assign(error, {
+    [Symbol.for('hsmusic.annotateError.indexInSourceArray')]:
+      index,
+
+    message:
+      `(${colors.yellow(`#${index + 1}`)}) ` +
+      error.message,
+  });
+}
+
 export function decorateErrorWithIndex(fn) {
   return (x, index, array) => {
     try {
       return fn(x, index, array);
     } catch (error) {
-      error.message = `(${colors.yellow(`#${index + 1}`)}) ${error.message}`;
-      error[Symbol.for('hsmusic.decorate.indexInSourceArray')] = index;
+      annotateErrorWithIndex(error, index);
       throw error;
     }
   };
@@ -658,6 +676,18 @@ export function decorateErrorWithCause(fn, cause) {
       throw error;
     }
   };
+}
+
+export function annotateErrorWithFile(error, file) {
+  return Object.assign(error, {
+    [Symbol.for('hsmusic.annotateError.file')]:
+      file,
+
+    message:
+      error.message +
+      (error.message.includes('\n') ? '\n' : ' ') +
+      `(file: ${colors.bright(colors.blue(file))})`,
+  });
 }
 
 export function conditionallySuppressError(conditionFn, callbackFn) {

--- a/test/unit/data/composite/data/withPropertiesFromObject.js
+++ b/test/unit/data/composite/data/withPropertiesFromObject.js
@@ -207,7 +207,7 @@ t.test(`withPropertiesFromObject: validate static inputs`, t => {
       {message: `object: Expected an object, got array`},
       {message: `properties: Errors validating array items`, errors: [
         {
-          [Symbol.for('hsmusic.decorate.indexInSourceArray')]: 2,
+          [Symbol.for('hsmusic.annotateError.indexInSourceArray')]: 2,
           message: /Expected a string, got number/,
         },
       ]},
@@ -240,7 +240,7 @@ t.test(`withPropertiesFromObject: validate dynamic inputs`, t => {
           {message: `object: Expected an object, got array`},
           {message: `properties: Errors validating array items`, errors: [
             {
-              [Symbol.for('hsmusic.decorate.indexInSourceArray')]: 2,
+              [Symbol.for('hsmusic.annotateError.indexInSourceArray')]: 2,
               message: /Expected a string, got number/,
             },
           ]},


### PR DESCRIPTION
This PR makes various changes that try to improve the versatility of error annotation and function-decorating, primarily by adding new underlying (and publicly exposed) utilities.

* Functions like `mapAggregate` can now take the `aggregateOpts` and `fn` arguments in either order, which allows for putting messages and other metadata closer to the top when working with larger functions.
* A new `annotateError` function is added, which applies a series of provided callbacks to the provided error, then returns that error. This is mainly for compositional purposes, providing a common syntax for annotating an error with one or more details. It's also the basis for `decorateErrorWithAnnotation`.
* A new `asyncAdaptiveDecorateError` function (which is also exported as just `decorateError`) creates both a sync and async function. This is directly inspired by [gensync](https://writing.bakkot.com/gensync.html), though the implementation is much simpler - the provided callback will be called if and only if the provided function throws an error, gets provided that thrown error as well as the decorated function's arguments, and returns an error (the original or another built off it), which will thereafter be thrown. With such strict behavior, a simple try/catch/throw (one with `await`, one without) is enough to get both sync and async working. It returns the sync function directly, with the async variant attached (`.async`).
* Existing `decorateError` functions are refactored in terms of `asyncAdaptiveDecorateError` (directly or through `decorateErrorWithAnnotation`), and (in `#sugar`) have async variants conveniently exported, which just extract the `.async` function off the standard call.
* `decorateErrorWithIndex` has its annotating behavior separated out into a new `annotateErrorWithIndex` function, which is more generic, taking just the index rather than index and array.
* `decorateErrorWithFile` (which remains defined in `yaml.js`) similarly gets its annotation separated into `annotateErrorWithFile` - this is exported under `#sugar`. The decorating function remains defined in `yaml.js`, because there's no generalized function-form which a decorator would apply to across the whole codebase; but it does get redefined in terms of `asyncAdaptiveDecorateError` (via `decorateErrorWithAnnotation`), and this comes in handy to get a nicer call under the "Errors loading data files" aggregate.

Apart from the changes to `decorateErrorWithFile`, YAML file-loading and document-parsing is generally tidied. This makes one substantive change to error reporting - the errors "Failed to read data file" and "Failed to parse valid YAML" are contained in the same aggregate ("Errors loading data files") instead of separate aggregates. This mostly makes the code quite a bit simpler (`yamlResults` and `processResults` can be implemented with basically the same form, each with a single map-aggregate, instead of additional piping/in-between steps in a sequence that is serial for each file anyway.