### PR TITLE
Live language strings file reloading!

### DIFF
--- a/src/data/language.js
+++ b/src/data/language.js
@@ -120,6 +120,8 @@ export function watchLanguageFile(file, {
     try {
       properties = await processLanguageSpecFromFile(file);
     } catch (error) {
+      events.emit('error', error);
+
       if (logging) {
         if (successfullyAppliedLanguage) {
           logWarn`Failed to load language ${basename} - using existing version`;
@@ -128,6 +130,7 @@ export function watchLanguageFile(file, {
         }
         showAggregate(error, {showTraces: false});
       }
+
       return;
     }
 

--- a/src/data/language.js
+++ b/src/data/language.js
@@ -5,35 +5,43 @@ import he from 'he';
 
 import T from '#things';
 
-export async function processLanguageFile(file) {
-  const contents = await readFile(file, 'utf-8');
-  const json = JSON.parse(contents);
+export function processLanguageSpec(spec) {
+  const {
+    'meta.languageCode': code,
+    'meta.languageName': name,
 
-  const code = json['meta.languageCode'];
+    'meta.languageIntlCode': intlCode = null,
+    'meta.hidden': hidden = false,
+
+    ...strings
+  } = spec;
+
   if (!code) {
     throw new Error(`Missing language code (file: ${file})`);
   }
-  delete json['meta.languageCode'];
 
-  const intlCode = json['meta.languageIntlCode'] ?? null;
-  delete json['meta.languageIntlCode'];
-
-  const name = json['meta.languageName'];
   if (!name) {
     throw new Error(`Missing language name (${code})`);
   }
-  delete json['meta.languageName'];
-
-  const hidden = json['meta.hidden'] ?? false;
-  delete json['meta.hidden'];
 
   const language = new T.Language();
-  language.code = code;
-  language.intlCode = intlCode;
-  language.name = name;
-  language.hidden = hidden;
-  language.escapeHTML = (string) =>
+
+  Object.assign(language, {
+    code,
+    intlCode,
+    name,
+    hidden,
+    strings,
+  });
+
+  language.escapeHTML = string =>
     he.encode(string, {useNamedReferences: true});
-  language.strings = json;
+
   return language;
+}
+
+export async function processLanguageFile(file) {
+  const contents = await readFile(file, 'utf-8');
+  const spec = JSON.parse(contents);
+  return processLanguageSpec(spec);
 }

--- a/src/data/language.js
+++ b/src/data/language.js
@@ -17,7 +17,7 @@ import {
 
 const {Language} = T;
 
-export function processLanguageSpec(spec, {existingCode = null}) {
+export function processLanguageSpec(spec, {existingCode = null} = {}) {
   const {
     'meta.languageCode': code,
     'meta.languageName': name,

--- a/src/upd8.js
+++ b/src/upd8.js
@@ -290,6 +290,11 @@ async function main() {
       type: 'flag',
     },
 
+    'no-input': {
+      help: `Don't wait on input from stdin - assume the device is headless`,
+      type: 'flag',
+    },
+
     // Want sweet, sweet trace8ack info in aggreg8te error messages? This
     // will print all the juicy details (or at least the first relevant
     // line) right to your output, 8ut also pro8a8ly give you a headache
@@ -456,6 +461,7 @@ async function main() {
   const thumbsOnly = cliOptions['thumbs-only'] ?? false;
   const skipReferenceValidation = cliOptions['skip-reference-validation'] ?? false;
   const noBuild = cliOptions['no-build'] ?? false;
+  const noInput = cliOptions['no-input'] ?? false;
 
   showStepStatusSummary = cliOptions['show-step-summary'] ?? false;
 

--- a/src/upd8.js
+++ b/src/upd8.js
@@ -1162,7 +1162,10 @@ async function main() {
   });
 
   const customDefaultLanguage =
-    languages[wikiData.wikiInfo.defaultLanguage ?? internalDefaultLanguage.code];
+    (wikiData.wikiInfo.defaultLanguage
+      ? languages[wikiData.wikiInfo.defaultLanguage]
+      : null);
+
   let finalDefaultLanguage;
 
   if (customDefaultLanguage) {

--- a/src/upd8.js
+++ b/src/upd8.js
@@ -39,7 +39,7 @@ import {fileURLToPath} from 'node:url';
 import wrap from 'word-wrap';
 
 import {displayCompositeCacheAnalysis} from '#composite';
-import {watchLanguageFile} from '#language';
+import {processLanguageFile, watchLanguageFile} from '#language';
 import {isMain, traverse} from '#node-utils';
 import bootRepl from '#repl';
 import {empty, showAggregate, withEntries} from '#sugar';
@@ -295,6 +295,13 @@ async function main() {
       type: 'flag',
     },
 
+    'no-language-reloading': {
+      help: `Don't reload language files while the build is running\n\nApplied by default for --static-build`,
+      type: 'flag',
+    },
+
+    'no-language-reload': {alias: 'no-language-reloading'},
+
     // Want sweet, sweet trace8ack info in aggreg8te error messages? This
     // will print all the juicy details (or at least the first relevant
     // line) right to your output, 8ut also pro8a8ly give you a headache
@@ -462,6 +469,7 @@ async function main() {
   const skipReferenceValidation = cliOptions['skip-reference-validation'] ?? false;
   const noBuild = cliOptions['no-build'] ?? false;
   const noInput = cliOptions['no-input'] ?? false;
+  let noLanguageReloading = cliOptions['no-language-reloading'] ?? null; // Will get default later.
 
   showStepStatusSummary = cliOptions['show-step-summary'] ?? false;
 
@@ -572,11 +580,23 @@ async function main() {
   }
 
   if (noBuild) {
+    logInfo`Won't generate any site or page files this run (--no-build passed).`;
+
     Object.assign(stepStatusSummary.performBuild, {
       status: STATUS_NOT_APPLICABLE,
       annotation: `--no-build provided`,
     });
+  } else if (usingDefaultBuildMode) {
+    logInfo`No build mode specified, will use default: ${selectedBuildModeFlag}`;
+  } else {
+    logInfo`Will use specified build mode: ${selectedBuildModeFlag}`;
   }
+
+  noLanguageReloading ??=
+    ({
+      'static-build': true,
+      'live-dev-server': false,
+    })[selectedBuildModeFlag];
 
   if (skipThumbs && thumbsOnly) {
     logInfo`Well, you've put yourself rather between a roc and a hard place, hmmmm?`;
@@ -769,14 +789,6 @@ async function main() {
     }
 
     thumbsCache = result.cache;
-  }
-
-  if (noBuild) {
-    logInfo`Not generating any site or page files this run (--no-build passed).`;
-  } else if (usingDefaultBuildMode) {
-    logInfo`No build mode specified, using default: ${selectedBuildModeFlag}`;
-  } else {
-    logInfo`Using specified build mode: ${selectedBuildModeFlag}`;
   }
 
   if (showInvalidPropertyAccesses) {
@@ -1090,35 +1102,54 @@ async function main() {
   });
 
   let internalDefaultLanguage;
+  let internalDefaultLanguageWatcher;
 
-  const internalDefaultLanguageWatcher =
-    watchLanguageFile(path.join(__dirname, DEFAULT_STRINGS_FILE));
+  const internalDefaultStringsFile = path.join(__dirname, DEFAULT_STRINGS_FILE);
 
-  try {
-    await new Promise((resolve, reject) => {
-      const watcher = internalDefaultLanguageWatcher;
+  let errorLoadingInternalDefaultLanguage = false;
 
-      const onReady = () => {
-        watcher.removeListener('ready', onReady);
-        watcher.removeListener('error', onError);
-        resolve();
-      };
+  if (noLanguageReloading) {
+    internalDefaultLanguageWatcher = null;
 
-      const onError = error => {
-        watcher.removeListener('ready', onReady);
-        watcher.removeListener('error', onError);
-        watcher.close();
-        reject(error);
-      };
+    try {
+      internalDefaultLanguage = await processLanguageFile(internalDefaultStringsFile);
+    } catch (error) {
+      niceShowAggregate(error);
+      errorLoadingInternalDefaultLanguage = true;
+    }
+  } else {
+    internalDefaultLanguageWatcher = watchLanguageFile(internalDefaultStringsFile);
 
-      watcher.on('ready', onReady);
-      watcher.on('error', onError);
-    });
+    try {
+      await new Promise((resolve, reject) => {
+        const watcher = internalDefaultLanguageWatcher;
 
-    internalDefaultLanguage = internalDefaultLanguageWatcher.language;
-  } catch (_error) {
-    // No need to display the error here - it's already printed by
-    // watchLanguageFile.
+        const onReady = () => {
+          watcher.removeListener('ready', onReady);
+          watcher.removeListener('error', onError);
+          resolve();
+        };
+
+        const onError = error => {
+          watcher.removeListener('ready', onReady);
+          watcher.removeListener('error', onError);
+          watcher.close();
+          reject(error);
+        };
+
+        watcher.on('ready', onReady);
+        watcher.on('error', onError);
+      });
+
+      internalDefaultLanguage = internalDefaultLanguageWatcher.language;
+    } catch (_error) {
+      // No need to display the error here - it's already printed by
+      // watchLanguageFile.
+      errorLoadingInternalDefaultLanguage = true;
+    }
+  }
+
+  if (errorLoadingInternalDefaultLanguage) {
     logError`There was an error reading the internal language file.`;
     fileIssue();
 
@@ -1131,8 +1162,10 @@ async function main() {
     return false;
   }
 
-  // Bypass node.js special-case handling for uncaught error events
-  internalDefaultLanguageWatcher.on('error', () => {});
+  if (!noLanguageReloading) {
+    // Bypass node.js special-case handling for uncaught error events
+    internalDefaultLanguageWatcher.on('error', () => {});
+  }
 
   Object.assign(stepStatusSummary.loadInternalDefaultLanguage, {
     status: STATUS_DONE_CLEAN,
@@ -1153,81 +1186,118 @@ async function main() {
       pathStyle: 'device',
     });
 
-    customLanguageWatchers =
-      languageDataFiles.map(file => {
-        const watcher = watchLanguageFile(file);
+    let errorLoadingCustomLanguages = false;
 
-        // Bypass node.js special-case handling for uncaught error events
-        watcher.on('error', () => {});
+    if (noLanguageReloading) {
+      languages = {};
 
-        return watcher;
-      });
+      const results =
+        await Promise.allSettled(
+          languageDataFiles
+            .map(file => processLanguageFile(file)));
 
-    const waitingOnWatchers = new Set(customLanguageWatchers);
+      for (const {status, value: language, reason: error} of results) {
+        if (status === 'rejected') {
+          errorLoadingCustomLanguages = true;
+          niceShowAggregate(error);
+        } else {
+          languages[language.code] = language;
+        }
+      }
+    } else watchCustomLanguages: {
+      customLanguageWatchers =
+        languageDataFiles.map(file => {
+          const watcher = watchLanguageFile(file);
 
-    const initialResults =
-      await Promise.allSettled(
-        customLanguageWatchers.map(watcher =>
-          new Promise((resolve, reject) => {
-            const onReady = () => {
-              watcher.removeListener('ready', onReady);
-              watcher.removeListener('error', onError);
-              waitingOnWatchers.delete(watcher);
-              resolve();
-            };
+          // Bypass node.js special-case handling for uncaught error events
+          watcher.on('error', () => {});
 
-            const onError = error => {
-              watcher.removeListener('ready', onReady);
-              watcher.removeListener('error', onError);
-              reject(error);
-            };
-
-            watcher.on('ready', onReady);
-            watcher.on('error', onError);
-          })));
-
-    if (initialResults.some(({status}) => status === 'rejected')) {
-      logWarn`There were errors loading custom languages from the language path`;
-      logWarn`provided: ${langPath}`;
-
-      if (noInput) {
-        logError`Failed to load language files. Please investigate these, or don't provide`;
-        logError`--lang-path (or HSMUSIC_LANG) and build again.`;
-
-        Object.assign(stepStatusSummary.loadLanguageFiles, {
-          status: STATUS_FATAL_ERROR,
-          annotation: `see log for details`,
-          timeEnd: Date.now(),
+          return watcher;
         });
 
-        return false;
+      const waitingOnWatchers = new Set(customLanguageWatchers);
+
+      const initialResults =
+        await Promise.allSettled(
+          customLanguageWatchers
+            .map(watcher => new Promise((resolve, reject) => {
+              const onReady = () => {
+                watcher.removeListener('ready', onReady);
+                watcher.removeListener('error', onError);
+                waitingOnWatchers.delete(watcher);
+                resolve();
+              };
+
+              const onError = error => {
+                watcher.removeListener('ready', onReady);
+                watcher.removeListener('error', onError);
+                reject(error);
+              };
+
+              watcher.on('ready', onReady);
+              watcher.on('error', onError);
+            })));
+
+      if (initialResults.some(({status}) => status === 'rejected')) {
+        logWarn`There were errors loading custom languages from the language path`;
+        logWarn`provided: ${langPath}`;
+
+        if (noInput) {
+          internalDefaultLanguageWatcher.close();
+
+          for (const watcher of Object.values(customLanguageWatchers)) {
+            watcher.close();
+          }
+
+          errorLoadingCustomLanguages = true;
+          break watchCustomLanguages;
+        }
+
+        logWarn`The build should start automatically if you investigate these.`;
+        logWarn`Or, exit by pressing ^C here (control+C) and run again without`;
+        logWarn`providing ${'--lang-path'} (or ${'HSMUSIC_LANG'}) to build without custom`;
+        logWarn`languages.`;
+
+        await new Promise(resolve => {
+          for (const watcher of waitingOnWatchers) {
+            watcher.once('ready', () => {
+              waitingOnWatchers.remove(watcher);
+              if (empty(waitingOnWatchers)) {
+                resolve();
+              }
+            });
+          }
+        });
       }
 
-      logWarn`The build should start automatically if you investigate these.`;
-      logWarn`Or, exit by pressing ^C here (control+C) and run again without`;
-      logWarn`providing ${'--lang-path'} (or ${'HSMUSIC_LANG'}) to build without custom`;
-      logWarn`languages.`;
-
-      await new Promise(resolve => {
-        for (const watcher of waitingOnWatchers) {
-          watcher.once('ready', () => {
-            waitingOnWatchers.remove(watcher);
-            if (empty(waitingOnWatchers)) {
-              resolve();
-            }
-          });
-        }
-      });
+      languages =
+        Object.fromEntries(
+          customLanguageWatchers
+            .map(({language}) => [language.code, language]));
     }
 
-    languages =
-      Object.fromEntries(
-        customLanguageWatchers
-          .map(watcher => [watcher.language.code, watcher.language]));
+    if (errorLoadingCustomLanguages) {
+      logError`Failed to load language files. Please investigate these, or don't provide`;
+      logError`--lang-path (or HSMUSIC_LANG) and build again.`;
+
+      Object.assign(stepStatusSummary.loadLanguageFiles, {
+        status: STATUS_FATAL_ERROR,
+        annotation: `see log for details`,
+        timeEnd: Date.now(),
+      });
+
+      return false;
+    }
 
     Object.assign(stepStatusSummary.loadLanguageFiles, {
       status: STATUS_DONE_CLEAN,
       timeEnd: Date.now(),
+        annotation:
+        (noLanguageReloading
+          ? (selectedBuildModeFlag === 'static-build'
+              ? `loaded statically, default for --static-build`
+              : `loaded statically, --no-language-reloading provided`)
+          : `watching for changes`),
     });
   } else {
     languages = {};
@@ -1265,24 +1335,40 @@ async function main() {
     logInfo`Applying new default strings from custom ${customDefaultLanguage.code} language file.`;
 
     finalDefaultLanguage = customDefaultLanguage;
-    finalDefaultLanguageWatcher =
-      customLanguageWatchers.find(({language}) => language === customDefaultLanguage);
     finalDefaultLanguageAnnotation = `using wiki-specified custom default language`;
+
+    if (!noLanguageReloading) {
+      finalDefaultLanguageWatcher =
+        customLanguageWatchers
+          .find(({language}) => language === customDefaultLanguage);
+    }
   } else if (languages[internalDefaultLanguage.code]) {
     const customDefaultLanguage = languages[internalDefaultLanguage.code];
+
     finalDefaultLanguage = customDefaultLanguage;
-    finalDefaultLanguageWatcher =
-      customLanguageWatchers.find(({language}) => language === customDefaultLanguage);
     finalDefaultLanguageAnnotation = `using inferred custom default language`;
+
+    if (!noLanguageReloading) {
+      finalDefaultLanguageWatcher =
+        customLanguageWatchers
+          .find(({language}) => language === customDefaultLanguage);
+    }
   } else {
     languages[internalDefaultLanguage.code] = internalDefaultLanguage;
 
     finalDefaultLanguage = internalDefaultLanguage;
-    finalDefaultLanguageWatcher = internalDefaultLanguageWatcher;
     finalDefaultLanguageAnnotation = `no custom default language specified`;
+
+    if (!noLanguageReloading) {
+      finalDefaultLanguageWatcher = internalDefaultLanguageWatcher;
+    }
   }
 
   const inheritStringsFromInternalLanguage = () => {
+    // The custom default language, if set, will be the new one providing fallback
+    // strings for other languages. But on its own, it still might not be a complete
+    // list of strings - so it falls back to the internal default language, which
+    // won't otherwise be presented in the build.
     if (finalDefaultLanguage === internalDefaultLanguage) return;
     const {strings: inheritedStrings} = internalDefaultLanguage;
     Object.assign(finalDefaultLanguage, {inheritedStrings});
@@ -1296,22 +1382,24 @@ async function main() {
     }
   };
 
-  // The custom default language, if set, will be the new one providing fallback
-  // strings for other languages. But on its own, it still might not be a complete
-  // list of strings - so it falls back to the internal default language, which
-  // won't otherwise be presented in the build.
   if (finalDefaultLanguage !== internalDefaultLanguage) {
     inheritStringsFromInternalLanguage();
-    internalDefaultLanguageWatcher.on('update', () => {
-      inheritStringsFromInternalLanguage();
-      inheritStringsFromDefaultLanguage();
-    });
   }
 
   inheritStringsFromDefaultLanguage();
-  finalDefaultLanguageWatcher.on('update', () => {
-    inheritStringsFromDefaultLanguage();
-  });
+
+  if (!noLanguageReloading) {
+    if (finalDefaultLanguage !== internalDefaultLanguage) {
+      internalDefaultLanguageWatcher.on('update', () => {
+        inheritStringsFromInternalLanguage();
+        inheritStringsFromDefaultLanguage();
+      });
+    }
+
+    finalDefaultLanguageWatcher.on('update', () => {
+      inheritStringsFromDefaultLanguage();
+    });
+  }
 
   logInfo`Loaded language strings: ${Object.keys(languages).join(', ')}`;
 

--- a/src/upd8.js
+++ b/src/upd8.js
@@ -1233,11 +1233,6 @@ async function main() {
     timeStart: Date.now(),
   });
 
-  const customDefaultLanguage =
-    (wikiData.wikiInfo.defaultLanguage
-      ? languages[wikiData.wikiInfo.defaultLanguage]
-      : null);
-
   let finalDefaultLanguage;
   let finalDefaultLanguageWatcher;
   let finalDefaultLanguageAnnotation;
@@ -1262,14 +1257,25 @@ async function main() {
       return false;
     }
 
-    customDefaultLanguage.inheritedStrings = internalDefaultLanguage.strings;
-
     logInfo`Applying new default strings from custom ${customDefaultLanguage.code} language file.`;
+
+    // The custom default language will be the new one providing fallback strings
+    // for other languages, but on its own, it still might not be a complete list
+    // of strings. So it falls back to the internal default language - which won't
+    // otherwise be presented on the site.
+    customDefaultLanguage.inheritedStrings = internalDefaultLanguage.strings;
 
     finalDefaultLanguage = customDefaultLanguage;
     finalDefaultLanguageWatcher =
       customLanguageWatchers.find(({language}) => language === customDefaultLanguage);
     finalDefaultLanguageAnnotation = `using wiki-specified custom default language`;
+  } else if (languages[internalDefaultLanguage.code]) {
+    const customDefaultLanguage = languages[internalDefaultLanguage.code];
+    customDefaultLanguage.inheritedStrings = internalDefaultLanguage.strings;
+    finalDefaultLanguage = customDefaultLanguage;
+    finalDefaultLanguageWatcher =
+      customLanguageWatchers.find(({language}) => language === customDefaultLanguage);
+    finalDefaultLanguageAnnotation = `using inferred custom default language`;
   } else {
     languages[internalDefaultLanguage.code] = internalDefaultLanguage;
 

--- a/src/upd8.js
+++ b/src/upd8.js
@@ -39,7 +39,7 @@ import {fileURLToPath} from 'node:url';
 import wrap from 'word-wrap';
 
 import {displayCompositeCacheAnalysis} from '#composite';
-import {processLanguageFile, watchLanguageFile} from '#language';
+import {watchLanguageFile} from '#language';
 import {isMain, traverse} from '#node-utils';
 import bootRepl from '#repl';
 import {empty, showAggregate, withEntries} from '#sugar';
@@ -56,7 +56,6 @@ import {
   logError,
   parseOptions,
   progressCallAll,
-  progressPromiseAll,
 } from '#cli';
 
 import genThumbs, {


### PR DESCRIPTION
This PR implements a general-purpose `watchLanguageFile` function, which itself is built on a variety of smaller utilities (shared with `processLanguageFile`), and comprehensively integrates it into `upd8.js` - so live reload (or hot swapping) is supported for both the internal `strings-default.json` file, as well as custom languages!

No extra work is needed to enable language reloading - it's on for default when using the `--live-dev-server` build mode. It can be disabled with `--no-language-reloading` (or `--no-language-reload`), and although `--static-build` in principle will work with live-updated languages no problem, it's... kind of antithetical to a *static* build. So there's no CLI option to enable it there.

If there are errors during the initial loading of a language, hsmusic will wait for them to be fixed. Since this can result in a hang which isn't ideal in any kind of headless context, this PR also adds a new `--no-input` option, which provides sensible points of process.exit() instead of waiting. (This is mostly a stub here, but gets implemented more thoroughly into `gen-thumbs.js` in a separate PR.)

On the surface level (i.e. `upd8.js`), there just isn't a lot of overlap between processing language files statically and watching them, so these additions are mostly implemented in separate if/else statements conditional on the `--no-language-reloading` flag.

A portion of logic is updated to make sure languages all continue to inherit strings correctly (custom, non-default languages inherit from the default language, and the default language, if it's custom, inherits from the internal default language) - including when the parent languages are updated. The gist of this behavior existed before, but it's separated out into neater functions now, and those are reused across static processing and live reloading.

File changes are detected with chokidar and the implementation is loosely based on existing content function reloading, `content/dependencies/index.js`. This implementation, though, doesn't support automatically adding and removing language files, and if you try to change the `meta.languageCode` of a language that's already been loaded, the watcher will complain (politely). Like with content functions, if a previous version of a language has been loaded successfully, then it will be reused if processing that file fails when it's changed.