### PR TITLE
Fetch "random link" data only when needed + related cleanup

### DIFF
--- a/src/content/dependencies/generateAlbumCommentaryPage.js
+++ b/src/content/dependencies/generateAlbumCommentaryPage.js
@@ -201,6 +201,7 @@ export default {
         ],
 
         leftSidebarStickyMode: 'column',
+        leftSidebarClass: 'commentary-track-list-sidebar-box',
         leftSidebarContent: [
           html.tag('h1', relations.sidebarAlbumLink),
           relations.sidebarTrackSections.map(section =>

--- a/src/content/dependencies/generateAlbumNavAccent.js
+++ b/src/content/dependencies/generateAlbumNavAccent.js
@@ -92,7 +92,7 @@ export default {
         html.tag('a',
           {
             href: '#',
-            'data-random': 'track-in-album',
+            'data-random': 'track-in-sidebar',
             id: 'random-button',
           },
           (data.isTrackPage

--- a/src/content/dependencies/generateAlbumSidebar.js
+++ b/src/content/dependencies/generateAlbumSidebar.js
@@ -30,6 +30,7 @@ export default {
 
   generate(data, relations, {html}) {
     const trackListBox = {
+      class: 'track-list-sidebar-box',
       content:
         html.tags([
           html.tag('h1', relations.albumLink),
@@ -40,8 +41,10 @@ export default {
     if (data.isAlbumPage) {
       const groupBoxes =
         relations.groupBoxes
-          .map(content => content.slot('mode', 'album'))
-          .map(content => ({content}));
+          .map(content => ({
+            class: 'individual-group-sidebar-box',
+            content: content.slot('mode', 'album'),
+          }));
 
       return {
         leftSidebarMultiple: [
@@ -52,6 +55,7 @@ export default {
     }
 
     const conjoinedGroupBox = {
+      class: 'conjoined-group-sidebar-box',
       content:
         relations.groupBoxes
           .flatMap((content, i, {length}) => [

--- a/src/content/dependencies/generateFlashActSidebar.js
+++ b/src/content/dependencies/generateFlashActSidebar.js
@@ -137,7 +137,7 @@ export default {
   }),
 
   generate(data, relations, {getColors, html, language}) {
-    const currentActBox = html.tags([
+    const currentActBoxContent = html.tags([
       html.tag('h1', relations.currentActLink),
 
       html.tag('details',
@@ -160,7 +160,7 @@ export default {
         ]),
     ]);
 
-    const sideMapBox = html.tags([
+    const sideMapBoxContent = html.tags([
       html.tag('h1', relations.flashIndexLink),
 
       stitchArrays({
@@ -188,17 +188,21 @@ export default {
           ])),
     ]);
 
+    const sideMapBox = {
+      class: 'flash-act-map-sidebar-box',
+      content: sideMapBoxContent,
+    };
+
+    const currentActBox = {
+      class: 'flash-current-act-sidebar-box',
+      content: currentActBoxContent,
+    };
+
     return {
       leftSidebarMultiple:
         (data.isFlashActPage
-          ? [
-              {content: sideMapBox},
-              {content: currentActBox},
-            ]
-          : [
-              {content: currentActBox},
-              {content: sideMapBox},
-            ]),
+          ? [sideMapBox, currentActBox]
+          : [currentActBox, sideMapBox]),
     };
   },
 };

--- a/src/content/dependencies/generateGroupSidebar.js
+++ b/src/content/dependencies/generateGroupSidebar.js
@@ -22,6 +22,7 @@ export default {
 
   generate(relations, slots, {html, language}) {
     return {
+      leftSidebarClass: 'category-map-sidebar-box',
       leftSidebarContent: [
         html.tag('h1',
           language.$('groupSidebar.title')),

--- a/src/content/dependencies/generateListingSidebar.js
+++ b/src/content/dependencies/generateListingSidebar.js
@@ -11,6 +11,7 @@ export default {
 
   generate(relations, {html}) {
     return {
+      leftSidebarClass: 'listing-map-sidebar-box',
       leftSidebarContent: [
         html.tag('h1', relations.listingIndexLink),
         relations.listingIndexList.slot('mode', 'sidebar'),

--- a/src/content/dependencies/generatePageLayout.js
+++ b/src/content/dependencies/generatePageLayout.js
@@ -6,12 +6,19 @@ function sidebarSlots(side) {
     // if specified.
     [side + 'Content']: {type: 'html'},
 
-    // Multiple is an array of {content: (HTML)} objects. Each of these
-    // will generate one sidebar section.
+    // A single class to apply to the whole sidebar. If specifying multiple
+    // sections, this be added to the containing sidebar-column - specify a
+    // class on each section if that's more suitable.
+    [side + 'Class']: {type: 'string'},
+
+    // Multiple is an array of objects, each specifying content (HTML) and
+    // optionally class (a string). Each of these will generate one sidebar
+    // section.
     [side + 'Multiple']: {
       validate: v =>
         v.sparseArrayOf(
           v.validateProperties({
+            class: v.optional(v.isString),
             content: v.isHTML,
           })),
     },
@@ -27,6 +34,7 @@ function sidebarSlots(side) {
     // the whole section's containing box (or the sidebar column as a whole).
     [side + 'StickyMode']: {
       validate: v => v.is('last', 'column', 'static'),
+      default: 'static',
     },
 
     // Collapsing sidebars disappear when the viewport is sufficiently
@@ -354,6 +362,7 @@ export default {
 
     const generateSidebarHTML = (side, id) => {
       const content = slots[side + 'Content'];
+      const topClass = slots[side + 'Class'];
       const multiple = slots[side + 'Multiple'];
       const stickyMode = slots[side + 'StickyMode'];
       const wide = slots[side + 'Wide'];
@@ -363,20 +372,18 @@ export default {
       let sidebarContent = html.blank();
 
       if (!html.isBlank(content)) {
-        sidebarClasses = ['sidebar'];
+        sidebarClasses = ['sidebar', topClass];
         sidebarContent = content;
       } else if (multiple) {
-        sidebarClasses = ['sidebar-multiple'];
+        sidebarClasses = ['sidebar-multiple', topClass];
         sidebarContent =
           multiple
             .filter(Boolean)
-            .map(({content}) =>
-              html.tag('div',
-                {
-                  [html.onlyIfContent]: true,
-                  class: 'sidebar',
-                },
-                content));
+            .map(box =>
+              html.tag('div', {
+                [html.onlyIfContent]: true,
+                class: ['sidebar', box.class],
+              }, box.content));
       }
 
       if (html.isBlank(sidebarContent)) {

--- a/src/content/dependencies/generatePageLayout.js
+++ b/src/content/dependencies/generatePageLayout.js
@@ -655,7 +655,7 @@ export default {
 
               html.tag('script', {
                 type: 'module',
-                src: to('shared.staticFile', 'client2.js', cachebust),
+                src: to('shared.staticFile', 'client3.js', cachebust),
               }),
             ]),
         ])

--- a/src/content/dependencies/generateWikiHomeNewsBox.js
+++ b/src/content/dependencies/generateWikiHomeNewsBox.js
@@ -42,6 +42,7 @@ export default {
     }
 
     return {
+      class: 'latest-news-sidebar-box',
       content: [
         html.tag('h1', language.$('homepage.news.title')),
 

--- a/src/content/dependencies/generateWikiHomePage.js
+++ b/src/content/dependencies/generateWikiHomePage.js
@@ -75,6 +75,7 @@ export default {
       leftSidebarMultiple: [
         (relations.customSidebarContent
           ? {
+              class: 'custom-content-sidebar-box',
               content:
                 relations.customSidebarContent
                   .slot('mode', 'multiline'),

--- a/src/content/dependencies/listRandomPageLinks.js
+++ b/src/content/dependencies/listRandomPageLinks.js
@@ -119,6 +119,9 @@ export default {
 
         html.tag('p', {id: 'data-loaded-line'},
           language.$('listingPage.other.randomPages.dataLoadedLine')),
+
+        html.tag('p', {id: 'data-error-line'},
+          language.$('listingPage.other.randomPages.dataErrorLine')),
       ],
 
       showSkipToSection: true,

--- a/src/content/dependencies/listRandomPageLinks.js
+++ b/src/content/dependencies/listRandomPageLinks.js
@@ -114,12 +114,10 @@ export default {
               language.$('listingPage.other.randomPages.chooseLinkLine.browserSupportPart'),
           })),
 
-        html.tag('p',
-          {class: 'js-hide-once-data'},
+        html.tag('p', {id: 'data-loading-line'},
           language.$('listingPage.other.randomPages.dataLoadingLine')),
 
-        html.tag('p',
-          {class: 'js-show-once-data'},
+        html.tag('p', {id: 'data-loaded-line'},
           language.$('listingPage.other.randomPages.dataLoadedLine')),
       ],
 

--- a/src/static/client2.js
+++ b/src/static/client2.js
@@ -187,6 +187,19 @@ function addRandomLinkListeners() {
           break;
         }
 
+        case 'track-in-sidebar': {
+          // Note that the container for track links may be <ol> or <ul>, and
+          // they can't be identified by href, since links from one track to
+          // another don't include "track" in the href.
+          const trackLinks =
+            Array.from(document
+              .querySelector('.track-list-sidebar-box')
+              .querySelectorAll('li a'));
+
+          a.href = pick(trackLinks).href;
+          break;
+        }
+
         /* Legacy links, for old versions             *
          * of generateListRandomPageLinksGroupSection */
 
@@ -255,9 +268,7 @@ function addNavigationKeyPressListeners() {
       } else if (event.charCode === 'P'.charCodeAt(0)) {
         scriptedLinkInfo.previousNavLink?.click();
       } else if (event.charCode === 'R'.charCodeAt(0)) {
-        if (ready) {
-          scriptedLinkInfo.randomNavLink?.click();
-        }
+        scriptedLinkInfo.randomNavLink?.click();
       }
     }
   });

--- a/src/static/client3.js
+++ b/src/static/client3.js
@@ -14,7 +14,6 @@ import {
 } from '../util/wiki-data.js';
 
 let albumData, artistData;
-let officialAlbumData, fandomAlbumData, beyondAlbumData;
 
 let ready = false;
 
@@ -200,37 +199,8 @@ function addRandomLinkListeners() {
           break;
         }
 
-        /* Legacy links, for old versions             *
-         * of generateListRandomPageLinksGroupSection */
-
-        case 'album-in-official':
-          a.href = openAlbum(pick(officialAlbumData).directory);
-          break;
-
-        case 'album-in-fandom':
-          a.href = openAlbum(pick(fandomAlbumData).directory);
-          break;
-
-        case 'album-in-beyond':
-          a.href = openAlbum(pick(beyondAlbumData).directory);
-          break;
-
-        /* End legacy links */
-
         case 'track-in-album':
           a.href = openTrack(getRefDirectory(pick(getAlbum(a).tracks)));
-          break;
-
-        case 'track-in-official':
-          a.href = openTrack(getRefDirectory(pick(tracks(officialAlbumData))));
-          break;
-
-        case 'track-in-fandom':
-          a.href = openTrack(getRefDirectory(pick(tracks(fandomAlbumData))));
-          break;
-
-        case 'track-in-beyond':
-          a.href = openTrack(getRefDirectory(pick(tracks(beyondAlbumData))));
           break;
 
         case 'artist':
@@ -303,15 +273,6 @@ fetch(rebase('data.json', 'rebaseShared'))
   .then((data) => {
     albumData = data.albumData;
     artistData = data.artistData;
-
-    const albumsInGroup = directory =>
-      albumData
-        .filter(album =>
-          album.groups.includes(`group:${directory}`));
-
-    officialAlbumData = albumsInGroup('official');
-    fandomAlbumData = albumsInGroup('fandom');
-    beyondAlbumData = albumsInGroup('beyond');
 
     for (const element of elements1) element.style.display = 'none';
     for (const element of elements2) element.style.display = 'block';

--- a/src/static/client3.js
+++ b/src/static/client3.js
@@ -287,6 +287,7 @@ if (
 ) {
   const dataLoadingLine = document.getElementById('data-loading-line');
   const dataLoadedLine = document.getElementById('data-loaded-line');
+  const dataErrorLine = document.getElementById('data-error-line');
 
   dataLoadingLine.style.display = 'block';
 
@@ -300,8 +301,20 @@ if (
 
       dataLoadingLine.style.display = 'none';
       dataLoadedLine.style.display = 'block';
-    });
+    })
+    .catch(() => {
+      const info = scriptedLinkInfo;
 
+      for (const a of info.randomLinks) {
+        const href = determineRandomLinkHref(a);
+        if (!href) {
+          a.removeAttribute('href');
+        }
+      }
+
+      dataLoadingLine.style.display = 'none';
+      dataErrorLine.style.display = 'block';
+    });
 }
 
 // Data & info card ---------------------------------------

--- a/src/static/site5.css
+++ b/src/static/site5.css
@@ -792,6 +792,11 @@ html[data-url-key="localized.albumCommentary"] li.no-commentary {
   opacity: 0.7;
 }
 
+html[data-url-key="localized.listing"][data-url-value0="random"] #data-loading-line,
+html[data-url-key="localized.listing"][data-url-value0="random"] #data-loaded-line {
+  display: none;
+}
+
 /* Images */
 
 .image-container {

--- a/src/static/site5.css
+++ b/src/static/site5.css
@@ -793,8 +793,13 @@ html[data-url-key="localized.albumCommentary"] li.no-commentary {
 }
 
 html[data-url-key="localized.listing"][data-url-value0="random"] #data-loading-line,
-html[data-url-key="localized.listing"][data-url-value0="random"] #data-loaded-line {
+html[data-url-key="localized.listing"][data-url-value0="random"] #data-loaded-line,
+html[data-url-key="localized.listing"][data-url-value0="random"] #data-error-line {
   display: none;
+}
+
+html[data-url-key="localized.listing"][data-url-value0="random"] #content a:not([href]) {
+  opacity: 0.7;
 }
 
 /* Images */

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -1556,7 +1556,7 @@ listingPage:
           If your browser doesn't support relatively modern JavaScript
           or you've disabled it, these links won't work - sorry.
 
-      # dataLoadingLine, dataLoadedLine:
+      # dataLoadingLine, dataLoadedLine, dataErrorLine:
       #   Since the links on this page depend on access to a fairly
       #   large data file that is downloaded separately and in the
       #   background, these messages indicate the status of that
@@ -1567,6 +1567,9 @@ listingPage:
 
       dataLoadedLine: >-
         (Data files have finished being downloaded. The links should work!)
+
+      dataErrorLine: >-
+        (Data files failed to download. Sorry, some of these links won't work right now!)
 
       chunk:
 

--- a/src/write/build-modes/live-dev-server.js
+++ b/src/write/build-modes/live-dev-server.js
@@ -16,7 +16,7 @@ import {
 } from '#urls';
 
 import {bindUtilities} from '../bind-utilities.js';
-import {generateGlobalWikiDataJSON, generateRedirectHTML} from '../common-templates.js';
+import {generateRandomLinkDataJSON, generateRedirectHTML} from '../common-templates.js';
 
 const defaultHost = '0.0.0.0';
 const defaultPort = 8002;
@@ -157,19 +157,20 @@ export async function go({
 
     // Specialized routes
 
-    if (pathname === '/data.json') {
+    if (pathname === '/random-link-data.json') {
       try {
-        const json = generateGlobalWikiDataJSON({
+        const json = generateRandomLinkDataJSON({
           serializeThings,
           wikiData,
         });
+
         response.writeHead(200, contentTypeJSON);
         response.end(json);
-        if (loudResponses) console.log(`${requestHead} [200] /data.json`);
+        if (loudResponses) console.log(`${requestHead} [200] ${pathname}`);
       } catch (error) {
         response.writeHead(500, contentTypeJSON);
         response.end(`Internal error serializing wiki JSON`);
-        console.error(`${requestHead} [500] /data.json`);
+        console.error(`${requestHead} [500] ${pathname}`);
         showError(error);
       }
       return;

--- a/src/write/build-modes/static-build.js
+++ b/src/write/build-modes/static-build.js
@@ -31,7 +31,7 @@ import {
 } from '#urls';
 
 import {bindUtilities} from '../bind-utilities.js';
-import {generateRedirectHTML, generateGlobalWikiDataJSON} from '../common-templates.js';
+import {generateRedirectHTML, generateRandomLinkDataJSON} from '../common-templates.js';
 
 const pageFlags = Object.keys(pageSpecs);
 
@@ -145,14 +145,8 @@ export async function go({
   });
 
   await writeSharedFilesAndPages({
-    language: defaultLanguage,
     outputPath,
-    urls,
-    wikiData,
-    wikiDataJSON: generateGlobalWikiDataJSON({
-      serializeThings,
-      wikiData,
-    }),
+    randomLinkDataJSON: generateRandomLinkDataJSON({wikiData}),
   });
 
   const buildSteps = writeAll
@@ -477,12 +471,12 @@ async function writeFavicon({
 
 async function writeSharedFilesAndPages({
   outputPath,
-  wikiDataJSON,
+  randomLinkDataJSON,
 }) {
   return progressPromiseAll(`Writing files & pages shared across languages.`, [
-    wikiDataJSON &&
+    randomLinkDataJSON &&
       writeFile(
-        path.join(outputPath, 'data.json'),
-        wikiDataJSON),
+        path.join(outputPath, 'random-link-data.json'),
+        randomLinkDataJSON),
   ].filter(Boolean));
 }

--- a/src/write/common-templates.js
+++ b/src/write/common-templates.js
@@ -1,4 +1,5 @@
 import * as html from '#html';
+import {getArtistNumContributions} from '#wiki-data';
 
 export function generateRedirectHTML(title, target, {language}) {
   return `<!DOCTYPE html>\n` + html.tag('html', [
@@ -30,22 +31,25 @@ export function generateRedirectHTML(title, target, {language}) {
   ]);
 }
 
-export function generateGlobalWikiDataJSON({
-  serializeThings,
-  wikiData,
-}) {
-  const stringifyThings = thingData =>
-    JSON.stringify(serializeThings(thingData));
+export function generateRandomLinkDataJSON({wikiData}) {
+  const {albumData, artistData} = wikiData;
 
-  return '{\n' +
-    ([
-      `"albumData": ${stringifyThings(wikiData.albumData)},`,
-      wikiData.wikiInfo.enableFlashesAndGames &&
-        `"flashData": ${stringifyThings(wikiData.flashData)},`,
-      `"artistData": ${stringifyThings(wikiData.artistData)}`,
-    ]
-      .filter(Boolean)
-      .map(line => '  ' + line)
-      .join('\n')) +
-    '\n}';
+  return JSON.stringify({
+    albumDirectories:
+      albumData
+        .map(album => album.directory),
+
+    albumTrackDirectories:
+      albumData
+        .map(album => album.tracks
+          .map(track => track.directory)),
+
+    artistDirectories:
+      artistData
+        .map(artist => artist.directory),
+
+    artistNumContributions:
+      artistData
+        .map(artist => getArtistNumContributions(artist)),
+  });
 }


### PR DESCRIPTION
This PR changes the way random links work to only require fetching a large data file on the "Random Pages" listing, and brings along a host of related changes.

User-visible changes:

* The "Random Pages" listing now has a clean error state when data fails to download - an error message is displayed and links which will not work are dimmed out.
* The "Random" link in the album (and track) nav bar no longer requires downloading a data file to work - it picks the track link from the sidebar. This means it's immediately responsive instead of not reacting until a delay invisibly passes.
* The downloaded data JSON is generally more concise and should load quicker using less bandwidth on a slow or limited connection. It's better specialized for the "Random Pages" listing now that it's only used there. (It's also renamed from `data.json` to `random-link-data.json`.)
  * It does still take some time to generate, when needed, presumably due to counting every artist's contributions. However...
* Because the data file is only fetched on the "Random Pages" listing instead of on every page, the `live-dev-server` build mode is much better at keeping up - it doesn't get hung serializing the data JSON after the first request every time it's restarted. This is a big deal for local data work!

Supporting internal changes:

* `generatePageLayout` gets a new slot `leftSidebarClass` (etc), as well as an optional `class` property accompanying `content` when specifying multiple sidebar boxes/sections. These are now used in sidebars across the site to help make specific sidebars targetable from JavaScript or CSS - only one is used in JS for now (`track-list-sidebar-box`) but classes have been supplied to all sidebars.
* The code in `client3.js` (moved from `client2.js`) to do with scripted random links is heavily refactored and tidied, though the original structure still shows through. As the only part of the code consuming `albumData` and `artistData` (as well as `ready`), those variables, reworked with the `random-link-data.json` changes, are now stored as state on `scriptedLinkInfo` instead of globally. Legacy cases for `switch (a.dataset.random)` are removed since this is a separate and generally incompatible file.