### PR TITLE
Additional Names field and box!

### DIFF
--- a/src/content/dependencies/generateAdditionalNamesBox.js
+++ b/src/content/dependencies/generateAdditionalNamesBox.js
@@ -1,0 +1,48 @@
+import {stitchArrays} from '#sugar';
+
+export default {
+  contentDependencies: ['transformContent'],
+  extraDependencies: ['html', 'language'],
+
+  relations: (relation, additionalNames) => ({
+    names:
+      additionalNames.map(({name}) =>
+        relation('transformContent', name)),
+
+    annotations:
+      additionalNames.map(({annotation}) =>
+        (annotation
+          ? relation('transformContent', annotation)
+          : null)),
+  }),
+
+  generate: (relations, {html, language}) => {
+    const names =
+      relations.names.map(name =>
+        html.tag('span', {class: 'additional-name'},
+          name.slot('mode', 'inline')));
+
+    const annotations =
+      relations.annotations.map(annotation =>
+        (annotation
+          ? html.tag('span', {class: 'annotation'},
+              language.$('misc.additionalNames.item.annotation', {
+                annotation:
+                  annotation.slot('mode', 'inline'),
+              }))
+          : null));
+
+    return html.tag('div', {id: 'additional-names-box'}, [
+      html.tag('p',
+        language.$('misc.additionalNames.title')),
+
+      html.tag('ul',
+        stitchArrays({name: names, annotation: annotations})
+          .map(({name, annotation}) =>
+            html.tag('li',
+              (annotation
+                ? language.$('misc.additionalNames.item.withAnnotation', {name, annotation})
+                : language.$('misc.additionalNames.item', {name}))))),
+    ]);
+  },
+};

--- a/src/content/dependencies/generatePageLayout.js
+++ b/src/content/dependencies/generatePageLayout.js
@@ -108,6 +108,8 @@ export default {
     title: {type: 'html'},
     showWikiNameInTitle: {type: 'boolean', default: true},
 
+    additionalNames: {type: 'html'},
+
     cover: {type: 'html'},
 
     socialEmbed: {type: 'html'},
@@ -222,22 +224,25 @@ export default {
     const colors = getColors(slots.color ?? data.wikiColor);
     const hasSocialEmbed = !html.isBlank(slots.socialEmbed);
 
-    let titleHTML = null;
+    const titleContentsHTML =
+      (html.isBlank(slots.title)
+        ? null
+     : html.isBlank(slots.additionalNames)
+        ? language.sanitize(slots.title)
+        : html.tag('a', {
+            href: '#additional-names-box',
+            title: language.$('misc.additionalNames.tooltip').toString(),
+          }, language.sanitize(slots.title)));
 
-    if (!html.isBlank(slots.title)) {
-      switch (slots.headingMode) {
-        case 'sticky':
-          titleHTML =
-            relations.stickyHeadingContainer.slots({
-              title: slots.title,
-              cover: slots.cover,
-            });
-          break;
-        case 'static':
-          titleHTML = html.tag('h1', slots.title);
-          break;
-      }
-    }
+    const titleHTML =
+      (html.isBlank(slots.title)
+        ? null
+     : slots.headingMode === 'sticky'
+        ? relations.stickyHeadingContainer.slots({
+            title: titleContentsHTML,
+            cover: slots.cover,
+          })
+        : html.tag('h1', titleContentsHTML));
 
     let footerContent = slots.footerContent;
 
@@ -254,6 +259,7 @@ export default {
         titleHTML,
 
         slots.cover,
+        slots.additionalNames,
 
         html.tag('div',
           {

--- a/src/content/dependencies/generateTrackInfoPage.js
+++ b/src/content/dependencies/generateTrackInfoPage.js
@@ -6,6 +6,7 @@ import getChronologyRelations from '../util/getChronologyRelations.js';
 export default {
   contentDependencies: [
     'generateAdditionalFilesShortcut',
+    'generateAdditionalNamesBox',
     'generateAlbumAdditionalFilesList',
     'generateAlbumNavAccent',
     'generateAlbumSidebar',
@@ -105,6 +106,11 @@ export default {
       heading: relation('generateContentHeading'),
       list: relation('generateAlbumAdditionalFilesList', album, additionalFiles),
     });
+
+    if (!empty(track.additionalNames)) {
+      relations.additionalNamesBox =
+        relation('generateAdditionalNamesBox', track.additionalNames);
+    }
 
     if (track.hasUniqueCoverArt || album.hasCoverArt) {
       relations.cover =
@@ -299,6 +305,8 @@ export default {
       .slots({
         title: language.$('trackPage.title', {track: data.name}),
         headingMode: 'sticky',
+
+        additionalNames: relations.additionalNamesBox ?? null,
 
         color: data.color,
         styleRules: [relations.albumStyleRules],

--- a/src/data/composite/wiki-properties/additionalNameList.js
+++ b/src/data/composite/wiki-properties/additionalNameList.js
@@ -1,0 +1,13 @@
+// A list of additional names! These can be used for a variety of purposes,
+// e.g. providing extra searchable titles, localizations, romanizations or
+// original titles, and so on. Each item has a name and, optionally, a
+// descriptive annotation.
+
+import {isAdditionalNameList} from '#validators';
+
+export default function() {
+  return {
+    flags: {update: true, expose: true},
+    update: {validate: isAdditionalNameList},
+  };
+}

--- a/src/data/composite/wiki-properties/index.js
+++ b/src/data/composite/wiki-properties/index.js
@@ -1,4 +1,5 @@
 export {default as additionalFiles} from './additionalFiles.js';
+export {default as additionalNameList} from './additionalNameList.js';
 export {default as color} from './color.js';
 export {default as commentary} from './commentary.js';
 export {default as commentatorArtists} from './commentatorArtists.js';

--- a/src/data/things/track.js
+++ b/src/data/things/track.js
@@ -24,6 +24,7 @@ import {
 
 import {
   additionalFiles,
+  additionalNameList,
   commentary,
   commentatorArtists,
   contributionList,
@@ -63,6 +64,7 @@ export class Track extends Thing {
 
     name: name('Unnamed Track'),
     directory: directory(),
+    additionalNames: additionalNameList(),
 
     duration: duration(),
     urls: urls(),

--- a/src/data/things/validators.js
+++ b/src/data/things/validators.js
@@ -96,7 +96,10 @@ export function isStringNonEmpty(value) {
 }
 
 export function optional(validator) {
-  return value => value === null || value === undefined || validator(value);
+  return value =>
+    value === null ||
+    value === undefined ||
+    validator(value);
 }
 
 // Complex types (non-primitives)
@@ -285,20 +288,14 @@ export function validateProperties(spec) {
 
 export const isContribution = validateProperties({
   who: isArtistRef,
-  what: (value) =>
-    value === undefined ||
-    value === null ||
-    isStringNonEmpty(value),
+  what: optional(isStringNonEmpty),
 });
 
 export const isContributionList = validateArrayItems(isContribution);
 
 export const isAdditionalFile = validateProperties({
   title: isString,
-  description: (value) =>
-    value === undefined ||
-    value === null ||
-    isString(value),
+  description: optional(isStringNonEmpty),
   files: validateArrayItems(isString),
 });
 

--- a/src/data/things/validators.js
+++ b/src/data/things/validators.js
@@ -373,6 +373,13 @@ export function isURL(string) {
   return true;
 }
 
+export const isAdditionalName = validateProperties({
+  name: isName,
+  annotation: optional(isStringNonEmpty),
+});
+
+export const isAdditionalNameList = validateArrayItems(isAdditionalName);
+
 export function validateReference(type = 'track') {
   return (ref) => {
     isStringNonEmpty(ref);

--- a/src/data/yaml.js
+++ b/src/data/yaml.js
@@ -717,26 +717,28 @@ export function parseAdditionalFiles(array) {
   }));
 }
 
-export function parseContributors(contributors) {
+const extractAccentRegex =
+  /^(?<main>.*?)(?: \((?<accent>.*)\))?$/;
+
+export function parseContributors(contributionStrings) {
   // If this isn't something we can parse, just return it as-is.
   // The Thing object's validators will handle the data error better
   // than we're able to here.
-  if (!Array.isArray(contributors)) {
-    return contributors;
+  if (!Array.isArray(contributionStrings)) {
+    return contributionStrings;
   }
 
-  contributors = contributors.map((contrib) => {
-    if (typeof contrib !== 'string') return contrib;
+  return contributionStrings.map(contribString => {
+    if (typeof contribString !== 'string') return contribString;
 
-    const match = contrib.match(/^(.*?)( \((.*)\))?$/);
-    if (!match) return contrib;
+    const match = contribString.match(extractAccentRegex);
+    if (!match) return contribString;
 
-    const who = match[1];
-    const what = match[3] || null;
-    return {who, what};
+    return {
+      who: match.groups.main,
+      what: match.groups.accent ?? null,
+    };
   });
-
-  return contributors;
 }
 
 function parseDimensions(string) {

--- a/src/data/yaml.js
+++ b/src/data/yaml.js
@@ -436,6 +436,7 @@ export const processTrackSectionDocument = makeProcessDocument(T.TrackSectionHel
 
 export const processTrackDocument = makeProcessDocument(T.Track, {
   fieldTransformations: {
+    'Additional Names': parseAdditionalNames,
     'Duration': parseDuration,
 
     'Date First Released': (value) => new Date(value),
@@ -457,6 +458,7 @@ export const processTrackDocument = makeProcessDocument(T.Track, {
   propertyFieldMapping: {
     name: 'Track',
     directory: 'Directory',
+    additionalNames: 'Additional Names',
     duration: 'Duration',
     color: 'Color',
     urls: 'URLs',
@@ -737,6 +739,24 @@ export function parseContributors(contributionStrings) {
     return {
       who: match.groups.main,
       what: match.groups.accent ?? null,
+    };
+  });
+}
+
+export function parseAdditionalNames(additionalNameStrings) {
+  if (!Array.isArray(additionalNameStrings)) {
+    return additionalNameStrings;
+  }
+
+  return additionalNameStrings.map(additionalNameString => {
+    if (typeof additionalNameString !== 'string') return additionalNameString;
+
+    const match = additionalNameString.match(extractAccentRegex);
+    if (!match) return additionalNameString;
+
+    return {
+      name: match.groups.main,
+      annotation: match.groups.accent ?? null,
     };
   });
 }

--- a/src/data/yaml.js
+++ b/src/data/yaml.js
@@ -730,11 +730,14 @@ export function parseContributors(contributionStrings) {
     return contributionStrings;
   }
 
-  return contributionStrings.map(contribString => {
-    if (typeof contribString !== 'string') return contribString;
+  return contributionStrings.map(item => {
+    if (typeof item === 'object' && item['Who'])
+      return {who: item['Who'], what: item['What'] ?? null};
 
-    const match = contribString.match(extractAccentRegex);
-    if (!match) return contribString;
+    if (typeof item !== 'string') return item;
+
+    const match = item.match(extractAccentRegex);
+    if (!match) return item;
 
     return {
       who: match.groups.main,
@@ -748,11 +751,14 @@ export function parseAdditionalNames(additionalNameStrings) {
     return additionalNameStrings;
   }
 
-  return additionalNameStrings.map(additionalNameString => {
-    if (typeof additionalNameString !== 'string') return additionalNameString;
+  return additionalNameStrings.map(item => {
+    if (typeof item === 'object' && item['Name'])
+      return {name: item['Name'], annotation: item['Annotation'] ?? null};
 
-    const match = additionalNameString.match(extractAccentRegex);
-    if (!match) return additionalNameString;
+    if (typeof item !== 'string') return item;
+
+    const match = item.match(extractAccentRegex);
+    if (!match) return item;
 
     return {
       name: match.groups.main,

--- a/src/static/client3.js
+++ b/src/static/client3.js
@@ -576,6 +576,7 @@ const hashLinkInfo = clientInfo.hashLinkInfo = {
   },
 
   event: {
+    beforeHashLinkScrolls: [],
     whenHashLinkClicked: [],
   },
 };
@@ -638,6 +639,21 @@ function addHashLinkListeners() {
         return;
       }
 
+      // Don't do anything if the target element isn't actually visible!
+      if (target.offsetParent === null) {
+        return;
+      }
+
+      // Allow event handlers to prevent scrolling.
+      for (const handler of event.beforeHashLinkScrolls) {
+        if (handler({
+          link: hashLink,
+          target,
+        }) === false) {
+          return;
+        }
+      }
+
       // Hide skipper box right away, so the layout is updated on time for the
       // math operations coming up next.
       const skipper = document.getElementById('skippers');
@@ -675,6 +691,7 @@ function addHashLinkListeners() {
       for (const handler of event.whenHashLinkClicked) {
         handler({
           link: hashLink,
+          target,
         });
       }
     });

--- a/src/static/client3.js
+++ b/src/static/client3.js
@@ -1260,6 +1260,96 @@ function loadImage(imageUrl, onprogress) {
   });
 }
 
+// "Additional names" box ---------------------------------
+
+const additionalNamesBoxInfo = clientInfo.additionalNamesBox = {
+  box: null,
+  links: null,
+  mainContentContainer: null,
+
+  state: {
+    visible: false,
+  },
+};
+
+function getAdditionalNamesBoxReferences() {
+  const info = additionalNamesBoxInfo;
+
+  info.box =
+    document.getElementById('additional-names-box');
+
+  info.links =
+    document.querySelectorAll('a[href="#additional-names-box"]');
+
+  info.mainContentContainer =
+    document.querySelector('#content .main-content-container');
+}
+
+function addAdditionalNamesBoxInternalListeners() {
+  const info = additionalNamesBoxInfo;
+
+  hashLinkInfo.event.beforeHashLinkScrolls.push(({target}) => {
+    if (target === info.box) {
+      return false;
+    }
+  });
+}
+
+function addAdditionalNamesBoxListeners() {
+  const info = additionalNamesBoxInfo;
+
+  for (const link of info.links) {
+    link.addEventListener('click', domEvent => {
+      handleAdditionalNamesBoxLinkClicked(domEvent);
+    });
+  }
+}
+
+function handleAdditionalNamesBoxLinkClicked(domEvent) {
+  const info = additionalNamesBoxInfo;
+  const {state} = info;
+
+  domEvent.preventDefault();
+
+  if (!info.box || !info.mainContentContainer) return;
+
+  const margin =
+    +(cssProp(info.box, 'scroll-margin-top').replace('px', ''));
+
+  const {top} =
+    (state.visible
+      ? info.box.getBoundingClientRect()
+      : info.mainContentContainer.getBoundingClientRect());
+
+  if (top + 20 < margin || top > 0.4 * window.innerHeight) {
+    if (!state.visible) {
+      toggleAdditionalNamesBox();
+    }
+
+    window.scrollTo({
+      top: window.scrollY + top - margin,
+      behavior: 'smooth',
+    });
+  } else {
+    toggleAdditionalNamesBox();
+  }
+}
+
+function toggleAdditionalNamesBox() {
+  const info = additionalNamesBoxInfo;
+  const {state} = info;
+
+  state.visible = !state.visible;
+  info.box.style.display =
+    (state.visible
+      ? 'block'
+      : 'none');
+}
+
+clientSteps.getPageReferences.push(getAdditionalNamesBoxReferences);
+clientSteps.addInternalListeners.push(addAdditionalNamesBoxInternalListeners);
+clientSteps.addPageListeners.push(addAdditionalNamesBoxListeners);
+
 // Group contributions table ------------------------------
 
 const groupContributionsTableInfo =

--- a/src/static/site5.css
+++ b/src/static/site5.css
@@ -802,6 +802,68 @@ html[data-url-key="localized.listing"][data-url-value0="random"] #content a:not(
   opacity: 0.7;
 }
 
+/* Additional names (heading and box) */
+
+h1 a[href="#additional-names-box"] {
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+}
+
+h1 a[href="#additional-names-box"]:hover {
+  text-decoration-style: solid;
+}
+
+#additional-names-box {
+  --custom-scroll-offset: calc(0.5em - 2px);
+
+  margin: 1em 0 1em -10px;
+  padding: 15px 20px 10px 20px;
+  width: max-content;
+  max-width: min(60vw, 600px);
+
+  border: 1px dotted var(--primary-color);
+  border-radius: 6px;
+
+  background:
+    linear-gradient(var(--bg-color), var(--bg-color)),
+    linear-gradient(#000000bb, #000000bb),
+    var(--primary-color);
+
+  box-shadow: 0 -2px 6px -1px var(--dim-color) inset;
+
+  display: none;
+}
+
+#additional-names-box > :first-child { margin-top: 0; }
+#additional-names-box > :last-child { margin-bottom: 0; }
+
+#additional-names-box p {
+  padding-left: 10px;
+  padding-right: 10px;
+  margin-bottom: 0;
+  font-style: oblique;
+}
+
+#additional-names-box ul {
+  padding-left: 10px;
+  margin-top: 0.5em;
+}
+
+#additional-names-box li .additional-name {
+  margin-right: 0.25em;
+}
+
+#additional-names-box li .additional-name .content-image {
+  margin-bottom: 0.25em;
+  margin-top: 0.5em;
+}
+
+#additional-names-box li .annotation {
+  opacity: 0.8;
+  display: inline-block;
+}
+
 /* Images */
 
 .image-container {
@@ -1757,6 +1819,10 @@ html[data-language-code="preview-en"][data-url-key="localized.home"] #content
   #cover-art-container {
     margin: 25px 0 5px 0;
     width: 100%;
+    max-width: unset;
+  }
+
+  #additional-names-box {
     max-width: unset;
   }
 

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -338,6 +338,21 @@ trackList:
 #
 misc:
 
+  # additionalNames:
+  #   "Drop"-styled box that catalogues a variety of additional or
+  #   alternate names for the current thing; toggled by clicking on the
+  #   thing's title, which is styled interactively and gets a tooltip
+  #   (hover text), since it isn't usually an interactive element.
+
+  additionalNames:
+    title: "Additional or alternate names:"
+    tooltip: "Click to view additional or alternate names"
+
+    item:
+      _: "{NAME}"
+      withAnnotation: "{NAME} {ANNOTATION}"
+      annotation: "({ANNOTATION})"
+
   # alt:
   #   Fallback text for the alt text of images and artworks - these
   #   are read aloud by screen readers.


### PR DESCRIPTION
Snazzy! This PR adds a new `Additional Names` field to various classes of data objects, which is written similarly to the "who (what)" format for contributions, and adds a neat box presenting those details on corresponding pages:

<img width="560" alt="Fuchsia Ruler, thin layout - a subtly glowing, round-corner box beneath the cover art is titled: 'Additional or alternate names:' and has two items: 'Witc)(ing )(our (contest-submitted name)' and 'Witching Hour (contest-submitted name, normalized)" src="https://github.com/hsmusic/hsmusic-wiki/assets/9948030/eb4e590e-c9e3-4dab-ba63-7a2017a8e31b">

<img width="639" alt="Iron Knight, medium layout: a similar box, glowing grey to match the track, spans spans beneath the cover art floating on the right, and reads: Additional or alternate names: Caw Caw Motherfuckers (contest-submitted name)" src="https://github.com/hsmusic/hsmusic-wiki/assets/9948030/4bb80885-b3e9-48c3-be74-6269d0d4d9b1">

Development:

* Resolves #103!

User-visible changes:

* The new "additional or alternate names" box!
  * This is invisible by default, and shown when the title text is clicked. Since the title isn't necessarily an element you expect to be interactive, it gets both the standard-fare [dotted underline](https://github.com/hsmusic/hsmusic-wiki/issues/211) *and* a tooltip. (This should probably be expanded to other interactive elements, but it's particularly useful here.)
  * Clicking the title text will usually toggle the visibility of the additional names box, but if it's offscreen or most of the way down the screen, clicking will always show the box (rather than toggle it) and smoothly scroll it into view. Clicking again will toggle the box closed.
  * This box is loosely styled off of macOS and iOS notifications, which it certainly isn't *exactly* the same kind of element as, but shares an "ethereal" quality with - it's something that can appear or disappear and whose presence is something you have control over. Thus the rounded corners, frosty appearance, and generally "touchable" look (it has a light faux-3D glowing effect!).
* Additional names aren't used for *anything* else, just yet - they're treated as purely extra text. That said, there *is* room to integrate these into, for example, "by Name" style listings, or an altogether alternate view for the track list on the album page...
* Additional names are entered into the `Additional Names` field in much the same format as artist contributions - name, optionally plus annotation in parentheses.
  * This [should be ordered](https://github.com/hsmusic/hsmusic-data/issues/353) after the name (e.g. `Track`) *and* directory fields, but otherwise should precede anything else (usually artists).
  * While this format is familiar and works a lot of the time, it isn't necessarily the *best* fit... it's challenging to include, for example, an alternate name "Savior of the Dreaming Dead (Blaze Remix)" with annotation "beta title" because the "Blaze Remix" part could be interpreted as the annotation.
  * So you can *also* represent alternate names in an object-structured format: `Name: Savior of the Dreaming Dead (Blaze Remix)`, `Annotation: beta title`. Cool!
  * This goes for artist contributions too, e.g. `Who: Toby Fox`, `What: arrangement`. It just doesn't come up nearly so often there, part because `artist:foo-bar-baz` lets you get around `Foo (Bar Baz)` type syntax already.

Supporting internal changes:

* New `additionalNameList` wiki property, plus `isAdditionalNameList` validator - this titling is intended to be in line with e.g. `isContributionList`, `isAdditionalFileList`.
* The `parseContributors` function in yaml.js is generally refactored - the regular expression it works with is now on its own, since it's used by the new `parseAdditionalNames`, and is touched up with named capturing groups, for better regex form.
* The additional names box is generated by the page definition but slotted into `generatePageLayout`, much the same as cover art, and the automatically generated title heading (whether sticky or not) adapts to be interactive if that slot is filled.
* On the client, the hash links code gets a new internal event, `beforeHashLinkScrolls` - if any of its listeners returns false (exactly), the hash scrolling behavior is completely cancelled and it's up to a separate DOM `click` event listener to control click behavior (if custom behavior is desired at all).
* Notably, both pieces of data-specified text in additional names are processed with `transformInline` for display purposes. This allows [some ridiculosity](https://nebula.ed1.club/stuff/ijo/hsmusic-bowsette.mp4) as well as, for example, Markdown-formatted links or `[[string]]` content tags in the annotation - but *will* cause some trouble for treating these as ordinary text data down the line (e.g. for sorting purposes). It's a low stakes place to mess around since most of the benefit of "additional names" is just getting to see them on the info page for the thing they belong to.