### PR TITLE
Transition tooltips hidden + related style changes

### DIFF
--- a/src/static/client3.js
+++ b/src/static/client3.js
@@ -792,9 +792,12 @@ function beginTransitioningTooltipHidden(tooltip) {
   cssProp(tooltip, {
     'display': 'block',
     'opacity': '0',
+
     'transition-property': 'opacity',
-    'transition-timing-function': 'linear',
-    'transition-duration': `${settings.transitionHiddenDuration / 1000}s`,
+    'transition-timing-function':
+      `steps(${Math.ceil(settings.transitionHiddenDuration / 60)}, end)`,
+    'transition-duration':
+      `${settings.transitionHiddenDuration / 1000}s`,
   });
 
   state.currentlyTransitioningHiddenTooltip = tooltip;

--- a/src/static/client3.js
+++ b/src/static/client3.js
@@ -443,11 +443,6 @@ const hoverableTooltipInfo = clientInfo.hoverableTooltipInfo = {
     currentTouchIdentifiers: new Set(),
     touchIdentifiersBanishedByScrolling: new Set(),
   },
-
-  event: {
-    whenTooltipShouldBeShown: [],
-    whenTooltipShouldBeHidden: [],
-  },
 };
 
 // Adds DOM event listeners, so must be called during addPageListeners step.
@@ -856,6 +851,9 @@ function hideCurrentlyShownTooltip(intendingToReplace = false) {
     beginTransitioningTooltipHidden(state.currentlyShownTooltip);
   }
 
+  tooltip.classList.remove('visible');
+  tooltip.inert = true;
+
   state.currentlyShownTooltip = null;
   state.currentlyActiveHoverable = null;
 
@@ -864,8 +862,6 @@ function hideCurrentlyShownTooltip(intendingToReplace = false) {
   setTimeout(() => {
     state.tooltipWasJustHidden = false;
   });
-
-  dispatchInternalEvent(event, 'whenTooltipShouldBeHidden', {tooltip});
 
   return true;
 }
@@ -883,13 +879,13 @@ function showTooltipFromHoverable(hoverable) {
   }
 
   hoverable.classList.add('has-visible-tooltip');
+  tooltip.classList.add('visible');
+  tooltip.inert = false;
 
   state.currentlyShownTooltip = tooltip;
   state.currentlyActiveHoverable = hoverable;
 
   state.tooltipWasJustHidden = false;
-
-  dispatchInternalEvent(event, 'whenTooltipShouldBeShown', {hoverable, tooltip});
 
   return true;
 }
@@ -1979,30 +1975,6 @@ function getExternalIconTooltipReferences() {
       .map(span => span.querySelector('span.icons-tooltip'));
 }
 
-function addExternalIconTooltipInternalListeners() {
-  const info = externalIconTooltipInfo;
-
-  hoverableTooltipInfo.event.whenTooltipShouldBeShown.push(({tooltip}) => {
-    if (!info.iconContainers.includes(tooltip)) return;
-    showExternalIconTooltip(tooltip);
-  });
-
-  hoverableTooltipInfo.event.whenTooltipShouldBeHidden.push(({tooltip}) => {
-    if (!info.iconContainers.includes(tooltip)) return;
-    hideExternalIconTooltip(tooltip);
-  });
-}
-
-function showExternalIconTooltip(iconContainer) {
-  iconContainer.classList.add('visible');
-  iconContainer.inert = false;
-}
-
-function hideExternalIconTooltip(iconContainer) {
-  iconContainer.classList.remove('visible');
-  iconContainer.inert = true;
-}
-
 function addExternalIconTooltipPageListeners() {
   const info = externalIconTooltipInfo;
 
@@ -2016,7 +1988,6 @@ function addExternalIconTooltipPageListeners() {
 }
 
 clientSteps.getPageReferences.push(getExternalIconTooltipReferences);
-clientSteps.addInternalListeners.push(addExternalIconTooltipInternalListeners);
 clientSteps.addPageListeners.push(addExternalIconTooltipPageListeners);
 
 /*

--- a/src/static/client3.js
+++ b/src/static/client3.js
@@ -63,8 +63,25 @@ function pick(array) {
   return array[Math.floor(Math.random() * array.length)];
 }
 
-function cssProp(el, key) {
-  return getComputedStyle(el).getPropertyValue(key).trim();
+function cssProp(el, ...args) {
+  if (typeof args[0] === 'string' && args.length === 1) {
+    return getComputedStyle(el).getPropertyValue(args[0]).trim();
+  }
+
+  if (typeof args[0] === 'string' && args.length === 2) {
+    if (args[1] === null) {
+      el.style.removeProperty(args[0]);
+    } else {
+      el.style.setProperty(args[0], args[1]);
+    }
+    return;
+  }
+
+  if (typeof args[0] === 'object') {
+    for (const [property, value] of Object.entries(args[0])) {
+      cssProp(el, property, value);
+    }
+  }
 }
 
 // TODO: These should pro8a8ly access some shared urlSpec path. We'd need to
@@ -772,9 +789,13 @@ function beginTransitioningTooltipHidden(tooltip) {
     cancelTransitioningTooltipHidden();
   }
 
-  tooltip.classList.add('transition-tooltip-hidden');
-  tooltip.style.transitionDuration =
-    `${settings.transitionHiddenDuration / 1000}s`;
+  cssProp(tooltip, {
+    'display': 'block',
+    'opacity': '0',
+    'transition-property': 'opacity',
+    'transition-timing-function': 'linear',
+    'transition-duration': `${settings.transitionHiddenDuration / 1000}s`,
+  });
 
   state.currentlyTransitioningHiddenTooltip = tooltip;
   state.transitionHiddenTimeout =
@@ -800,8 +821,13 @@ function endTransitioningTooltipHidden() {
 
   if (!tooltip) return;
 
-  tooltip.classList.remove('transition-tooltip-hidden');
-  tooltip.style.removeProperty('transition-duration');
+  cssProp(tooltip, {
+    'display': null,
+    'opacity': null,
+    'transition-property': null,
+    'transition-timing-function': null,
+    'transition-duration': null,
+  });
 
   state.currentlyTransitioningHiddenTooltip = null;
 }

--- a/src/static/client3.js
+++ b/src/static/client3.js
@@ -847,11 +847,11 @@ function hideCurrentlyShownTooltip(intendingToReplace = false) {
   // apparent in the interaction, and should be hidden with a transition.
   if (intendingToReplace) {
     cancelTransitioningTooltipHidden();
+    cssProp(tooltip, 'display', 'none');
   } else {
     beginTransitioningTooltipHidden(state.currentlyShownTooltip);
   }
 
-  tooltip.classList.remove('visible');
   tooltip.inert = true;
 
   state.currentlyShownTooltip = null;
@@ -879,7 +879,8 @@ function showTooltipFromHoverable(hoverable) {
   }
 
   hoverable.classList.add('has-visible-tooltip');
-  tooltip.classList.add('visible');
+
+  cssProp(tooltip, 'display', 'block');
   tooltip.inert = false;
 
   state.currentlyShownTooltip = tooltip;

--- a/src/static/client3.js
+++ b/src/static/client3.js
@@ -383,6 +383,10 @@ const hoverableTooltipInfo = clientInfo.hoverableTooltipInfo = {
     focusInfoDelay: 750,
 
     hideTooltipDelay: 500,
+
+    // If a tooltip that's transitioning to hidden is hovered, it'll cancel
+    // out of this animation immediately.
+    transitionHiddenDuration: 300,
   },
 
   state: {
@@ -399,8 +403,10 @@ const hoverableTooltipInfo = clientInfo.hoverableTooltipInfo = {
     focusTimeout: null,
     touchTimeout: null,
     hideTimeout: null,
+    transitionHiddenTimeout: null,
     currentlyShownTooltip: null,
     currentlyActiveHoverable: null,
+    currentlyTransitioningHiddenTooltip: null,
     tooltipWasJustHidden: false,
     hoverableWasRecentlyTouched: false,
 
@@ -548,21 +554,36 @@ function handleTooltipReceivedFocus(tooltip) {
 function handleTooltipLostFocus(tooltip) {
   const {settings, state} = hoverableTooltipInfo;
 
-  // Hide the current tooltip right away when it loses focus.
-  hideCurrentlyShownTooltip();
+  // Hide the current tooltip right away when it loses focus. Specify intent
+  // to replace - while we don't strictly know if another tooltip is going to
+  // immediately replace it, the mode of navigating with tab focus (once one
+  // tooltip has been activated) is a "switch focus immediately" kind of
+  // interaction in its nature.
+  hideCurrentlyShownTooltip(true);
 }
 
 function handleTooltipHoverableMouseEntered(hoverable) {
   const {event, settings, state} = hoverableTooltipInfo;
+  const {tooltip} = state.registeredHoverables.get(hoverable);
+
+  // If this tooltip was transitioning to hidden, hovering should cancel that
+  // animation and show it immediately.
+
+  if (tooltip === state.currentlyTransitioningHiddenTooltip) {
+    cancelTransitioningTooltipHidden();
+    showTooltipFromHoverable(hoverable);
+    return;
+  }
+
+  // Start a timer to show the corresponding tooltip, with the delay depending
+  // on whether fast hovering or not. This could be canceled by mousing out of
+  // the hoverable.
 
   const hoverTimeoutDelay =
     (state.fastHovering
       ? settings.fastHoveringInfoDelay
       : settings.normalHoverInfoDelay);
 
-  // Start a timer to show the corresponding tooltip, with the delay depending
-  // on whether fast hovering or not. This could be canceled by mousing out of
-  // the hoverable.
   state.hoverTimeout =
     setTimeout(() => {
       state.hoverTimeout = null;
@@ -650,9 +671,10 @@ function handleTooltipHoverableLostFocus(hoverable, domEvent) {
 
   // Unless focus is entering the tooltip itself, hide the tooltip immediately.
   // This will set the tooltipWasJustHidden flag, which is detected by a newly
-  // focused hoverable, if applicable.
+  // focused hoverable, if applicable. Always specify intent to replace when
+  // navigating via tab focus. (Check `handleTooltipLostFocus` for details.)
   if (!currentlyShownTooltipHasFocus(domEvent.relatedTarget)) {
-    hideCurrentlyShownTooltip();
+    hideCurrentlyShownTooltip(true);
   }
 }
 
@@ -743,7 +765,48 @@ function currentlyShownTooltipHasFocus(focusElement = document.activeElement) {
   return false;
 }
 
-function hideCurrentlyShownTooltip() {
+function beginTransitioningTooltipHidden(tooltip) {
+  const {settings, state} = hoverableTooltipInfo;
+
+  if (state.currentlyTransitioningHiddenTooltip) {
+    cancelTransitioningTooltipHidden();
+  }
+
+  tooltip.classList.add('transition-tooltip-hidden');
+  tooltip.style.transitionDuration =
+    `${settings.transitionHiddenDuration / 1000}s`;
+
+  state.currentlyTransitioningHiddenTooltip = tooltip;
+  state.transitionHiddenTimeout =
+    setTimeout(() => {
+      endTransitioningTooltipHidden();
+    }, settings.transitionHiddenDuration);
+}
+
+function cancelTransitioningTooltipHidden() {
+  const {state} = hoverableTooltipInfo;
+
+  endTransitioningTooltipHidden();
+
+  if (state.transitionHiddenTimeout) {
+    clearTimeout(state.transitionHiddenTimeout);
+    state.transitionHiddenTimeout = null;
+  }
+}
+
+function endTransitioningTooltipHidden() {
+  const {state} = hoverableTooltipInfo;
+  const {currentlyTransitioningHiddenTooltip: tooltip} = state;
+
+  if (!tooltip) return;
+
+  tooltip.classList.remove('transition-tooltip-hidden');
+  tooltip.style.removeProperty('transition-duration');
+
+  state.currentlyTransitioningHiddenTooltip = null;
+}
+
+function hideCurrentlyShownTooltip(intendingToReplace = false) {
   const {event, state} = hoverableTooltipInfo;
   const {currentlyShownTooltip: tooltip} = state;
 
@@ -755,6 +818,14 @@ function hideCurrentlyShownTooltip() {
   if (currentlyShownTooltipHasFocus()) return false;
 
   state.currentlyActiveHoverable.classList.remove('has-visible-tooltip');
+
+  // If there's no intent to replace this tooltip, it's the last one currently
+  // apparent in the interaction, and should be hidden with a transition.
+  if (intendingToReplace) {
+    cancelTransitioningTooltipHidden();
+  } else {
+    beginTransitioningTooltipHidden(state.currentlyShownTooltip);
+  }
 
   state.currentlyShownTooltip = null;
   state.currentlyActiveHoverable = null;
@@ -774,7 +845,13 @@ function showTooltipFromHoverable(hoverable) {
   const {event, state} = hoverableTooltipInfo;
   const {tooltip} = state.registeredHoverables.get(hoverable);
 
-  if (!hideCurrentlyShownTooltip()) return false;
+  if (!hideCurrentlyShownTooltip(true)) return false;
+
+  // Cancel out another tooltip that's transitioning hidden, if that's going
+  // on - it's a distraction that this tooltip is now replacing.
+  if (state.currentlyTransitioningHiddenTooltip) {
+    cancelTransitioningTooltipHidden();
+  }
 
   hoverable.classList.add('has-visible-tooltip');
 

--- a/src/static/client3.js
+++ b/src/static/client3.js
@@ -754,6 +754,8 @@ function hideCurrentlyShownTooltip() {
   // Never hide the tooltip if it's focused.
   if (currentlyShownTooltipHasFocus()) return false;
 
+  state.currentlyActiveHoverable.classList.remove('has-visible-tooltip');
+
   state.currentlyShownTooltip = null;
   state.currentlyActiveHoverable = null;
 
@@ -773,6 +775,8 @@ function showTooltipFromHoverable(hoverable) {
   const {tooltip} = state.registeredHoverables.get(hoverable);
 
   if (!hideCurrentlyShownTooltip()) return false;
+
+  hoverable.classList.add('has-visible-tooltip');
 
   state.currentlyShownTooltip = tooltip;
   state.currentlyActiveHoverable = hoverable;

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -498,9 +498,6 @@ a:not([href]):hover {
   left: -34px;
   top: calc(1em + 1px);
   padding: 3px 6px 6px 6px;
-}
-
-.icons-tooltip:not(.visible) {
   display: none;
 }
 

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -482,6 +482,11 @@ a:not([href]):hover {
   text-decoration-style: dotted;
 }
 
+.contribution.has-tooltip > a:hover,
+.contribution.has-tooltip > a.has-visible-tooltip {
+  text-decoration-style: wavy !important;
+}
+
 .icons {
   font-style: normal;
   white-space: nowrap;

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -504,6 +504,14 @@ a:not([href]):hover {
   display: none;
 }
 
+.icons-tooltip:not(.visible).transition-tooltip-hidden {
+  display: block !important;
+  opacity: 0;
+
+  transition-property: opacity;
+  transition-timing-function: linear;
+}
+
 .icons-tooltip-content {
   display: block;
   padding: 6px 2px 2px 2px;

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -504,14 +504,6 @@ a:not([href]):hover {
   display: none;
 }
 
-.icons-tooltip:not(.visible).transition-tooltip-hidden {
-  display: block !important;
-  opacity: 0;
-
-  transition-property: opacity;
-  transition-timing-function: linear;
-}
-
 .icons-tooltip-content {
   display: block;
   padding: 6px 2px 2px 2px;

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -490,9 +490,9 @@ a:not([href]):hover {
 .icons-tooltip {
   position: absolute;
   z-index: 3;
-  left: -36px;
-  top: calc(1em - 2px);
-  padding: 4px 12px 6px 8px;
+  left: -34px;
+  top: calc(1em + 1px);
+  padding: 3px 6px 6px 6px;
 }
 
 .icons-tooltip:not(.visible) {


### PR DESCRIPTION
This PR tweaks and polishes tooltips, mostly to do with hovering. Details:

* The padding box around tooltips is slightly contracted, so there's less surrounding "ghost" space where hovering will keep a tooltip visible instead of interacting with whatever's beneath. This space was more necessary when tooltips were a fairly small element and only occupied a fairly short vertical space. A little is still good, but more makes it awkward to get to links that aren't quite all the way covered.
* Tooltip links are now styled with a wavy underline, instead of straight, when hovered. This is to differentiate the interaction from other dotted underlines, which expect a click rather than a hover to access the "unusual" behavior. Interaction cues might still use some experimenting to get quite right...
* When interacting via hover, tooltips now transition to zero opacity (when not being replaced by another tooltip), rather than hiding immediately. This transition can be interrupted at any point, showing the tooltip at full opacity, by hovering over the hoverable (i.e. artist link). It can also be canceled, for a short "grace" period, by hovering over the tooltip itself; after the grace period, the tooltip goes inert.

Supporting internal changes:

* The utility function `cssProp` is reworked to allow setting and removing CSS properties (including multiple at a time).
* The internal tooltip system interacts much more directly with page elements - insofar as its impact is minimal and always clearly defined, anyway. Rather than going through an internal listener which itself interacts with the element both directly (setting `inert`) and indirectly (setting a `.visible` CSS class), now all changes are direct: the contained system sets appropriate CSS properties and the `inert` property all on its own, and the corresponding internal events are removed.
  * This makes the interface for adding new tooltips simpler in JavaScript (you only need to register tooltips and hoverables, no more event listening)...
  * As well as in CSS (no need for a supporting `.visible` class, let alone transition details - just specify `display: none` as the default state and the tooltip is good to go).
  * It makes behavior more reliably consistent, so it's reasonable to directly manipulate `inert` to implement e.g. the transition-hidden grace period.
  * And, it gives more direct (and better warranted) access to CSS property values, like tweaking the transition-hidden duration and easing.
