### PR TITLE
Restrict albums' own track reference resolving to a static subset of trackData

### DIFF
--- a/src/data/composite/things/album/withTrackSections.js
+++ b/src/data/composite/things/album/withTrackSections.js
@@ -22,7 +22,7 @@ export default templateCompositeFrom({
 
   steps: () => [
     exitWithoutDependency({
-      dependency: 'trackData',
+      dependency: 'ownTrackData',
       value: input.value([]),
     }),
 
@@ -75,7 +75,7 @@ export default templateCompositeFrom({
 
     withResolvedReferenceList({
       list: '#trackRefs',
-      data: 'trackData',
+      data: 'ownTrackData',
       notFoundMode: input.value('null'),
       find: input.value(find.track),
     }).outputs({

--- a/src/data/composite/things/album/withTracks.js
+++ b/src/data/composite/things/album/withTracks.js
@@ -12,7 +12,7 @@ export default templateCompositeFrom({
 
   steps: () => [
     exitWithoutDependency({
-      dependency: 'trackData',
+      dependency: 'ownTrackData',
       value: input.value([]),
     }),
 
@@ -35,7 +35,7 @@ export default templateCompositeFrom({
 
     withResolvedReferenceList({
       list: '#trackRefs',
-      data: 'trackData',
+      data: 'ownTrackData',
       find: input.value(find.track),
     }),
 

--- a/src/data/things/album.js
+++ b/src/data/things/album.js
@@ -133,7 +133,10 @@ export class Album extends Thing {
       class: input.value(Group),
     }),
 
-    trackData: wikiData({
+    // Only the tracks which belong to this album.
+    // Necessary for computing the track list, so provide this statically
+    // or keep it updated.
+    ownTrackData: wikiData({
       class: input.value(Track),
     }),
 

--- a/src/data/things/track.js
+++ b/src/data/things/track.js
@@ -331,12 +331,21 @@ export class Track extends Thing {
     }
 
     let album;
-    if (depth >= 0 && (album = this.album ?? this.dataSourceAlbum)) {
+
+    if (depth >= 0) {
+      try {
+        album = this.album;
+      } catch (_error) {}
+
+      album ??= this.dataSourceAlbum;
+    }
+
+    if (album) {
       const albumName = album.name;
       const albumIndex = album.tracks.indexOf(this);
       const trackNum =
         (albumIndex === -1
-          ? '#?'
+          ? 'indeterminate position'
           : `#${albumIndex + 1}`);
       parts.push(` (${colors.yellow(trackNum)} in ${colors.green(albumName)})`);
     }

--- a/src/data/yaml.js
+++ b/src/data/yaml.js
@@ -936,6 +936,7 @@ export const dataSteps = [
         // an individual section before applying it, since those are just
         // generic objects; they aren't Things in and of themselves.)
         const trackSections = [];
+        const ownTrackData = [];
 
         let currentTrackSection = {
           name: `Default Track Section`,
@@ -970,13 +971,16 @@ export const dataSteps = [
 
           entry.dataSourceAlbum = albumRef;
 
+          ownTrackData.push(entry);
           currentTrackSection.tracks.push(Thing.getReference(entry));
         }
 
         closeCurrentTrackSection();
 
-        album.trackSections = trackSections;
         albumData.push(album);
+
+        album.trackSections = trackSections;
+        album.ownTrackData = ownTrackData;
       }
 
       return {albumData, trackData};
@@ -1551,7 +1555,7 @@ export function linkWikiDataArrays(wikiData, {
 
   assignWikiData([WD.wikiInfo], 'groupData');
 
-  assignWikiData(WD.albumData, 'artistData', 'artTagData', 'groupData', 'trackData');
+  assignWikiData(WD.albumData, 'artistData', 'artTagData', 'groupData');
   assignWikiData(WD.trackData, 'albumData', 'artistData', 'artTagData', 'flashData', 'trackData');
   assignWikiData(WD.artistData, 'albumData', 'artistData', 'flashData', 'trackData');
   assignWikiData(WD.groupData, 'albumData', 'groupCategoryData');

--- a/src/data/yaml.js
+++ b/src/data/yaml.js
@@ -1625,8 +1625,7 @@ export function filterDuplicateDirectories(wikiData) {
         call(() => {
           throw new Error(
             `Duplicate directory ${colors.green(directory)}:\n` +
-              places.map((thing) => ` - ` + inspect(thing)).join('\n')
-          );
+            places.map(thing => ` - ` + inspect(thing)).join('\n'));
         });
       }
 

--- a/src/util/sugar.js
+++ b/src/util/sugar.js
@@ -589,6 +589,32 @@ export function _withAggregate(mode, aggregateOpts, fn) {
   }
 }
 
+export const unhelpfulStackLines = [
+  /sugar/,
+  /node:/,
+  /<anonymous>/,
+];
+
+export function getUsefulStackLine(stack) {
+  if (!stack) return '';
+
+  function isUseful(stackLine) {
+    const trimmed = stackLine.trim();
+
+    if (!trimmed.startsWith('at'))
+      return false;
+
+    if (unhelpfulStackLines.some(regex => regex.test(trimmed)))
+      return false;
+
+    return true;
+  }
+
+  const stackLines = stack.split('\n');
+  const usefulStackLine = stackLines.find(isUseful);
+  return usefulStackLine ?? '';
+}
+
 export function showAggregate(topError, {
   pathToFileURL = f => f,
   showTraces = true,
@@ -670,15 +696,8 @@ export function showAggregate(topError, {
         : messagePart);
 
     if (showTraces) {
-      const stackLines =
-        stack?.split('\n');
-
       const stackLine =
-        stackLines?.find(line =>
-          line.trim().startsWith('at') &&
-          !line.includes('sugar') &&
-          !line.includes('node:') &&
-          !line.includes('<anonymous>'));
+        getUsefulStackLine(stack);
 
       const tracePart =
         (stackLine

--- a/test/unit/data/things/album.js
+++ b/test/unit/data/things/album.js
@@ -204,11 +204,13 @@ t.test(`Album.tracks`, t => {
   const track1 = stubTrack('track1');
   const track2 = stubTrack('track2');
   const track3 = stubTrack('track3');
+  const tracks = [track1, track2, track3];
 
-  linkAndBindWikiData({
-    albumData: [album],
-    trackData: [track1, track2, track3],
-  });
+  album.ownTrackData = tracks;
+
+  for (const track of tracks) {
+    track.albumData = [album];
+  }
 
   t.same(album.tracks, [],
     `Album.tracks #1: defaults to empty array`);
@@ -259,11 +261,13 @@ t.test(`Album.trackSections`, t => {
   const track2 = stubTrack('track2');
   const track3 = stubTrack('track3');
   const track4 = stubTrack('track4');
+  const tracks = [track1, track2, track3, track4];
 
-  linkAndBindWikiData({
-    albumData: [album],
-    trackData: [track1, track2, track3, track4],
-  });
+  album.ownTrackData = tracks;
+
+  for (const track of tracks) {
+    track.albumData = [album];
+  }
 
   album.trackSections = [
     {tracks: ['track:track1', 'track:track2']},

--- a/test/unit/data/things/track.js
+++ b/test/unit/data/things/track.js
@@ -80,8 +80,8 @@ t.test(`Track.album`, t => {
 
   track1.albumData = [album1, album2];
   track2.albumData = [album1, album2];
-  album1.trackData = [track1, track2];
-  album2.trackData = [track1, track2];
+  album1.ownTrackData = [track1, track2];
+  album2.ownTrackData = [track1, track2];
   album1.trackSections = [{tracks: ['track:track1']}];
   album2.trackSections = [{tracks: ['track:track2']}];
 
@@ -98,13 +98,13 @@ t.test(`Track.album`, t => {
   t.equal(track1.album, null,
     `album #4: is null when track missing albumData`);
 
-  album1.trackData = [];
+  album1.ownTrackData = [];
   track1.albumData = [album1, album2];
 
   t.equal(track1.album, null,
-    `album #5: is null when album missing trackData`);
+    `album #5: is null when album missing ownTrackData`);
 
-  album1.trackData = [track1, track2];
+  album1.ownTrackData = [track1, track2];
   album1.trackSections = [{tracks: ['track:track2']}];
 
   // XXX_decacheWikiData
@@ -165,7 +165,7 @@ t.test(`Track.color`, t => {
 
   const {track, album} = stubTrackAndAlbum();
 
-  const {wikiData, linkWikiDataArrays, XXX_decacheWikiData} = linkAndBindWikiData({
+  const {XXX_decacheWikiData} = linkAndBindWikiData({
     albumData: [album],
     trackData: [track],
   });
@@ -188,7 +188,7 @@ t.test(`Track.color`, t => {
   // track's album will always have a corresponding track section. But if that
   // connection breaks for some future reason (with the album still present),
   // Track.color should still inherit directly from the album.
-  wikiData.albumData = [
+  track.albumData = [
     {
       constructor: {[Thing.referenceType]: 'album'},
       color: '#abcdef',
@@ -198,8 +198,6 @@ t.test(`Track.color`, t => {
       ],
     },
   ];
-
-  linkWikiDataArrays();
 
   t.equal(track.color, '#abcdef',
     `color #3: inherits from album without matching track section`);


### PR DESCRIPTION
Development:

* Fixes #298 - hopefully!

This PR attempts to make track inspection, used in the REPL and (importantly) in error reporting, more resilient.

Details:

* The album part (i.e. album name and track number) falls back to `dataSourceAlbum` more reliably: now `track.album` failing to evaluate (for any reason, but the easiest inflictor is bugs in `album.tracks`) will also be cause for falling back, in addition to `track.album` just returning null/undefined.
* Albums now search only a static, externally provided subset of `trackData` for their tracks. The implementation isn't functionally different, apart from `trackData` being renamed to `ownTrackData`; but, externally, that array must/should now be provided as including only the relevant tracks for this album. That's not something the album itself is capable of identifying, by nature, so keeping track is an external job.
* Accordingly, YAML parsing now keeps a list of all the track entries in an album file, and the initial data processing is now responsible for providing `ownTrackData`, rather than `linkWikiDataArrays` just providing the wiki-wide `trackData` list at once.
* In order to keep test logic clean, the testing library's `linkAndBindWikiData` function now handles inferring and binding `ownWikiData` on its own - this is the same underlying behavior as before, only moving the `find.track` calls out of `withTracks`/`withTrackSection` and into testing infrastructure. However, some caveats:
  * Because inference directly accesses the update value of `trackSections`, it's not suitable for mock albums.
  * Likewise, inference only accesses the *current* update value, not any potential future ones. It tries to be smart about providing only the relevant subset of `trackData`, more closely simulating a real-world environment. Thus it's necessary to re-call `linkAndBindWikiData` after setting updated `trackSections`, or else handle data linking manually.
  * Inference can be outright disabled by providing `{inferAlbumsOwnTrackData: false}`, though since the relevant test cases only work with albums and tracks anyway, it was preferred to just link everything manually.