### PR TITLE
Datetimestamp tooltips!

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.1.0",
             "license": "GPL-3.0",
             "dependencies": {
+                "@js-temporal/polyfill": "^0.4.4",
                 "chroma-js": "^2.4.2",
                 "command-exists": "^1.2.9",
                 "eslint": "^8.37.0",
@@ -239,6 +240,18 @@
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.0.3",
                 "@jridgewell/sourcemap-codec": "^1.4.10"
+            }
+        },
+        "node_modules/@js-temporal/polyfill": {
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.4.4.tgz",
+            "integrity": "sha512-2X6bvghJ/JAoZO52lbgyAPFj8uCflhTo2g7nkFzEQdXd/D8rEeD4HtmTEpmtGCva260fcd66YNXBOYdnmHqSOg==",
+            "dependencies": {
+                "jsbi": "^4.3.0",
+                "tslib": "^2.4.1"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -3077,6 +3090,11 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
+        "node_modules/jsbi": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.0.tgz",
+            "integrity": "sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g=="
+        },
         "node_modules/json-parse-even-better-errors": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.0.tgz",
@@ -5231,8 +5249,7 @@
         "node_modules/tslib": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-            "dev": true
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/tuf-js": {
             "version": "2.1.0",
@@ -5876,6 +5893,15 @@
             "requires": {
                 "@jridgewell/resolve-uri": "^3.0.3",
                 "@jridgewell/sourcemap-codec": "^1.4.10"
+            }
+        },
+        "@js-temporal/polyfill": {
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.4.4.tgz",
+            "integrity": "sha512-2X6bvghJ/JAoZO52lbgyAPFj8uCflhTo2g7nkFzEQdXd/D8rEeD4HtmTEpmtGCva260fcd66YNXBOYdnmHqSOg==",
+            "requires": {
+                "jsbi": "^4.3.0",
+                "tslib": "^2.4.1"
             }
         },
         "@nodelib/fs.scandir": {
@@ -7928,6 +7954,11 @@
                 "argparse": "^2.0.1"
             }
         },
+        "jsbi": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.0.tgz",
+            "integrity": "sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g=="
+        },
         "json-parse-even-better-errors": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.0.tgz",
@@ -9473,8 +9504,7 @@
         "tslib": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-            "dev": true
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "tuf-js": {
             "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "node": ">= 20.9.0"
     },
     "dependencies": {
+        "@js-temporal/polyfill": "^0.4.4",
         "chroma-js": "^2.4.2",
         "command-exists": "^1.2.9",
         "eslint": "^8.37.0",

--- a/src/content/dependencies/generateAbsoluteDatetimestamp.js
+++ b/src/content/dependencies/generateAbsoluteDatetimestamp.js
@@ -1,0 +1,41 @@
+export default {
+  contentDependencies: ['generateDatetimestampTemplate'],
+  extraDependencies: ['html', 'language'],
+
+  data: (date) =>
+    ({date}),
+
+  relations: (relation) =>
+    ({template: relation('generateDatetimestampTemplate')}),
+
+  slots: {
+    style: {
+      validate: v => v.is('full', 'year'),
+      default: 'full',
+    },
+
+    // Only has an effect for 'year' style.
+    tooltip: {
+      type: 'boolean',
+      default: false,
+    },
+  },
+
+  generate: (data, relations, slots, {language}) =>
+    relations.template.slots({
+      mainContent:
+        (slots.style === 'full'
+          ? language.formatDate(data.date)
+       : slots.style === 'year'
+          ? data.date.getFullYear().toString()
+          : null),
+
+      tooltipContent:
+        slots.tooltip &&
+        slots.style === 'year' &&
+          language.formatDate(data.date),
+
+      datetime:
+        data.date.toISOString(),
+    }),
+};

--- a/src/content/dependencies/generateColorStyleRules.js
+++ b/src/content/dependencies/generateColorStyleRules.js
@@ -18,9 +18,12 @@ export default {
       `:root {`,
       ...(
         relations.variables
-          .slot('color', slots.color)
+          .slots({
+            color: slots.color,
+            context: 'page-root',
+            mode: 'property-list',
+          })
           .content
-          .split(';')
           .map(line => line + ';')),
       `}`,
     ].join('\n');

--- a/src/content/dependencies/generateColorStyleVariables.js
+++ b/src/content/dependencies/generateColorStyleVariables.js
@@ -2,7 +2,23 @@ export default {
   extraDependencies: ['html', 'getColors'],
 
   slots: {
-    color: {validate: v => v.isColor},
+    color: {
+      validate: v => v.isColor,
+    },
+
+    context: {
+      validate: v => v.is(
+        'any-content',
+        'page-root',
+        'primary-only'),
+
+      default: 'any-content',
+    },
+
+    mode: {
+      validate: v => v.is('style', 'property-list'),
+      default: 'style',
+    },
   },
 
   generate(slots, {getColors}) {
@@ -18,7 +34,7 @@ export default {
       shadow,
     } = getColors(slots.color);
 
-    return [
+    let anyContent = [
       `--primary-color: ${primary}`,
       `--dark-color: ${dark}`,
       `--dim-color: ${dim}`,
@@ -26,6 +42,35 @@ export default {
       `--bg-color: ${bg}`,
       `--bg-black-color: ${bgBlack}`,
       `--shadow-color: ${shadow}`,
-    ].join('; ');
+    ];
+
+    let selectedProperties;
+
+    switch (slots.context) {
+      case 'any-content':
+        selectedProperties = anyContent;
+        break;
+
+      case 'page-root':
+        selectedProperties = [
+          ...anyContent,
+          `--page-primary-color: ${primary}`,
+        ];
+        break;
+
+      case 'primary-only':
+        selectedProperties = [
+          `--primary-color: ${primary}`,
+        ];
+        break;
+    }
+
+    switch (slots.mode) {
+      case 'style':
+        return selectedProperties.join('; ');
+
+      case 'property-list':
+        return selectedProperties;
+    }
   },
 };

--- a/src/content/dependencies/generateDatetimestampTemplate.js
+++ b/src/content/dependencies/generateDatetimestampTemplate.js
@@ -1,0 +1,28 @@
+export default {
+  extraDependencies: ['html'],
+
+  slots: {
+    mainContent: {type: 'html'},
+    tooltipContent: {type: 'html'},
+    datetime: {type: 'string'},
+  },
+
+  generate: (slots, {html}) =>
+    html.tag('span', {
+      [html.joinChildren]: '',
+
+      class: [
+        'datetimestamp',
+        slots.tooltipContent && 'has-tooltip',
+      ],
+    }, [
+      html.tag('time',
+        {datetime: slots.datetime},
+        slots.mainContent),
+
+      slots.tooltipContent &&
+        html.tag('span', {class: 'datetimestamp-tooltip'},
+          html.tag('span', {class: 'datetimestamp-tooltip-content'},
+            slots.tooltipContent)),
+    ]),
+};

--- a/src/content/dependencies/generateGroupInfoPage.js
+++ b/src/content/dependencies/generateGroupInfoPage.js
@@ -3,6 +3,7 @@ import {empty, stitchArrays} from '#sugar';
 export default {
   contentDependencies: [
     'generateAbsoluteDatetimestamp',
+    'generateColorStyleVariables',
     'generateContentHeading',
     'generateGroupNavLinks',
     'generateGroupSecondaryNav',
@@ -63,6 +64,10 @@ export default {
       sec.albums.galleryLink =
         relation('linkGroupGallery', group);
 
+      sec.albums.colorVariables =
+        group.albums
+          .map(() => relation('generateColorStyleVariables'));
+
       sec.albums.albumLinks =
         group.albums
           .map(album => relation('linkAlbum', album));
@@ -90,6 +95,9 @@ export default {
 
     data.name = group.name;
     data.color = group.color;
+
+    data.albumColors =
+      group.albums.map(album => album.color);
 
     return data;
   },
@@ -137,10 +145,21 @@ export default {
                 albumLink: sec.albums.albumLinks,
                 groupLink: sec.albums.groupLinks,
                 datetimestamp: sec.albums.datetimestamps,
-              }).map(({albumLink, groupLink, datetimestamp}) => {
+                colorVariables: sec.albums.colorVariables,
+                albumColor: data.albumColors,
+              }).map(({
+                  albumLink,
+                  groupLink,
+                  datetimestamp,
+                  colorVariables,
+                  albumColor,
+                }) => {
                   const prefix = 'groupInfoPage.albumList.item';
                   const parts = [prefix];
-                  const options = {album: albumLink};
+                  const options = {};
+
+                  options.album =
+                    albumLink.slot('color', false);
 
                   if (datetimestamp) {
                     parts.push('withYear');
@@ -161,9 +180,11 @@ export default {
                         }));
                   }
 
-                  return language.$(...parts, options);
-                })
-                .map(content => html.tag('li', content))),
+                  return (
+                    html.tag('li',
+                      {style: colorVariables.slot('color', albumColor).content},
+                      language.$(...parts, options)));
+                })),
           ],
         ],
 

--- a/src/content/dependencies/generateGroupInfoPage.js
+++ b/src/content/dependencies/generateGroupInfoPage.js
@@ -2,6 +2,7 @@ import {empty, stitchArrays} from '#sugar';
 
 export default {
   contentDependencies: [
+    'generateAbsoluteDatetimestamp',
     'generateContentHeading',
     'generateGroupNavLinks',
     'generateGroupSecondaryNav',
@@ -73,6 +74,12 @@ export default {
             (group
               ? relation('linkGroup', group)
               : null));
+
+      sec.albums.datetimestamps =
+        group.albums.map(album =>
+          (album.date
+            ? relation('generateAbsoluteDatetimestamp', album.date)
+            : null));
     }
 
     return relations;
@@ -83,10 +90,6 @@ export default {
 
     data.name = group.name;
     data.color = group.color;
-
-    data.albumYears =
-      group.albums
-        .map(album => album.date?.getFullYear());
 
     return data;
   },
@@ -133,17 +136,18 @@ export default {
               stitchArrays({
                 albumLink: sec.albums.albumLinks,
                 groupLink: sec.albums.groupLinks,
-                albumYear: data.albumYears,
-              }).map(({albumLink, groupLink, albumYear}) => {
+                datetimestamp: sec.albums.datetimestamps,
+              }).map(({albumLink, groupLink, datetimestamp}) => {
                   const prefix = 'groupInfoPage.albumList.item';
                   const parts = [prefix];
                   const options = {album: albumLink};
 
-                  if (albumYear) {
+                  if (datetimestamp) {
                     parts.push('withYear');
                     options.yearAccent =
                       language.$(prefix, 'yearAccent', {
-                        year: albumYear,
+                        year:
+                          datetimestamp.slots({style: 'year', tooltip: true}),
                       });
                   }
 

--- a/src/content/dependencies/generateRelativeDatetimestamp.js
+++ b/src/content/dependencies/generateRelativeDatetimestamp.js
@@ -1,0 +1,58 @@
+export default {
+  contentDependencies: [
+    'generateAbsoluteDatetimestamp',
+    'generateDatetimestampTemplate',
+  ],
+
+  extraDependencies: ['html', 'language'],
+
+  data: (currentDate, referenceDate) =>
+    (currentDate.getTime() === referenceDate.getTime()
+      ? {equal: true, date: currentDate}
+      : {equal: false, currentDate, referenceDate}),
+
+  relations: (relation, currentDate) =>
+    ({template: relation('generateDatetimestampTemplate'),
+      fallback: relation('generateAbsoluteDatetimestamp', currentDate)}),
+
+  slots: {
+    style: {
+      validate: v => v.is('full', 'year'),
+      default: 'full',
+    },
+
+    tooltip: {
+      type: 'boolean',
+      default: false,
+    },
+  },
+
+  generate(data, relations, slots, {language}) {
+    if (data.comparison === 'equal') {
+      return relations.fallback.slots({
+        style: slots.style,
+        tooltip: slots.tooltip,
+      });
+    }
+
+    return relations.template.slots({
+      mainContent:
+        (slots.style === 'full'
+          ? language.formatDate(data.currentDate)
+       : slots.style === 'year'
+          ? data.currentDate.getFullYear().toString()
+          : null),
+
+      tooltipContent:
+        slots.tooltip &&
+          language.formatRelativeDate(data.currentDate, data.referenceDate, {
+            considerRoundingDays: true,
+            approximate: true,
+            absolute: true,
+          }),
+
+      datetime:
+        data.currentDate.toISOString(),
+    });
+  },
+};

--- a/src/content/dependencies/generateRelativeDatetimestamp.js
+++ b/src/content/dependencies/generateRelativeDatetimestamp.js
@@ -48,7 +48,7 @@ export default {
           language.formatRelativeDate(data.currentDate, data.referenceDate, {
             considerRoundingDays: true,
             approximate: true,
-            absolute: true,
+            absolute: slots.style === 'year',
           }),
 
       datetime:

--- a/src/content/dependencies/generateTrackInfoPage.js
+++ b/src/content/dependencies/generateTrackInfoPage.js
@@ -13,6 +13,7 @@ export default {
     'generateAlbumSidebar',
     'generateAlbumStyleRules',
     'generateChronologyLinks',
+    'generateColorStyleVariables',
     'generateCommentarySection',
     'generateContentHeading',
     'generateContributionList',
@@ -141,6 +142,10 @@ export default {
 
       otherReleases.heading =
         relation('generateContentHeading');
+
+      otherReleases.colorVariables =
+        track.otherReleases
+          .map(() => relation('generateColorStyleVariables'));
 
       otherReleases.trackLinks =
         track.otherReleases
@@ -311,6 +316,9 @@ export default {
       hasTrackNumbers: track.album.hasTrackNumbers,
       trackNumber: track.album.tracks.indexOf(track) + 1,
 
+      otherReleaseColors:
+        track.otherReleases.map(track => track.color),
+
       numAdditionalFiles: track.additionalFiles.length,
     };
   },
@@ -381,9 +389,20 @@ export default {
                 trackLink: sec.otherReleases.trackLinks,
                 albumLink: sec.otherReleases.albumLinks,
                 datetimestamp: sec.otherReleases.datetimestamps,
-              }).map(({trackLink, albumLink, datetimestamp}) => {
+                colorVariables: sec.otherReleases.colorVariables,
+                color: data.otherReleaseColors,
+              }).map(({
+                  trackLink,
+                  albumLink,
+                  datetimestamp,
+                  colorVariables,
+                  color,
+                }) => {
                   const parts = ['releaseInfo.alsoReleasedAs.item'];
-                  const options = {track: trackLink, album: albumLink};
+                  const options = {};
+
+                  options.track = trackLink.slot('color', false);
+                  options.album = albumLink;
 
                   if (datetimestamp) {
                     parts.push('withYear');
@@ -396,6 +415,7 @@ export default {
 
                   return (
                     html.tag('li',
+                      {style: colorVariables.slot('color', color).content},
                       language.$(...parts, options)));
                 })),
           ],

--- a/src/data/things/language.js
+++ b/src/data/things/language.js
@@ -369,7 +369,7 @@ export class Language extends Thing {
     const relative =
       this.formatString(
         'count.dateDuration',
-        (approximate
+        (approximate && (years || months || days)
           ? (comparison === -1
               ? 'approximateEarlier'
               : 'approximateLater')

--- a/src/data/things/language.js
+++ b/src/data/things/language.js
@@ -1,3 +1,5 @@
+import { Temporal, toTemporalInstant } from '@js-temporal/polyfill';
+
 import {isLanguageCode} from '#validators';
 import {Tag} from '#html';
 
@@ -284,6 +286,108 @@ export class Language extends Thing {
     return this.intl_date.formatRange(startDate, endDate);
   }
 
+  formatDateDuration({
+    years: numYears = 0,
+    months: numMonths = 0,
+    days: numDays = 0,
+    approximate = false,
+  }) {
+    let basis;
+
+    const years = this.countYears(numYears, {unit: true});
+    const months = this.countMonths(numMonths, {unit: true});
+    const days = this.countDays(numDays, {unit: true});
+
+    if (numYears && numMonths && numDays)
+      basis = this.formatString('count.dateDuration.yearsMonthsDays', {years, months, days});
+    else if (numYears && numMonths)
+      basis = this.formatString('count.dateDuration.yearsMonths', {years, months});
+    else if (numYears && numDays)
+      basis = this.formatString('count.dateDuration.yearsDays', {years, days});
+    else if (numYears)
+      basis = this.formatString('count.dateDuration.years', {years});
+    else if (numMonths && numDays)
+      basis = this.formatString('count.dateDuration.monthsDays', {months, days});
+    else if (numMonths)
+      basis = this.formatzString('count.dateDuration.months', {months});
+    else if (numDays)
+      basis = this.formatString('count.dateDuration.days', {days});
+    else
+      return this.formatString('count.dateDuration.zero');
+
+    if (approximate) {
+      return this.formatString('count.dateDuration.approximate', {
+        duration: basis,
+      });
+    } else {
+      return basis;
+    }
+  }
+
+  formatRelativeDate(currentDate, referenceDate, {
+    considerRoundingDays = false,
+    approximate = true,
+    absolute = true,
+  } = {}) {
+    const currentInstant = toTemporalInstant.apply(currentDate);
+    const referenceInstant = toTemporalInstant.apply(referenceDate);
+
+    const comparison =
+      Temporal.Instant.compare(currentInstant, referenceInstant);
+
+    if (comparison === 0) {
+      return this.formatString('count.dateDuration.same');
+    }
+
+    const currentTDZ = currentInstant.toZonedDateTimeISO('Etc/UTC');
+    const referenceTDZ = referenceInstant.toZonedDateTimeISO('Etc/UTC');
+
+    const earlierTDZ = (comparison === -1 ? currentTDZ : referenceTDZ);
+    const laterTDZ = (comparison === 1 ? currentTDZ : referenceTDZ);
+
+    const {years, months, days} =
+      laterTDZ.since(earlierTDZ, {
+        largestUnit: 'year',
+        smallestUnit:
+          (considerRoundingDays
+            ? (laterTDZ.since(earlierTDZ, {
+                largestUnit: 'year',
+                smallestUnit: 'day',
+              }).years
+                ? 'month'
+                : 'day')
+            : 'day'),
+        roundingMode: 'halfCeil',
+      });
+
+    const duration =
+      this.formatDateDuration({
+        years, months, days,
+        approximate: false,
+      });
+
+    const relative =
+      this.formatString(
+        'count.dateDuration',
+        (approximate
+          ? (comparison === -1
+              ? 'approximateEarlier'
+              : 'approximateLater')
+          : (comparison === -1
+              ? 'earlier'
+              : 'later')),
+        {duration});
+
+    if (absolute) {
+      return this.formatString('count.dateDuration.relativeAbsolute', {
+        relative,
+        absolute: this.formatDate(currentDate),
+      });
+    } else {
+      return relative;
+    }
+  }
+
   formatDuration(secTotal, {approximate = false, unit = false} = {}) {
     if (secTotal === 0) {
       return this.formatString('count.duration.missing');
@@ -442,7 +546,11 @@ Object.assign(Language.prototype, {
   countCommentaryEntries: countHelper('commentaryEntries', 'entries'),
   countContributions: countHelper('contributions'),
   countCoverArts: countHelper('coverArts'),
+  countDays: countHelper('days'),
+  countMonths: countHelper('months'),
   countTimesReferenced: countHelper('timesReferenced'),
   countTimesUsed: countHelper('timesUsed'),
   countTracks: countHelper('tracks'),
+  countWeeks: countHelper('weeks'),
+  countYears: countHelper('years'),
 });

--- a/src/static/client3.js
+++ b/src/static/client3.js
@@ -1981,8 +1981,8 @@ for (const info of groupContributionsTableInfo) {
 // Artist link icon tooltips ------------------------------
 
 const externalIconTooltipInfo = clientInfo.externalIconTooltipInfo = {
-  hoverableLinks: null,
-  iconContainers: null,
+  hoverables: null,
+  tooltips: null,
 };
 
 function getExternalIconTooltipReferences() {
@@ -1991,21 +1991,19 @@ function getExternalIconTooltipReferences() {
   const spans =
     Array.from(document.querySelectorAll('span.contribution.has-tooltip'));
 
-  info.hoverableLinks =
-    spans
-      .map(span => span.querySelector('a'));
+  info.hoverables =
+    spans.map(span => span.querySelector('a'));
 
-  info.iconContainers =
-    spans
-      .map(span => span.querySelector('span.icons-tooltip'));
+  info.tooltips =
+    spans.map(span => span.querySelector('span.icons-tooltip'));
 }
 
 function addExternalIconTooltipPageListeners() {
   const info = externalIconTooltipInfo;
 
   for (const {hoverable, tooltip} of stitchArrays({
-    hoverable: info.hoverableLinks,
-    tooltip: info.iconContainers,
+    hoverable: info.hoverables,
+    tooltip: info.tooltips,
   })) {
     registerTooltipElement(tooltip);
     registerTooltipHoverableElement(hoverable, tooltip);
@@ -2014,6 +2012,41 @@ function addExternalIconTooltipPageListeners() {
 
 clientSteps.getPageReferences.push(getExternalIconTooltipReferences);
 clientSteps.addPageListeners.push(addExternalIconTooltipPageListeners);
+
+// Datetimestamp tooltips ---------------------------------
+
+const datetimestampTooltipInfo = clientInfo.datetimestampTooltipInfo = {
+  hoverables: null,
+  tooltips: null,
+};
+
+function getDatestampTooltipReferences() {
+  const info = datetimestampTooltipInfo;
+
+  const spans =
+    Array.from(document.querySelectorAll('span.datetimestamp.has-tooltip'));
+
+  info.hoverables =
+    spans.map(span => span.querySelector('time'));
+
+  info.tooltips =
+    spans.map(span => span.querySelector('span.datetimestamp-tooltip'));
+}
+
+function addDatestampTooltipPageListeners() {
+  const info = datetimestampTooltipInfo;
+
+  for (const {hoverable, tooltip} of stitchArrays({
+    hoverable: info.hoverables,
+    tooltip: info.tooltips,
+  })) {
+    registerTooltipElement(tooltip);
+    registerTooltipHoverableElement(hoverable, tooltip);
+  }
+}
+
+clientSteps.getPageReferences.push(getDatestampTooltipReferences);
+clientSteps.addPageListeners.push(addDatestampTooltipPageListeners);
 
 // Sticky commentary sidebar ------------------------------
 

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -514,7 +514,7 @@ a:not([href]):hover {
   left: -10px;
 }
 
-li .datetimestamp-tooltip {
+li:not(:first-child:last-child) .datetimestamp-tooltip {
   left: 14px;
 }
 

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -511,6 +511,10 @@ a:not([href]):hover {
 
 .datetimestamp-tooltip {
   padding: 3px 4px 2px 2px;
+  left: -10px;
+}
+
+li .datetimestamp-tooltip {
   left: 14px;
 }
 

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -603,6 +603,10 @@ a:not([href]):hover {
   white-space: nowrap;
 }
 
+.other-group-accent a {
+  color: var(--page-primary-color);
+}
+
 .content-columns {
   columns: 2;
 }

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -473,37 +473,51 @@ a:not([href]):hover {
   white-space: nowrap;
 }
 
-.contribution {
+.contribution.has-tooltip,
+.datetimestamp.has-tooltip {
   position: relative;
 }
 
-.contribution.has-tooltip > a {
+.contribution.has-tooltip > a,
+.datetimestamp.has-tooltip > time {
   text-decoration: underline;
   text-decoration-style: dotted;
 }
 
+.datetimestamp.has-tooltip > time {
+  cursor: default;
+}
+
 .contribution.has-tooltip > a:hover,
-.contribution.has-tooltip > a.has-visible-tooltip {
+.contribution.has-tooltip > a.has-visible-tooltip,
+.datetimestamp.has-tooltip > time:hover,
+.datetimestamp.has-tooltip > time.has-visible-tooltip {
   text-decoration-style: wavy !important;
 }
 
-.icons {
-  font-style: normal;
-  white-space: nowrap;
-}
-
-.icons-tooltip {
+.icons-tooltip,
+.datetimestamp-tooltip {
   position: absolute;
   z-index: 3;
   left: -34px;
   top: calc(1em + 1px);
-  padding: 3px 6px 6px 6px;
   display: none;
 }
 
-.icons-tooltip-content {
+.icons-tooltip {
+  padding: 3px 6px 6px 6px;
+  left: -34px;
+}
+
+.datetimestamp-tooltip {
+  padding: 3px 4px 2px 2px;
+  left: 14px;
+}
+
+.icons-tooltip-content,
+.datetimestamp-tooltip-content {
   display: block;
-  padding: 6px 2px 2px 2px;
+
   background: var(--bg-black-color);
   border: 1px dotted var(--primary-color);
   border-radius: 6px;
@@ -514,14 +528,29 @@ a:not([href]):hover {
           backdrop-filter:
     brightness(1.5) saturate(1.4) blur(4px);
 
-  -webkit-user-select: none;
-          user-select: none;
-
   box-shadow:
     0 3px 4px 4px #000000aa,
     0 -2px 4px -2px var(--primary-color) inset;
+}
+
+.icons-tooltip-content {
+  padding: 6px 2px 2px 2px;
+
+  -webkit-user-select: none;
+          user-select: none;
 
   cursor: default;
+}
+
+.datetimestamp-tooltip-content {
+  padding: 5px 6px;
+  white-space: nowrap;
+  font-size: 0.9em;
+}
+
+.icons {
+  font-style: normal;
+  white-space: nowrap;
 }
 
 .icons a:hover {

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -268,7 +268,10 @@ releaseInfo:
 
   alsoReleasedAs:
     _: "Also released as:"
-    item: "{TRACK} (on {ALBUM})"
+
+    item:
+      _: "{TRACK} ({ALBUM})"
+      withYear: "({YEAR}) {TRACK} ({ALBUM})"
 
   tracksReferenced: "Tracks that {TRACK} references:"
   tracksThatReference: "Tracks that reference {TRACK}:"

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -1023,10 +1023,20 @@ groupInfoPage:
     title: "Albums"
 
     item:
-      _: "({YEAR}) {ALBUM}"
-      withoutYear: "{ALBUM}"
-      withAccent: "{ITEM} {ACCENT}"
-      otherGroupAccent: "(from {GROUP})"
+      _: >-
+        {ALBUM}
+
+      withYear: >-
+        {YEAR_ACCENT} {ALBUM}
+
+      withOtherGroup: >-
+        {ALBUM} {OTHER_GROUP_ACCENT}
+
+      withYear.withOtherGroup: >-
+        {YEAR_ACCENT} {ALBUM} {OTHER_GROUP_ACCENT}
+
+      yearAccent: "({YEAR})"
+      otherGroupAccent:  "(from {GROUP})"
 
 #
 # groupGalleryPage:

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -206,7 +206,7 @@ count:
     earlier: "{DURATION} earlier"
     later: "{DURATION} later"
     same: "on the same date"
-    zero: "no days apart"
+    zero: "at most one day"
     approximate: "about {DURATION}"
     approximateEarlier: "about {DURATION} earlier"
     approximateLater: "about {DURATION} later"

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -129,6 +129,16 @@ count:
       many: ""
       other: "{DAYS} days"
 
+  months:
+    _: "{MONTHS}"
+    withUnit:
+      zero: ""
+      one: "{MONTHS} month"
+      two: ""
+      few: ""
+      many: ""
+      other: "{MONTHS} months"
+
   timesReferenced:
     _: "{TIMES_REFERENCED}"
     withUnit:
@@ -149,6 +159,16 @@ count:
       many: ""
       other: "used {TIMES_USED} times"
 
+  weeks:
+    _: "{WEEKS}"
+    withUnit:
+      zero: ""
+      one: "{WEEKS} week"
+      two: ""
+      few: ""
+      many: ""
+      other: "{WEEKS} weeks"
+
   words:
     _: "{WORDS}"
     thousand: "{WORDS}k"
@@ -159,6 +179,16 @@ count:
       few: ""
       many: ""
       other: "{WORDS} words"
+
+  years:
+    _: "{YEARS}"
+    withUnit:
+      zero: ""
+      one: "{YEARS} year"
+      two: ""
+      few: ""
+      many: ""
+      other: "{YEARS} years"
 
   # Numerical things that aren't exactly counting, per se
 
@@ -171,6 +201,24 @@ count:
     minutes:
       _:        "{MINUTES}:{SECONDS}"
       withUnit: "{MINUTES}:{SECONDS} minutes"
+
+  dateDuration:
+    earlier: "{DURATION} earlier"
+    later: "{DURATION} later"
+    same: "on the same date"
+    zero: "no days apart"
+    approximate: "about {DURATION}"
+    approximateEarlier: "about {DURATION} earlier"
+    approximateLater: "about {DURATION} later"
+    relativeAbsolute: "{ABSOLUTE}; {RELATIVE}"
+
+    years: "{YEARS}"
+    months: "{MONTHS}"
+    days: "{DAYS}"
+    yearsMonthsDays: "{YEARS}, {MONTHS}, {DAYS}"
+    yearsMonths: "{YEARS}, {MONTHS}"
+    yearsDays: "{YEARS}, {DAYS}"
+    monthsDays: "{MONTHS}, {DAYS}"
 
   fileSize:
     terabytes: "{TERABYTES} TB"


### PR DESCRIPTION
This PR adds a new kind of component, datetimestamps, which enable concealing extra details about a date behind a tooltip (as well as representing the date with a proper `<time>` element). It's used in two places, at the moment: the year for each album on a group's info page (which now shows the full date in a tooltip), and the newly present year beside each entry in a track's "also released as" list (which shows the full date in a tooltip, as well as the relative time since or before the current release).

<img width="326" alt="Also released as: (2023) Cometfall (Vinculum Vitae). The year is hovered and showing a stylish tooltip beneath, which reads: 4/13/2023; about 5 months, 3 days earlier" src="https://github.com/hsmusic/hsmusic-wiki/assets/9948030/b534b42a-92d1-4ea1-8973-8bbacd125988">

https://github.com/hsmusic/hsmusic-wiki/assets/9948030/8b7bc0a5-8b36-408b-aba9-bb6134a5fdb2

Development:

* Resolves #262.

Discord:

* See also relevant discussion about [reworking the appearance of "other releases"...](https://discord.com/channels/749042497610842152/779895315750715422/1179403962525421659)
* ...which eventually morphed into [tooltips, of course.](https://discord.com/channels/749042497610842152/779895315750715422/1179426791388106792)
* Lots of [screenshots and examples](https://discord.com/channels/749042497610842152/779895315750715422/1179538110611193856) there!

Supporting internal changes:

* New content function: `generateDatetimestampTemplate`
  * Similar to `linkTemplate`, this provides the basic HTML structure for datetimestamps. It shouldn't be used on its own.
* New content functions: `generateAbsoluteDatetimestamp`, `generateRelativeDatetimestamp`
  * These each take the slots `tooltip: true / false` and `style: 'full' / 'year'`, with self-descriptive behavior.
  * `generateAbsoluteDatetimestamp`'s tooltip is only used if `style` is `'year'`, since there's no additional information to display if the full date is already visible. But it can still be used to provide a (full) date in a proper `<time>` element. It's not integrated across the site yet, but should be in the future!
  * There's possibly room to do more with `generateRelativeDatetimestamp`'s styles - right now it's actually a bit of a "hybrid", presenting only absolute info (year or full date) until hovered. That's okay for the current use cases, but means there's no reason ever to provide it `tooltip: false`.
  * These wrap `generateDatetimestampTemplate`, of course, and provide it mostly with details formatted by language utilities, such as...
* New language utilities: `Language.formatDateDuration`, `Language.formatRelativeDate`
  * The first of these takes `{years, months, days}` options, as well as an `approximate` flag, and converts those raw numbers into a string such as "24 years, 1 month, 14 days" or "1 year, 2 days" or "about 3 months". A handful of new relevant strings are supplied under `count.dateDuration`.
  * The second wraps the first, and performs a bunch of Temporal-based math to calculate the time difference. It takes two date arguments (the first is considered the contextually "current" one), and has three options:
  * `approximate` is self-descriptive;
  * `considerRoundingDays` will round away the number of days if the time difference is at least one year;
  * `absolute` attaches the first date in absolute form, e.g. "8/4/2024; 10 months, 5 days later".
  * Unlike most counting functions (but like e.g. file sizes), these formatting functions always display units.
  * If `formatDateDuration` is directly provided a zero duration, it'll return "at most one day".
  * If `formatRelativeDate` is provided two dates that are equal, it'll return "on the same day". These do have to be *exactly* the same date, though; if they're the same date but different times, you'll still get the earlier/later part, e.g. "at most one day earlier". In principle this shouldn't come up at all, but it *could* interact awkwardly with BS uses of e.g. releasing an album "at" 12:04:05. For the future, it might be reasonable to truncate date-times to days before passing them here, or even just make `formatRelativeDate` ignore times outright. But no final decision on that yet.
    * [See also similar discussion.](https://github.com/hsmusic/hsmusic-wiki/issues/253)
* The relevant sections in `generateGroupInfoPage` and `generateTrackInfoPage` are tidied to use the more recent `stitchArrays` format, as well as cleaner, parts-formed strings for the former. Nothing special to see here, just nice to have code cleanup!
* We happily report that apart from some light cleanup for CSS rules, the tooltip system required zero changes to support this new use. 🎊