### PR TITLE
Cover art style tweaks

### DIFF
--- a/src/content/dependencies/generateColorStyleVariables.js
+++ b/src/content/dependencies/generateColorStyleVariables.js
@@ -11,6 +11,7 @@ export default {
         'any-content',
         'image-box',
         'page-root',
+        'image-box',
         'primary-only'),
 
       default: 'any-content',
@@ -29,7 +30,8 @@ export default {
       primary,
       dark,
       dim,
-      dimGhost,
+      deep,
+      deepGhost,
       bg,
       bgBlack,
       shadow,
@@ -39,7 +41,8 @@ export default {
       `--primary-color: ${primary}`,
       `--dark-color: ${dark}`,
       `--dim-color: ${dim}`,
-      `--dim-ghost-color: ${dimGhost}`,
+      `--deep-color: ${deep}`,
+      `--deep-ghost-color: ${deepGhost}`,
       `--bg-color: ${bg}`,
       `--bg-black-color: ${bgBlack}`,
       `--shadow-color: ${shadow}`,
@@ -56,6 +59,8 @@ export default {
         selectedProperties = [
           `--primary-color: ${primary}`,
           `--dim-color: ${dim}`,
+          `--deep-color: ${deep}`,
+          `--bg-black-color: ${bgBlack}`,
         ];
         break;
 

--- a/src/content/dependencies/generateCoverArtwork.js
+++ b/src/content/dependencies/generateCoverArtwork.js
@@ -2,7 +2,7 @@ import {empty} from '#sugar';
 
 export default {
   contentDependencies: ['image', 'linkArtTag'],
-  extraDependencies: ['html', 'language'],
+  extraDependencies: ['html'],
 
   relations(relation, artTags) {
     const relations = {};
@@ -41,7 +41,7 @@ export default {
     },
   },
 
-  generate(relations, slots, {html, language}) {
+  generate(relations, slots, {html}) {
     switch (slots.mode) {
       case 'primary':
         return html.tags([

--- a/src/content/dependencies/generateCoverArtwork.js
+++ b/src/content/dependencies/generateCoverArtwork.js
@@ -57,14 +57,12 @@ export default {
           }),
 
           !empty(relations.tagLinks) &&
-            html.tag('p',
-              language.$('releaseInfo.artTags.inline', {
-                tags:
-                  language.formatUnitList(
-                    relations.tagLinks
-                      .map(tagLink => tagLink.slot('preferShortName', true))),
-              })),
-          ]);
+            html.tag('ul', {class: 'image-details'},
+              relations.tagLinks
+                .map(tagLink =>
+                  html.tag('li',
+                    tagLink.slot('preferShortName', true)))),
+        ]);
 
       case 'thumbnail':
         return relations.image.slots({

--- a/src/content/dependencies/image.js
+++ b/src/content/dependencies/image.js
@@ -130,15 +130,15 @@ export default {
       slots.alt && {alt: slots.alt},
       slots.width && {width: slots.width},
       slots.height && {height: slots.height},
-
-      customLink &&
-        {'data-no-image-preview': true},
     ]);
 
     const linkAttributes = html.attributes([
       (customLink
         ? {href: slots.link}
         : {href: originalSrc}),
+
+      customLink &&
+        {class: 'no-image-preview'},
     ]);
 
     const containerAttributes = html.attributes();

--- a/src/static/client3.js
+++ b/src/static/client3.js
@@ -1621,11 +1621,7 @@ function addImageOverlayClickHandlers() {
     return;
   }
 
-  for (const link of document.querySelectorAll('.image-link')) {
-    if (link.querySelector('img').hasAttribute('data-no-image-preview')) {
-      continue;
-    }
-
+  for (const link of document.querySelectorAll('.image-link:not(.no-image-preview)')) {
     link.addEventListener('click', handleImageLinkClicked);
   }
 

--- a/src/static/client3.js
+++ b/src/static/client3.js
@@ -1491,7 +1491,7 @@ function updateStickyCoverVisibility(index) {
   const contentCover = info.contentCovers[index];
 
   if (contentCover && stickyCoverContainer) {
-    if (contentCover.getBoundingClientRect().bottom < 0) {
+    if (contentCover.getBoundingClientRect().bottom < 4) {
       stickyCoverContainer.classList.add('visible');
     } else {
       stickyCoverContainer.classList.remove('visible');

--- a/src/static/client3.js
+++ b/src/static/client3.js
@@ -145,6 +145,34 @@ function dispatchInternalEvent(event, eventName, ...args) {
   return results;
 }
 
+// CSS compatibility-assistant ----------------------------
+
+const cssCompatibilityAssistantInfo = clientInfo.cssCompatibilityAssistantInfo = {
+  coverArtContainer: null,
+  coverArtImageDetails: null,
+};
+
+function getCSSCompatibilityAssistantInfoReferences() {
+  const info = cssCompatibilityAssistantInfo;
+
+  info.coverArtContainer =
+    document.getElementById('cover-art-container');
+
+  info.coverArtImageDetails =
+    info.coverArtContainer?.querySelector('.image-details');
+}
+
+function mutateCSSCompatibilityContent() {
+  const info = cssCompatibilityAssistantInfo;
+
+  if (info.coverArtImageDetails) {
+    info.coverArtContainer.classList.add('has-image-details');
+  }
+}
+
+clientSteps.getPageReferences.push(getCSSCompatibilityAssistantInfoReferences);
+clientSteps.mutatePageContent.push(mutateCSSCompatibilityContent);
+
 // JS-based links -----------------------------------------
 
 const scriptedLinkInfo = initInfo('scriptedLinkInfo', {

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -650,10 +650,9 @@ p .current {
 }
 
 #cover-art-container .image-container {
-  background: var(--deep-color);
-
   /* Border is handled on the cover-art-container. */
   border: none;
+  border-radius: 0;
 }
 
 #cover-art-container .image-details {
@@ -1047,15 +1046,20 @@ h1 a[href="#additional-names-box"]:hover {
 /* Images */
 
 .image-container {
-  border: 2px solid var(--primary-color);
+  display: inline-block;
   box-sizing: border-box;
   position: relative;
-  padding: 5px;
-  text-align: left;
-  background-color: var(--dim-color);
-  color: white;
-  display: inline-block;
   height: 100%;
+  padding: 5px;
+  overflow: hidden;
+
+  background-color: var(--dim-color);
+  border: 2px solid var(--primary-color);
+  border-radius: 0;
+  box-shadow: 0 2px 4px -2px var(--bg-black-color) inset;
+
+  text-align: left;
+  color: white;
 }
 
 .image-text-area {
@@ -1069,8 +1073,10 @@ h1 a[href="#additional-names-box"]:hover {
   justify-content: center;
   text-align: center;
   padding: 5px 15px;
+
   background: rgba(0, 0, 0, 0.65);
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.5) inset;
+
   line-height: 1.35em;
   color: var(--primary-color);
   font-style: oblique;
@@ -1082,6 +1088,8 @@ h1 a[href="#additional-names-box"]:hover {
   width: 100%;
   height: 100%;
   overflow: hidden;
+
+  border-bottom: 1px solid #ffffff03;
   border-radius: 2.5px;
   box-shadow:
     0 1px 8px -3px var(--bg-black-color);
@@ -1150,6 +1158,12 @@ img.pixelate {
   display: none;
 }
 
+.image-link:not(.no-image-preview) .image-container {
+  background: var(--deep-color);
+  box-shadow: none;
+  border-radius: 0 0 4px 4px;
+}
+
 .sidebar .image-container {
   max-width: 350px;
 }
@@ -1176,10 +1190,6 @@ img.pixelate {
   border-radius: 2px;
   padding: 5px;
   margin: 10px;
-}
-
-.grid-item .image-container {
-  box-shadow: 0 2px 4px -2px var(--bg-black-color) inset;
 }
 
 .grid-item .image-inner-area {
@@ -1676,7 +1686,9 @@ main.long-content .content-sticky-heading-container .content-sticky-subheading-r
 
 .content-sticky-heading-cover .image-container {
   border-width: 1px;
-  padding: 2px;
+  padding: 3px;
+  border-radius: 1.25px;
+  box-shadow: none;
 }
 
 .content-sticky-heading-container .image-inner-area {
@@ -1699,9 +1711,12 @@ main.long-content .content-sticky-heading-container .content-sticky-subheading-r
 
   background: var(--bg-black-color);
   border-bottom: 1px dotted rgba(220, 220, 220, 0.4);
+  box-shadow:
+    0 2px 2px -1px #00000060,
+    0 4px 12px -4px #00000090;
 
-  -webkit-backdrop-filter: blur(3px);
-          backdrop-filter: blur(3px);
+  -webkit-backdrop-filter: blur(4px);
+          backdrop-filter: blur(4px);
 
   transition: margin-top 0.35s, opacity 0.25s;
 }
@@ -1728,13 +1743,7 @@ main.long-content .content-sticky-heading-container .content-sticky-subheading-r
 .content-sticky-heading-row {
   box-shadow:
     inset 0 10px 10px -5px var(--shadow-color),
-    0 4px 4px rgba(0, 0, 0, 0.8);
-}
-
-.content-sticky-heading-container h2.visible {
-  box-shadow:
-    inset 0 10px 10px -5px var(--shadow-color),
-    0 4px 4px rgba(0, 0, 0, 0.8);
+    0 4px 8px -4px #000000b0;
 }
 
 #content, .sidebar {
@@ -1820,6 +1829,18 @@ main.long-content .content-sticky-heading-container .content-sticky-subheading-r
   flex-direction: column;
   align-items: center;
   justify-content: center;
+}
+
+#image-overlay-container::before {
+  content: '';
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+
+  background: var(--deep-color);
+  opacity: 0.20;
 }
 
 #image-overlay-container.visible {

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -1625,6 +1625,7 @@ main.long-content .content-sticky-heading-container .content-sticky-subheading-r
 .content-sticky-heading-cover-container:not(.visible) .content-sticky-heading-cover {
   opacity: 0;
   transform: translateY(15px);
+  transition: transform 0.35s, opacity 0.30s;
 }
 
 .content-sticky-heading-cover .image-container {

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -635,13 +635,29 @@ p .current {
 
 #cover-art-container {
   font-size: 0.8em;
-  box-shadow: 0 3px 3px 6px rgba(0, 0, 0, 0.35);
+  border: 2px solid var(--primary-color);
+  box-shadow:
+    0 2px 14px -6px var(--primary-color),
+    0 0 12px 12px #00000080;
+
+  border-radius: 0 0 4px 4px;
+  overflow: hidden;
 }
 
 #cover-art-container:has(.image-details),
 #cover-art-container.has-image-details {
-  border-bottom-left-radius: 4px;
-  border-bottom-right-radius: 4px;
+  border-radius: 0 0 6px 6px;
+}
+
+#cover-art-container .image-container {
+  background: var(--deep-color);
+
+  /* Border is handled on the cover-art-container. */
+  border: none;
+}
+
+#cover-art-container .image-details {
+  border-top-color: var(--deep-color);
 }
 
 #cover-art img {
@@ -657,9 +673,7 @@ p .current {
   margin-top: 0;
   margin-bottom: 0;
   background: var(--bg-black-color);
-  border: 2px solid var(--primary-color);
-  border-top: 0;
-  border-radius: 0 0 4px 4px;
+  border-top: 1px dashed var(--dim-color);
 
   -webkit-backdrop-filter: blur(3px);
           backdrop-filter: blur(3px);
@@ -1064,12 +1078,31 @@ h1 a[href="#additional-names-box"]:hover {
 }
 
 .image-inner-area {
+  position: relative;
   width: 100%;
   height: 100%;
+  overflow: hidden;
+  border-radius: 2.5px;
+  box-shadow:
+    0 1px 8px -3px var(--bg-black-color);
 }
 
 img {
   object-fit: cover;
+}
+
+.image-inner-area::after {
+  content: "";
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-bottom-left-radius: 0.5px;
+  opacity: 0.035;
+  box-shadow:
+    6px -6px 2px -4px white inset;
 }
 
 img.pixelate {
@@ -1143,6 +1176,19 @@ img.pixelate {
   border-radius: 2px;
   padding: 5px;
   margin: 10px;
+}
+
+.grid-item .image-container {
+  box-shadow: 0 2px 4px -2px var(--bg-black-color) inset;
+}
+
+.grid-item .image-inner-area {
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.grid-item .image-inner-area::after {
+  box-shadow: none;
 }
 
 .grid-item img {
@@ -1633,6 +1679,10 @@ main.long-content .content-sticky-heading-container .content-sticky-subheading-r
   padding: 2px;
 }
 
+.content-sticky-heading-container .image-inner-area {
+  border-radius: 1.75px;
+}
+
 .content-sticky-heading-cover img {
   display: block;
   width: 100%;
@@ -1780,7 +1830,7 @@ main.long-content .content-sticky-heading-container .content-sticky-subheading-r
 #image-overlay-content-container {
   border-radius: 0 0 8px 8px;
   border: 2px solid var(--primary-color);
-  background: var(--dim-ghost-color);
+  background: var(--deep-ghost-color);
   padding: 3px;
   overflow: hidden;
 
@@ -1851,12 +1901,14 @@ main.long-content .content-sticky-heading-container .content-sticky-subheading-r
 }
 
 #image-overlay-action-container {
-  padding: 4px 4px 6px 4px;
+  padding: 7px 4px 7px 4px;
   border-radius: 0 0 5px 5px;
   background: var(--bg-black-color);
   color: white;
   font-style: oblique;
   text-align: center;
+  box-shadow:
+    0 3px 8px -5px var(--primary-color) inset;
 }
 
 #image-overlay-container #image-overlay-action-content-without-size:not(.visible),

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -635,10 +635,13 @@ p .current {
 
 #cover-art-container {
   font-size: 0.8em;
+  box-shadow: 0 3px 3px 6px rgba(0, 0, 0, 0.35);
 }
 
-#cover-art .square {
-  box-shadow: 0 0 3px 6px rgba(0, 0, 0, 0.35);
+#cover-art-container:has(.image-details),
+#cover-art-container.has-image-details {
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
 }
 
 #cover-art img {
@@ -647,8 +650,28 @@ p .current {
   height: 100%;
 }
 
-#cover-art-container p {
-  margin-top: 5px;
+.image-details {
+  display: block;
+
+  padding: 6px 9px 4px 9px;
+  margin-top: 0;
+  margin-bottom: 0;
+  background: var(--bg-black-color);
+  border: 2px solid var(--primary-color);
+  border-top: 0;
+  border-radius: 0 0 4px 4px;
+
+  -webkit-backdrop-filter: blur(3px);
+          backdrop-filter: blur(3px);
+}
+
+ul.image-details li {
+  display: inline-block;
+  margin: 0;
+}
+
+#cover-art-container ul li:not(:last-child)::after {
+  content: " \00b7 ";
 }
 
 .commentary-entry-heading {

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -288,7 +288,7 @@ releaseInfo:
 
   artTags:
     _: "Tags:"
-    inline: "Tags: {TAGS}"
+    inline: "{TAGS}"
 
   # Actions
 

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -286,10 +286,6 @@ releaseInfo:
 
   tracksFeatured: "Tracks that {FLASH} features:"
 
-  artTags:
-    _: "Tags:"
-    inline: "{TAGS}"
-
   # Actions
 
   viewCommentary:

--- a/src/util/colors.js
+++ b/src/util/colors.js
@@ -11,7 +11,7 @@ export function getColors(themeColor, {
   const primary = chroma(themeColor);
 
   const dark = primary.luminance(0.02);
-  const dim = primary.desaturate(2).darken(1.5);
+  const dim = primary.saturate(1.2).luminance(0.035);
   const dimGhost = dim.alpha(0.8);
   const light = chroma.average(['#ffffff', primary], 'rgb', [4, 1]);
 

--- a/src/util/colors.js
+++ b/src/util/colors.js
@@ -11,8 +11,9 @@ export function getColors(themeColor, {
   const primary = chroma(themeColor);
 
   const dark = primary.luminance(0.02);
-  const dim = primary.saturate(1.2).luminance(0.035);
-  const dimGhost = dim.alpha(0.8);
+  const dim = primary.desaturate(2).darken(1.5);
+  const deep = primary.saturate(1.2).luminance(0.035);
+  const deepGhost = deep.alpha(0.8);
   const light = chroma.average(['#ffffff', primary], 'rgb', [4, 1]);
 
   const bg = primary.luminance(0.008).desaturate(3.5).alpha(0.8);
@@ -27,7 +28,8 @@ export function getColors(themeColor, {
 
     dark: dark.hex(),
     dim: dim.hex(),
-    dimGhost: dimGhost.hex(),
+    deep: deep.hex(),
+    deepGhost: deepGhost.hex(),
     light: light.hex(),
 
     bg: bg.hex(),

--- a/tap-snapshots/test/snapshot/generateAlbumCoverArtwork.js.test.cjs
+++ b/tap-snapshots/test/snapshot/generateAlbumCoverArtwork.js.test.cjs
@@ -16,7 +16,11 @@ exports[`test/snapshot/generateAlbumCoverArtwork.js > TAP > generateAlbumCoverAr
    ]
  ]
  slots: { path: [ 'media.albumCover', 'bee-forus-seatbelt-safebee', 'png' ], color: '#f28514', thumb: 'medium', id: 'cover-art', reveal: true, link: true, square: true }]
-<p>Tags: <a href="tag/damara/">Damara</a>, <a href="tag/cronus/">Cronus</a>, <a href="tag/bees/">Bees</a></p>
+<ul class="image-details">
+    <li><a href="tag/damara/">Damara</a></li>
+    <li><a href="tag/cronus/">Cronus</a></li>
+    <li><a href="tag/bees/">Bees</a></li>
+</ul>
 `
 
 exports[`test/snapshot/generateAlbumCoverArtwork.js > TAP > generateAlbumCoverArtwork (snapshot) > display: thumbnail 1`] = `

--- a/tap-snapshots/test/snapshot/generateCoverArtwork.js.test.cjs
+++ b/tap-snapshots/test/snapshot/generateCoverArtwork.js.test.cjs
@@ -16,7 +16,11 @@ exports[`test/snapshot/generateCoverArtwork.js > TAP > generateCoverArtwork (sna
    ]
  ]
  slots: { path: [ 'media.albumCover', 'bee-forus-seatbelt-safebee', 'png' ], thumb: 'medium', id: 'cover-art', reveal: true, link: true, square: true }]
-<p>Tags: <a href="tag/damara/">Damara</a>, <a href="tag/cronus/">Cronus</a>, <a href="tag/bees/">Bees</a></p>
+<ul class="image-details">
+    <li><a href="tag/damara/">Damara</a></li>
+    <li><a href="tag/cronus/">Cronus</a></li>
+    <li><a href="tag/bees/">Bees</a></li>
+</ul>
 `
 
 exports[`test/snapshot/generateCoverArtwork.js > TAP > generateCoverArtwork (snapshot) > display: thumbnail 1`] = `

--- a/tap-snapshots/test/snapshot/generateTrackCoverArtwork.js.test.cjs
+++ b/tap-snapshots/test/snapshot/generateTrackCoverArtwork.js.test.cjs
@@ -16,14 +16,18 @@ exports[`test/snapshot/generateTrackCoverArtwork.js > TAP > generateTrackCoverAr
    ]
  ]
  slots: { path: [ 'media.albumCover', 'bee-forus-seatbelt-safebee', 'png' ], color: '#abcdef', thumb: 'medium', id: 'cover-art', reveal: true, link: true, square: true }]
-<p>Tags: <a href="tag/damara/">Damara</a>, <a href="tag/cronus/">Cronus</a>, <a href="tag/bees/">Bees</a></p>
+<ul class="image-details">
+    <li><a href="tag/damara/">Damara</a></li>
+    <li><a href="tag/cronus/">Cronus</a></li>
+    <li><a href="tag/bees/">Bees</a></li>
+</ul>
 `
 
 exports[`test/snapshot/generateTrackCoverArtwork.js > TAP > generateTrackCoverArtwork (snapshot) > display: primary - unique art 1`] = `
 [mocked: image
  args: [ [ { name: 'Bees', directory: 'bees', isContentWarning: false } ] ]
  slots: { path: [ 'media.trackCover', 'bee-forus-seatbelt-safebee', 'beesmp3', 'jpg' ], color: '#f28514', thumb: 'medium', id: 'cover-art', reveal: true, link: true, square: true }]
-<p>Tags: <a href="tag/bees/">Bees</a></p>
+<ul class="image-details"><li><a href="tag/bees/">Bees</a></li></ul>
 `
 
 exports[`test/snapshot/generateTrackCoverArtwork.js > TAP > generateTrackCoverArtwork (snapshot) > display: thumbnail - no unique art 1`] = `


### PR DESCRIPTION
Tweaks the way cover artworks appear, roughly as below:

https://github.com/hsmusic/hsmusic-wiki/assets/9948030/9d37f367-f327-49ce-b569-642f20122f52

Visible changes:

* Gets rid of the "Tags:" text at the start of the inline tag list and separates tags by dots instead of commas
* Puts a background and border around the tag list, giving it a "panel" appearance and more clearly delineating it from page content
* Tweaks the timing at which the sticky cover appears (the main cover can now be poking just past the top of the browser view as the sticky cover shows, and the sticky cover's hiding animation is a tiny bit slower)
* Makes the "dim" background color for images more consistently dim across pages by using chroma.js `.luminance` instead of `.darken` (only the latter is ~~additive~~ subtractive) - it should be a bit darker than before on most pages

Supporting changes:

* Generalizes the `#cover-art-container p` rule into just `.image-details`, which is now a `<ul>` (one `<li>` per tag), but works as `<p>` also
* Adds a very short client JS module to add a `.has-image-details` class manually on `#cover-art-container` — we're using `#cover-art-container:has(.image-details)` to selectively round the cover art's shadow, but this [isn't supported everywhere quite yet](https://caniuse.com/css-has)
  * In general using JavaScript to control the "right when loaded" appearance of the page is a major bad sign, which is something we've considered across code (i.e. the initial state of the page really ought to look the same even if JavaScript is outright disabled). It really is a practical concern, since the page can perform its first render before any JavaScript runs. But in this case it's a very minor, non-layout-affecting change, and will be automatically "phased out" / superseded by the browser via CSS if `:has()` is supported.
* Removes the `releaseInfo.artTags` strings as they aren't used at all anymore