### PR TITLE
Refactor string formatting across HTML and language, add "blockwrap" metatag

### DIFF
--- a/src/data/things/language.js
+++ b/src/data/things/language.js
@@ -1,8 +1,8 @@
 import { Temporal, toTemporalInstant } from '@js-temporal/polyfill';
 
-import {isLanguageCode} from '#validators';
-import {Tag} from '#html';
+import * as html from '#html';
 import {empty, withAggregate} from '#sugar';
+import {isLanguageCode} from '#validators';
 
 import {
   getExternalLinkStringOfStyleFromDescriptors,
@@ -274,8 +274,11 @@ export class Language extends Thing {
   // content is a string *that may contain HTML* and doesn't need to
   // sanitized any further. It'll still .toString() to just the string
   // contents, if needed.
-  #wrapSanitized(output) {
-    return new Tag(null, null, output);
+  #wrapSanitized(content) {
+    return html.tags(content, {
+      [html.joinChildren]: '',
+      [html.noEdgeWhitespace]: true,
+    });
   }
 
   // Similar to the above internal methods, but this one is public.
@@ -296,7 +299,7 @@ export class Language extends Thing {
 
     return (
       (typeof arg === 'string'
-        ? new Tag(null, null, escapeHTML(arg))
+        ? this.#wrapSanitized(escapeHTML(arg))
         : arg));
   }
 

--- a/src/data/things/language.js
+++ b/src/data/things/language.js
@@ -242,10 +242,7 @@ export class Language extends Thing {
       // Sanitize string arguments in particular. These are taken to come from
       // (raw) data and may include special characters that aren't meant to be
       // rendered as HTML markup.
-      const optionPart = this.#sanitizeStringArg(optionValue, {
-        // TODO: Won't need to specify preserveType.
-        preserveType: true,
-      });
+      const optionPart = this.#sanitizeStringArg(optionValue);
 
       outputParts.push(languageText);
       outputParts.push(optionPart);
@@ -280,23 +277,17 @@ export class Language extends Thing {
   // treated by the browser as a tag. This does *not* have an effect on actual
   // html.Tag objects, which are treated as sanitized by default (so that they
   // can be nested inside strings at all).
-  #sanitizeStringArg(arg, {preserveType = false} = {}) {
+  #sanitizeStringArg(arg) {
     const escapeHTML = CacheableObject.getUpdateValue(this, 'escapeHTML');
-
     if (!escapeHTML) {
       throw new Error(`escapeHTML unavailable`);
     }
 
-    if (typeof arg !== 'string') {
-      // TODO: Preserving type will be the only behavior.
-      if (preserveType) {
-        return arg;
-      } else {
-        return arg.toString();
-      }
+    if (typeof arg === 'string') {
+      return escapeHTML(arg);
+    } else {
+      return arg;
     }
-
-    return escapeHTML(arg);
   }
 
   // Wraps the output of a formatting function in a no-name-nor-attributes
@@ -321,16 +312,11 @@ export class Language extends Thing {
   // contents of a slot directly, it should be manually sanitized with this
   // function first.
   sanitize(arg) {
-    const escapeHTML = CacheableObject.getUpdateValue(this, 'escapeHTML');
-
-    if (!escapeHTML) {
-      throw new Error(`escapeHTML unavailable`);
+    if (typeof arg === 'string') {
+      return this.#wrapSanitized(this.#sanitizeStringArg(arg));
+    } else {
+      return arg;
     }
-
-    return (
-      (typeof arg === 'string'
-        ? this.#wrapSanitized(escapeHTML(arg))
-        : arg));
   }
 
   formatDate(date) {
@@ -552,10 +538,7 @@ export class Language extends Thing {
       const markerValue = array[markerIndex];
 
       const languageText = template.slice(lastIndex, match.index);
-      const markerPart = this.#sanitizeStringArg(markerValue, {
-        // TODO: Won't need to specify preserveType.
-        preserveType: true,
-      });
+      const markerPart = this.#sanitizeStringArg(markerValue);
 
       outputParts.push(languageText);
       outputParts.push(markerPart);

--- a/src/data/things/language.js
+++ b/src/data/things/language.js
@@ -283,10 +283,16 @@ export class Language extends Thing {
       throw new Error(`escapeHTML unavailable`);
     }
 
-    if (typeof arg === 'string') {
-      return escapeHTML(arg);
-    } else {
-      return arg;
+    switch (typeof arg) {
+      case 'string':
+        return escapeHTML(arg);
+
+      case 'number':
+      case 'boolean':
+        return arg.toString();
+
+      default:
+        return arg;
     }
   }
 

--- a/src/data/things/language.js
+++ b/src/data/things/language.js
@@ -255,7 +255,7 @@ export class Language extends Thing {
   // treated by the browser as a tag. This does *not* have an effect on actual
   // html.Tag objects, which are treated as sanitized by default (so that they
   // can be nested inside strings at all).
-  #sanitizeStringArg(arg) {
+  #sanitizeStringArg(arg, {preserveType = false} = {}) {
     const escapeHTML = CacheableObject.getUpdateValue(this, 'escapeHTML');
 
     if (!escapeHTML) {
@@ -263,7 +263,12 @@ export class Language extends Thing {
     }
 
     if (typeof arg !== 'string') {
-      return arg.toString();
+      // TODO: Preserving type will be the only behavior.
+      if (preserveType) {
+        return arg;
+      } else {
+        return arg.toString();
+      }
     }
 
     return escapeHTML(arg);

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -473,6 +473,10 @@ a:not([href]):hover {
   white-space: nowrap;
 }
 
+.blockwrap {
+  display: inline-block;
+}
+
 .contribution.has-tooltip,
 .datetimestamp.has-tooltip {
   position: relative;

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -284,6 +284,10 @@ export class Tag {
     }
   }
 
+  get contentOnly() {
+    return this.tagName === '' && this.attributes.blank;
+  }
+
   #setAttributeFlag(attribute, value) {
     if (value) {
       this.attributes.set(attribute, true);

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -477,8 +477,10 @@ export class Tag {
 
       // Blockwraps only apply if they actually contain some content whose
       // words should be kept together, so it's okay to put them beneath the
-      // itemContent check.
-      if (item instanceof Tag && item.blockwrap) {
+      // itemContent check. They also never apply at the very start of content,
+      // because at that point there aren't any preceding words from which the
+      // blockwrap would differentiate its content.
+      if (item instanceof Tag && item.blockwrap && content) {
         content += `<span class="blockwrap">`;
         blockwrapClosers += `</span>`;
       }


### PR DESCRIPTION
Development:

* Towards #341.

This pull request brings a few related changes together:

* **Preserve lives values through language formatting functions.**
  * Previously, `html.Tag` values (which we call "live values") which got passed into functions like `language.$` or `language.formatConjunctionList` would get stringified at the time of that formatting function call, so that they could be inserted into string surroundings, either from a template specified in a strings file, or dynamically placed by an `Intl.ListFormat` formatting function.
  * Now, we always preserve the live values passed in as template options or list items. in order to surround those values with string-based text, we wrap results in a multiple-child `html.tags` element. (We already did a similar wrapping for marking the output of a formatting function as [no longer needing sanitization](https://github.com/hsmusic/hsmusic-wiki/pull/269); we're accomplishing the same thing now, too, but also using `html.tags` to be able to bundle multiple live values together.)
  * The meat of the new formatter is in a relatively generic `#iterateOverTemplate` function, which takes a "template", a regular expression that identifies parts of the template that should be replaced, and an insertion function, which processes the match and returns the content to insert at that point. The insertion function can return `undefined` to mark output forming as canceled, in which case the rest of the matches are stlil iterated over, but no final output is returned.
    * Usage 1: Iterate over `{OPTION_NAMES}` in a language file string; insert option values as provided, or, if missing, cancel string forming and mark the option as missing. Strike used options from a list; mark unused options as misplaced.
    * Usage 2: Iterate over `<::insertion_0>`, `<::insertion_1>`, `<::insertion_2>` etc in a string that was composed by an `Intl.ListFormat` formatting function. Replace with the corresponding items in a provided array.
    * `#iterateOverTemplate` sanitizes raw string values (using `#sanitizeValueForInsertion`, née `#sanitizeStringArg`) and conjoins adjacent strings. It also flattens nested tag values that are "content only", i.e. no tag name/attributes nor special (metatag) behavior - i.e, `html.tags()`, which are most often embedded as the result of another formatting function call.
    * In general, `#iterateOverTemplate` not only is an abstraction of the basic iteration/insertion behavior, but also consolidates supplemental stuff common across `formatString` and list formatters.
  * Lists formatters (like `formatConjunctionList`) now use a `#formatListHelper` function to take care of creating and operating on insertion markers - it's just a convenient wrapper around `#iterateOverTemplate`.
  * We also detect and report misplaced language string options now (in addition to missing ones). In general, `formatString` has been touched up with fresher reading, mostly thanks to `#iterateOverTemplate`.
* **Add new `html.metatag` system, including `html.metatag('blockwrap')`.**
  * "Metatags" are tags that should be treated differently from normal tags when being processed by a parent.
  * `blockwrap` is a metatag which, during content stringification, "absorbs" all same-parent siblings following it and puts them together with its own children, under a `<span class="blockwrap">` tag.
  * Blockwrap exists as a somewhat crude, begrudgingly markup-based solution to the goal of "keep my words together on the same line, and let whatever inline content follows me come right after my last word". [See details in this write-up.](https://stackoverflow.com/questions/77729542/)

Since blockwrap fundamentally functions outside the normal stringification hierarchy behavior, the language changes are required to ensure the blockwrap itself gets stringified (at which point it can't be detected for special handling by the parent's stringification).

We don't actually *use* blockwrap anywhere in this PR - changes to content are kept for a follow-up pull request.
