### PR TITLE
Trace content function generate calls via a cause chain

### DIFF
--- a/src/content-function.js
+++ b/src/content-function.js
@@ -124,12 +124,32 @@ export function expectDependencies({
         throw new Error(`Expected relations`);
       }
 
-      if (hasDataFunction && hasRelationsFunction) {
-        return generate(arg1, arg2, ...extraArgs, fulfilledDependencies);
-      } else if (hasDataFunction || hasRelationsFunction) {
-        return generate(arg1, ...extraArgs, fulfilledDependencies);
-      } else {
-        return generate(...extraArgs, fulfilledDependencies);
+      try {
+        if (hasDataFunction && hasRelationsFunction) {
+          return generate(arg1, arg2, ...extraArgs, fulfilledDependencies);
+        } else if (hasDataFunction || hasRelationsFunction) {
+          return generate(arg1, ...extraArgs, fulfilledDependencies);
+        } else {
+          return generate(...extraArgs, fulfilledDependencies);
+        }
+      } catch (caughtError) {
+        const error = new Error(
+          `Error generating content for ${generate.name}`,
+          {cause: caughtError});
+
+        error[Symbol.for(`hsmusic.aggregate.alwaysTrace`)] = true;
+        error[Symbol.for(`hsmusic.aggregate.traceFrom`)] = caughtError;
+
+        error[Symbol.for(`hsmusic.aggregate.unhelpfulTraceLines`)] = [
+          /content-function\.js/,
+          /util\/html\.js/,
+        ];
+
+        error[Symbol.for(`hsmusic.aggregate.helpfulTraceLines`)] = [
+          /content\/dependencies\/(.*\.js:.*(?=\)))/,
+        ];
+
+        throw error;
       }
     };
 

--- a/src/write/build-modes/live-dev-server.js
+++ b/src/write/build-modes/live-dev-server.js
@@ -84,11 +84,14 @@ export async function go({
   niceShowAggregate,
 }) {
   const showError = (error) => {
-    if (error instanceof AggregateError && niceShowAggregate) {
-      niceShowAggregate(error);
-    } else {
-      console.error(inspect(error, {depth: Infinity}));
+    if (niceShowAggregate) {
+      if (error.errors || error.cause) {
+        niceShowAggregate(error);
+        return;
+      }
     }
+
+    console.error(inspect(error, {depth: Infinity}));
   };
 
   const host = cliOptions['host'] ?? defaultHost;


### PR DESCRIPTION
This PR makes errors thrown in a content function's `generate()` description insert an `error.cause`-chain layer, and always indicate where in the content function was responsible for the error. This works by hooking into a few new symbol-based properties for errors, which `showAggregate` uses to figure out the right stack trace line to show.

It also makes live-dev-server use `showAggregate` more aggressively (if an error is an aggregate *or* has `cause`, `showAggregate` will be used, now).

<img width="954" alt="Trace showing 'error generating content for...' layers, which show the responsible line and column number in that content function's file" src="https://github.com/hsmusic/hsmusic-wiki/assets/9948030/7b89ba6a-638d-442f-b16b-bd8ec50b2fe9">
