### PR TITLE
Improve HTML tag inspection and error tracing

### DIFF
--- a/src/util/html.js
+++ b/src/util/html.js
@@ -397,14 +397,27 @@ export class Tag {
     const joiner =
       (this.joinChildren === undefined
         ? '\n'
-        : (this.joinChildren === ''
-            ? ''
-            : `\n${this.joinChildren}\n`));
+     : this.joinChildren === ''
+        ? ''
+        : `\n${this.joinChildren}\n`);
 
-    return this.content
-      .map(item => item.toString())
-      .filter(Boolean)
-      .join(joiner);
+    let content = '';
+
+    for (const [index, item] of this.content.entries()) {
+      const itemContent = item.toString();
+
+      if (!itemContent) {
+        continue;
+      }
+
+      if (content) {
+        content += joiner;
+      }
+
+      content += itemContent;
+    }
+
+    return content;
   }
 
   static normalize(content) {

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -1068,7 +1068,13 @@ export class Template {
       slots[slotName] = this.getSlotValue(slotName);
     }
 
-    return this.description.content(slots);
+    try {
+      return this.description.content(slots);
+    } catch (caughtError) {
+      throw new Error(
+        `Error computing content of ${inspect(this, {compact: true})}`,
+        {cause: caughtError});
+    }
   }
 
   set description(_value) {

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -404,7 +404,17 @@ export class Tag {
     let content = '';
 
     for (const [index, item] of this.content.entries()) {
-      const itemContent = item.toString();
+      let itemContent;
+
+      try {
+        itemContent = item.toString();
+      } catch (caughtError) {
+        throw new Error(
+          `Error stringifying child #${index + 1} ` +
+          `of ${inspect(this, {compact: true})}: ` +
+          inspect(item, {compact: true}),
+          {cause: caughtError});
+      }
 
       if (!itemContent) {
         continue;

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -435,20 +435,50 @@ export class Tag {
     return new Tag(null, null, content);
   }
 
-  [inspect.custom]() {
-    if (this.tagName) {
-      if (empty(this.content)) {
-        return `Tag <${this.tagName} />`;
-      } else {
-        return `Tag <${this.tagName}> (${this.content.length} items)`;
-      }
-    } else {
-      if (empty(this.content)) {
-        return `Tag (no name)`;
-      } else {
-        return `Tag (no name, ${this.content.length} items)`;
+  [inspect.custom](depth, opts) {
+    const lines = [];
+
+    const heading =
+      (this.tagName
+        ? (empty(this.content)
+            ? `Tag <${this.tagName} />`
+            : `Tag <${this.tagName}> (${this.content.length} items)`)
+        : (empty(this.content)
+            ? `Tag (no name)`
+            : `Tag (no name, ${this.content.length} items)`));
+
+    lines.push(heading);
+
+    if (!opts.compact && (depth === null || depth >= 0)) {
+      const nextDepth =
+        (depth === null
+          ? null
+          : depth - 1);
+
+      for (const child of this.content) {
+        const childLines = [];
+
+        if (typeof child === 'string') {
+          const childFlat = child.replace(/\n/g, String.raw`\n`);
+          const childTrim =
+            (childFlat.length >= 40
+              ? childFlat.slice(0, 37) + '...'
+              : childFlat);
+
+          childLines.push(
+            `  Text: ${opts.stylize(`"${childTrim}"`, 'string')}`);
+        } else {
+          childLines.push(...
+            inspect(child, {depth: nextDepth})
+              .split('\n')
+              .map(line => `  ${line}`));
+        }
+
+        lines.push(...childLines);
       }
     }
+
+    return lines.join('\n');
   }
 }
 

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -410,7 +410,7 @@ export class Tag {
         itemContent = item.toString();
       } catch (caughtError) {
         throw new Error(
-          `Error stringifying child #${index + 1} ` +
+          `Error in child #${index + 1} ` +
           `of ${inspect(this, {compact: true})}: ` +
           inspect(item, {compact: true}),
           {cause: caughtError});
@@ -448,11 +448,44 @@ export class Tag {
   [inspect.custom](depth, opts) {
     const lines = [];
 
+    const niceAttributes = ['id', 'class'];
+    const attributes = new Attributes();
+
+    for (const attribute of niceAttributes) {
+      if (this.attributes.has(attribute)) {
+        const value = this.attributes.get(attribute);
+
+        let string;
+        let suffix = '';
+
+        if (Array.isArray(value)) {
+          string = value[0].toString();
+          if (value.length > 1) {
+            suffix = ` (+${value.length - 1})`;
+          }
+        } else {
+          string = value.toString();
+        }
+
+        const trim =
+          (string.length > 15
+            ? `${string.slice(0, 12)}...`
+            : string);
+
+        attributes.set(attribute, trim + suffix);
+      }
+    }
+
+    const attributesPart =
+      (attributes.blank
+        ? ``
+        : ` ${attributes}`);
+
     const heading =
       (this.tagName
         ? (empty(this.content)
-            ? `Tag <${this.tagName} />`
-            : `Tag <${this.tagName}> (${this.content.length} items)`)
+            ? `Tag <${this.tagName + attributesPart} />`
+            : `Tag <${this.tagName + attributesPart}> (${this.content.length} items)`)
         : (empty(this.content)
             ? `Tag (no name)`
             : `Tag (no name, ${this.content.length} items)`));

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -411,8 +411,7 @@ export class Tag {
       } catch (caughtError) {
         throw new Error(
           `Error in child #${index + 1} ` +
-          `of ${inspect(this, {compact: true})}: ` +
-          inspect(item, {compact: true}),
+          `of ${inspect(this, {compact: true})}`,
           {cause: caughtError});
       }
 

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -491,6 +491,10 @@ export class Attributes {
     return value;
   }
 
+  has(attribute) {
+    return attribute in this.#attributes;
+  }
+
   get(attribute) {
     return this.#attributes[attribute];
   }

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -472,6 +472,16 @@ export class Attributes {
     return this.#attributes;
   }
 
+  get blank() {
+    const attributeValues =
+      Object.values(this.#attributes);
+
+    const keepAnyAttributes =
+      attributeValues.some(value => this.#keepAttributeValue(value));
+
+    return !keepAnyAttributes;
+  }
+
   set(attribute, value) {
     if (value === null || value === undefined) {
       this.remove(attribute);


### PR DESCRIPTION
This PR does three things:

* Stringify a representation of a tag's child tree (up to `util.inspect`'s depth) if `compact` is false.
  * Inspect children and indent them beneath the heading for the current tag.
* Stringify a representation of a tag's `id` and `class` attributes (regardless `compact`).
  * Other attributes can be added, but these are the two most useful for identifying an element right away.
  * For `class` (and other array values), only the first value is shown, with a "+1" (or greater) for additional values.
  * individual values are chopped to 15 characters max.
* Insert an `error.cause` layer inspecting (with `compact: true`) the tag in which an error occurs while stringifying HTML elements.

<img width="864" alt="Fancy error chain showing the tag hierarchy where an error in a template occurred" src="https://github.com/hsmusic/hsmusic-wiki/assets/9948030/b2358aa9-b620-4117-a427-e1a480982dad">
