### PR TITLE
Fast oneOf() by validator introspection

### DIFF
--- a/src/data/composite/wiki-data/inputThingClass.js
+++ b/src/data/composite/wiki-data/inputThingClass.js
@@ -3,7 +3,7 @@
 // referencing Thing class values defined outside of the #composite folder.
 
 import {input} from '#composite';
-import {isType} from '#validators';
+import {isFunction} from '#validators';
 
 // TODO: Kludge.
 import Thing from '../../things/thing.js';
@@ -11,7 +11,7 @@ import Thing from '../../things/thing.js';
 export default function inputThingClass() {
   return input.staticValue({
     validate(thingClass) {
-      isType(thingClass, 'function');
+      isFunction(thingClass);
 
       if (!Object.hasOwn(thingClass, Thing.referenceType)) {
         throw new TypeError(`Expected a Thing constructor, missing Thing.referenceType`);

--- a/src/data/things/validators.js
+++ b/src/data/things/validators.js
@@ -12,6 +12,20 @@ function inspect(value) {
   return nodeInspect(value, {colors: ENABLE_COLOR});
 }
 
+export function getValidatorCreator(validator) {
+  return validator[Symbol.for(`hsmusic.validator.creator`)] ?? null;
+}
+
+export function getValidatorCreatorMeta(validator) {
+  return validator[Symbol.for(`hsmusic.validator.creatorMeta`)] ?? null;
+}
+
+export function setValidatorCreatorMeta(validator, creator, meta) {
+  validator[Symbol.for(`hsmusic.validator.creator`)] = creator;
+  validator[Symbol.for(`hsmusic.validator.creatorMeta`)] = meta;
+  return validator;
+}
+
 // Basic types (primitives)
 
 export function a(noun) {

--- a/src/data/things/validators.js
+++ b/src/data/things/validators.js
@@ -32,20 +32,37 @@ export function a(noun) {
   return /[aeiou]/.test(noun[0]) ? `an ${noun}` : `a ${noun}`;
 }
 
-export function isType(value, type) {
-  if (typeof value !== type)
-    throw new TypeError(`Expected ${a(type)}, got ${typeAppearance(value)}`);
+export function validateType(type) {
+  const fn = value => {
+    if (typeof value !== type)
+      throw new TypeError(`Expected ${a(type)}, got ${typeAppearance(value)}`);
 
-  return true;
+    return true;
+  };
+
+  setValidatorCreatorMeta(fn, validateType, {type});
+
+  return fn;
 }
 
-export function isBoolean(value) {
-  return isType(value, 'boolean');
-}
+export const isBoolean =
+  validateType('boolean');
 
-export function isNumber(value) {
-  return isType(value, 'number');
-}
+export const isFunction =
+  validateType('function');
+
+export const isNumber =
+  validateType('number');
+
+export const isString =
+  validateType('string');
+
+export const isSymbol =
+  validateType('symbol');
+
+// Use isObject instead, which disallows null.
+export const isTypeofObject =
+  validateType('object');
 
 export function isPositive(number) {
   isNumber(number);
@@ -101,10 +118,6 @@ export function isWholeNumber(number) {
   return true;
 }
 
-export function isString(value) {
-  return isType(value, 'string');
-}
-
 export function isStringNonEmpty(value) {
   isString(value);
 
@@ -142,12 +155,13 @@ export function isDate(value) {
 }
 
 export function isObject(value) {
-  isType(value, 'object');
+  isTypeofObject(value);
 
   // Note: Please remember that null is always a valid value for properties
   // held by a CacheableObject. This assertion is exclusively for use in other
   // contexts.
-  if (value === null) throw new TypeError(`Expected an object, got null`);
+  if (value === null)
+    throw new TypeError(`Expected an object, got null`);
 
   return true;
 }
@@ -245,7 +259,11 @@ export function sparseArrayOf(itemValidator) {
 }
 
 export function validateInstanceOf(constructor) {
-  return (object) => isInstance(object, constructor);
+  const fn = (object) => isInstance(object, constructor);
+
+  setValidatorCreatorMeta(fn, validateInstanceOf, {constructor});
+
+  return fn;
 }
 
 // Wiki data (primitives & non-primitives)

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -7,6 +7,10 @@ import {empty, typeAppearance} from '#sugar';
 import * as commonValidators from '#validators';
 
 const {
+  is,
+  isArray,
+  isString,
+  oneOf,
   validateArrayItems,
   validateInstanceOf,
 } = commonValidators;
@@ -1213,26 +1217,19 @@ export const isTag =
 export const isTemplate =
   validateInstanceOf(Template);
 
-export function isHTML(value) {
-  if (typeof value === 'string') {
-    return true;
-  }
-
-  if (value === null || value === undefined || value === false) {
-    return true;
-  }
-
-  if (isBlank(value) || value instanceof Tag || value instanceof Template) {
-    return true;
-  }
-
-  if (isArrayOfHTML(value)) {
-    return true;
-  }
-
-  throw new TypeError(
-    `Expected html (tag, template, or blank), got ${typeAppearance(value)}`);
-}
-
 export const isArrayOfHTML =
-  validateArrayItems(isHTML);
+  validateArrayItems(value => isHTML(value));
+
+export const isHTML =
+  oneOf(
+    is(null, undefined, false),
+    isString,
+    isTag,
+    isTemplate,
+
+    value => {
+      isArray(value);
+      return value.length === 0;
+    },
+
+    isArrayOfHTML);

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -6,6 +6,10 @@ import {colors} from '#cli';
 import {empty, typeAppearance} from '#sugar';
 import * as commonValidators from '#validators';
 
+const {
+  validateInstanceOf,
+} = commonValidators;
+
 // COMPREHENSIVE!
 // https://html.spec.whatwg.org/multipage/syntax.html#void-elements
 export const selfClosingTags = [
@@ -70,14 +74,6 @@ export function isBlank(value) {
   }
 
   return value.length === 0;
-}
-
-export function isTag(value) {
-  return value instanceof Tag;
-}
-
-export function isTemplate(value) {
-  return value instanceof Template;
 }
 
 export function isHTML(value) {
@@ -1238,3 +1234,9 @@ export class Stationery {
         : `Stationery ${colors.dim(`(no annotation)`)}`));
   }
 }
+
+export const isTag =
+  validateInstanceOf(Tag);
+
+export const isTemplate =
+  validateInstanceOf(Template);

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -57,11 +57,11 @@ export const blockwrap = Symbol();
 // html.blank()) and false for Tags and Templates (regardless of contents or
 // other properties). Don't depend on this to match any other values.
 export function isBlank(value) {
-  if (isTag(value)) {
+  if (value instanceof Tag) {
     return false;
   }
 
-  if (isTemplate(value)) {
+  if (value instanceof Template) {
     return false;
   }
 
@@ -89,7 +89,7 @@ export function isHTML(value) {
     return true;
   }
 
-  if (isBlank(value) || isTag(value) || isTemplate(value)) {
+  if (isBlank(value) || value instanceof Tag || value instanceof Template) {
     return true;
   }
 
@@ -111,7 +111,7 @@ export function isAttributes(value) {
     return false;
   }
 
-  if (isTag(value) || isTemplate(value)) {
+  if (value instanceof Tag || value instanceof Template) {
     return false;
   }
 
@@ -132,19 +132,11 @@ export const validators = {
   },
 
   isTag(value) {
-    if (!isTag(value)) {
-      throw new TypeError(`Expected HTML tag`);
-    }
-
-    return true;
+    return isTag(value);
   },
 
   isTemplate(value) {
-    if (!isTemplate(value)) {
-      throw new TypeError(`Expected HTML template`);
-    }
-
-    return true;
+    return isTemplate(value);
   },
 
   isHTML(value) {
@@ -1077,7 +1069,7 @@ export class Template {
         case 'string': {
           // Tags and templates are valid in string arguments - they'll be
           // stringified when exposed to the description's .content() function.
-          if (isTag(value) || isTemplate(value))
+          if (value instanceof Tag || value instanceof Template)
             return true;
 
           if (typeof value !== 'string')
@@ -1115,7 +1107,7 @@ export class Template {
     }
 
     if (description.type === 'string') {
-      if (isTag(providedValue) || isTemplate(providedValue)) {
+      if (providedValue instanceof Tag || providedValue instanceof Template) {
         return providedValue.toString();
       }
     }

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -7,6 +7,7 @@ import {empty, typeAppearance} from '#sugar';
 import * as commonValidators from '#validators';
 
 const {
+  validateArrayItems,
   validateInstanceOf,
 } = commonValidators;
 
@@ -76,28 +77,6 @@ export function isBlank(value) {
   return value.length === 0;
 }
 
-export function isHTML(value) {
-  if (typeof value === 'string') {
-    return true;
-  }
-
-  if (value === null || value === undefined || value === false) {
-    return true;
-  }
-
-  if (isBlank(value) || value instanceof Tag || value instanceof Template) {
-    return true;
-  }
-
-  if (Array.isArray(value)) {
-    if (value.every(isHTML)) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
 export function isAttributes(value) {
   if (typeof value !== 'object' || Array.isArray(value)) {
     return false;
@@ -136,11 +115,7 @@ export const validators = {
   },
 
   isHTML(value) {
-    if (!isHTML(value)) {
-      throw new TypeError(`Expected HTML content`);
-    }
-
-    return true;
+    return isHTML(value);
   },
 
   isAttributes(value) {
@@ -1056,10 +1031,7 @@ export class Template {
     if ('type' in description) {
       switch (description.type) {
         case 'html': {
-          if (!isHTML(value))
-            throw new TypeError(`Slot expects html (tag, template or blank), got ${typeof value}`);
-
-          return true;
+          return isHTML(value);
         }
 
         case 'string': {
@@ -1240,3 +1212,27 @@ export const isTag =
 
 export const isTemplate =
   validateInstanceOf(Template);
+
+export function isHTML(value) {
+  if (typeof value === 'string') {
+    return true;
+  }
+
+  if (value === null || value === undefined || value === false) {
+    return true;
+  }
+
+  if (isBlank(value) || value instanceof Tag || value instanceof Template) {
+    return true;
+  }
+
+  if (isArrayOfHTML(value)) {
+    return true;
+  }
+
+  throw new TypeError(
+    `Expected html (tag, template, or blank), got ${typeAppearance(value)}`);
+}
+
+export const isArrayOfHTML =
+  validateArrayItems(isHTML);


### PR DESCRIPTION
This PR speeds up most calls to `oneOf()` by causing it to do an initial round of introspection and then perform the operations of `validateType`, `validateInstanceOf`, and `is` inline, instead of entering the corresponding validator function.

The greatest speed-up is from combining multiple `typeof` calls (e.g. `oneOf(isString, isBoolean, isNumber)`) into one; now we just perform `validTypes.has(typeof value)` once. The other changes help too, but to a lesser degree.

In order to support introspection like this more generally, validators can now have "creator meta" details specified. These are accessed with a host of utility functions, or the global symbols `hsmusic.validator.creator` and `hsmusic.validator.creatorMeta`.

This PR also ports `#html` functions `isTag`, `isTemplate` and `isHTML` to be proper validator functions, mostly composed out of existing validators.