### PR TITLE
Add type: 'attributes' slot, refactor link colors

### DIFF
--- a/src/content/dependencies/generateAlbumSecondaryNav.js
+++ b/src/content/dependencies/generateAlbumSecondaryNav.js
@@ -120,7 +120,7 @@ export default {
 
             return (
               html.tag('span',
-                colorStyle,
+                colorStyle.slot('context', 'primary-only'),
 
                 [
                   language.$('albumSidebar.groupBox.title', {

--- a/src/content/dependencies/generateColorStyleAttribute.js
+++ b/src/content/dependencies/generateColorStyleAttribute.js
@@ -20,6 +20,7 @@ export default {
     context: {
       validate: v => v.is(
         'any-content',
+        'image-box',
         'primary-only'),
 
       default: 'any-content',

--- a/src/content/dependencies/generateColorStyleAttribute.js
+++ b/src/content/dependencies/generateColorStyleAttribute.js
@@ -20,7 +20,6 @@ export default {
     context: {
       validate: v => v.is(
         'any-content',
-        'page-root',
         'primary-only'),
 
       default: 'any-content',

--- a/src/content/dependencies/generateColorStyleVariables.js
+++ b/src/content/dependencies/generateColorStyleVariables.js
@@ -9,6 +9,7 @@ export default {
     context: {
       validate: v => v.is(
         'any-content',
+        'image-box',
         'page-root',
         'primary-only'),
 
@@ -49,6 +50,13 @@ export default {
     switch (slots.context) {
       case 'any-content':
         selectedProperties = anyContent;
+        break;
+
+      case 'image-box':
+        selectedProperties = [
+          `--primary-color: ${primary}`,
+          `--dim-color: ${dim}`,
+        ];
         break;
 
       case 'page-root':

--- a/src/content/dependencies/generateCoverGrid.js
+++ b/src/content/dependencies/generateCoverGrid.js
@@ -31,6 +31,7 @@ export default {
         }).map(({image, link, name, info}, index) =>
             link.slots({
               attributes: {class: ['grid-item', 'box']},
+              colorContext: 'image-box',
               content: [
                 image.slots({
                   thumb: 'medium',

--- a/src/content/dependencies/image.js
+++ b/src/content/dependencies/image.js
@@ -158,7 +158,10 @@ export default {
 
     if (slots.color) {
       const colorStyle =
-        relations.colorStyle.slot('color', slots.color);
+        relations.colorStyle.slots({
+          color: slots.color,
+          context: 'image-box',
+        });
 
       if (willLink) {
         linkAttributes.add(colorStyle);

--- a/src/content/dependencies/linkTemplate.js
+++ b/src/content/dependencies/linkTemplate.js
@@ -18,7 +18,7 @@ export default {
     linkless: {type: 'boolean', default: false},
 
     tooltip: {type: 'string'},
-    attributes: {validate: v => v.isAttributes},
+    attributes: {type: 'attributes'},
     color: {validate: v => v.isColor},
     content: {type: 'html'},
   },

--- a/src/content/dependencies/linkTemplate.js
+++ b/src/content/dependencies/linkTemplate.js
@@ -27,7 +27,7 @@ export default {
     language,
     to,
   }) {
-    const attributes = html.attributes();
+    const {attributes} = slots;
 
     if (!slots.linkless) {
       let href =
@@ -61,10 +61,6 @@ export default {
             disallowedTags: new Set(['a']),
           }));
 
-    return (
-      html.tag('a',
-        attributes,
-        slots.attributes,
-        content));
+    return html.tag('a', attributes, content);
   },
 }

--- a/src/content/dependencies/linkTemplate.js
+++ b/src/content/dependencies/linkTemplate.js
@@ -5,7 +5,6 @@ import striptags from 'striptags';
 export default {
   extraDependencies: [
     'appendIndexHTML',
-    'getColors',
     'html',
     'language',
     'to',
@@ -19,13 +18,11 @@ export default {
 
     tooltip: {type: 'string'},
     attributes: {type: 'attributes'},
-    color: {validate: v => v.isColor},
     content: {type: 'html'},
   },
 
   generate(slots, {
     appendIndexHTML,
-    getColors,
     html,
     language,
     to,
@@ -51,12 +48,6 @@ export default {
       }
 
       attributes.add({href});
-    }
-
-    if (slots.color) {
-      const {primary, dim} = getColors(slots.color);
-      attributes.set('style',
-        `--primary-color: ${primary}; --dim-color: ${dim}`);
     }
 
     if (slots.tooltip) {

--- a/src/content/dependencies/linkThing.js
+++ b/src/content/dependencies/linkThing.js
@@ -36,6 +36,7 @@ export default {
 
     colorContext: {
       validate: v => v.is(
+        'image-box',
         'primary-only'),
 
       default: 'primary-only',
@@ -81,6 +82,13 @@ export default {
       let selectColors;
 
       switch (slots.colorContext) {
+        case 'image-box':
+          selectColors = {
+            '--primary-color': 'primary',
+            '--dim-color': 'dim',
+          };
+          break;
+
         case 'primary-only':
           selectColors = {
             '--primary-color': 'primary',

--- a/src/content/dependencies/linkThing.js
+++ b/src/content/dependencies/linkThing.js
@@ -45,7 +45,7 @@ export default {
     anchor: {type: 'boolean', default: false},
     linkless: {type: 'boolean', default: false},
 
-    attributes: {validate: v => v.isAttributes},
+    attributes: {type: 'attributes'},
     hash: {type: 'string'},
   },
 

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -1378,7 +1378,8 @@ export const isAttributeKey =
 export const isAttributeValue =
   oneOf(
     isString, isNumber, isBoolean, isArray,
-    isTag, isTemplate);
+    isTag, isTemplate,
+    validateArrayItems(item => isAttributeValue(item)));
 
 export const isAttributesAdditionPair = pair => {
   isArray(pair);

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -644,7 +644,11 @@ export class Attributes {
 
   set(attribute, value) {
     if (value instanceof Template) {
-      return this.set(attribute, Template.resolve(value));
+      value = Template.resolve(value);
+    }
+
+    if (Array.isArray(value)) {
+      value = value.flat(Infinity);
     }
 
     if (value === null || value === undefined) {
@@ -722,6 +726,10 @@ export class Attributes {
 
     if (value instanceof Template) {
       return this.#addOneAttribute(attribute, Template.resolve(value));
+    }
+
+    if (Array.isArray(value)) {
+      value = value.flat(Infinity);
     }
 
     if (!this.has(attribute)) {

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -600,6 +600,10 @@ export class Attributes {
     this.attributes = attributes;
   }
 
+  clone() {
+    return new Attributes(this);
+  }
+
   set attributes(value) {
     this.#attributes = Object.create(null);
 

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -155,13 +155,21 @@ export function blank() {
 }
 
 export function tag(tagName, ...args) {
+  const lastArg = args.at(-1);
+
+  const lastArgIsAttributes =
+    typeof lastArg === 'object' && lastArg !== null &&
+    !Array.isArray(lastArg) &&
+    !(lastArg instanceof Tag) &&
+    !(lastArg instanceof Template);
+
   const content =
-    (isAttributes(args.at(-1))
+    (lastArgIsAttributes
       ? null
       : args.at(-1));
 
   const attributes =
-    (isAttributes(args.at(-1))
+    (lastArgIsAttributes
       ? args
       : args.slice(0, -1));
 

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -1056,6 +1056,7 @@ export class Template {
           'boolean',
           'symbol',
           'html',
+          'attributes',
         ];
 
         if (slotDescription.type === 'function') {
@@ -1160,6 +1161,10 @@ export class Template {
           return isHTML(value);
         }
 
+        case 'attributes': {
+          return isAttributesAdditionSingletValue(value);
+        }
+
         case 'string': {
           // Tags and templates are valid in string arguments - they'll be
           // stringified when exposed to the description's .content() function.
@@ -1198,6 +1203,18 @@ export class Template {
       }
 
       return providedValue;
+    }
+
+    if (description.type === 'attributes') {
+      if (!providedValue) {
+        return blankAttributes();
+      }
+
+      if (providedValue instanceof Attributes) {
+        return providedValue.clone();
+      }
+
+      return new Attributes(providedValue);
     }
 
     if (description.type === 'string') {

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -130,6 +130,10 @@ export function blank() {
   return [];
 }
 
+export function blankAttributes() {
+  return new Attributes();
+}
+
 export function tag(tagName, ...args) {
   const lastArg = args.at(-1);
 
@@ -477,7 +481,7 @@ export class Tag {
     const lines = [];
 
     const niceAttributes = ['id', 'class'];
-    const attributes = new Attributes();
+    const attributes = blankAttributes();
 
     for (const attribute of niceAttributes) {
       if (this.attributes.has(attribute)) {

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -100,27 +100,7 @@ export function isBlank(value) {
   return value.length === 0;
 }
 
-export function isAttributes(value) {
-  if (typeof value !== 'object' || Array.isArray(value)) {
-    return false;
-  }
-
-  if (value === null) {
-    return false;
-  }
-
-  if (value instanceof Tag || value instanceof Template) {
-    return false;
-  }
-
-  // TODO: Validate attribute values (just the general shape)
-
-  return true;
-}
-
 export const validators = {
-  // TODO: Move above implementations here and detail errors
-
   isBlank(value) {
     if (!isBlank(value)) {
       throw new TypeError(`Expected html.blank()`);
@@ -142,11 +122,7 @@ export const validators = {
   },
 
   isAttributes(value) {
-    if (!isAttributes(value)) {
-      throw new TypeError(`Expected HTML attributes`);
-    }
-
-    return true;
+    return isAttributesAdditionSingletValue(value);
   },
 };
 

--- a/tap-snapshots/test/snapshot/generateAlbumSecondaryNav.js.test.cjs
+++ b/tap-snapshots/test/snapshot/generateAlbumSecondaryNav.js.test.cjs
@@ -7,11 +7,11 @@
 'use strict'
 exports[`test/snapshot/generateAlbumSecondaryNav.js > TAP > generateAlbumSecondaryNav (snapshot) > basic behavior, mode: album 1`] = `
 <nav id="secondary-nav" class="nav-links-groups">
-    <span style="--primary-color: #abcdef; --dark-color: #21272e; --dim-color: #818181; --dim-ghost-color: #818181cc; --bg-color: #161616cc; --bg-black-color: #06090bcc; --shadow-color: #0d0d0dcc">
+    <span style="--primary-color: #abcdef">
         <a href="group/vcg/">VCG</a>
         (<a href="album/first/" title="First">Previous</a>, <a href="album/last/" title="Last">Next</a>)
     </span>
-    <span style="--primary-color: #123456; --dark-color: #0e2842; --dim-color: #000000; --dim-ghost-color: #000000cc; --bg-color: #161616cc; --bg-black-color: #000913cc; --shadow-color: #0d0d0dcc">
+    <span style="--primary-color: #123456">
         <a href="group/bepis/">Bepis</a>
         (<a href="album/second/" title="Second">Next</a>)
     </span>

--- a/tap-snapshots/test/snapshot/generateAlbumSecondaryNav.js.test.cjs
+++ b/tap-snapshots/test/snapshot/generateAlbumSecondaryNav.js.test.cjs
@@ -20,14 +20,14 @@ exports[`test/snapshot/generateAlbumSecondaryNav.js > TAP > generateAlbumSeconda
 
 exports[`test/snapshot/generateAlbumSecondaryNav.js > TAP > generateAlbumSecondaryNav (snapshot) > basic behavior, mode: track 1`] = `
 <nav id="secondary-nav" class="nav-links-groups">
-    <a href="group/vcg/" style="--primary-color: #abcdef; --dim-color: #818181">VCG</a>
-    <a href="group/bepis/" style="--primary-color: #123456; --dim-color: #000000">Bepis</a>
+    <a style="--primary-color: #abcdef" href="group/vcg/">VCG</a>
+    <a style="--primary-color: #123456" href="group/bepis/">Bepis</a>
 </nav>
 `
 
 exports[`test/snapshot/generateAlbumSecondaryNav.js > TAP > generateAlbumSecondaryNav (snapshot) > dateless album in mixed group 1`] = `
 <nav id="secondary-nav" class="nav-links-groups">
-    <a href="group/vcg/" style="--primary-color: #abcdef; --dim-color: #818181">VCG</a>
-    <a href="group/bepis/" style="--primary-color: #123456; --dim-color: #000000">Bepis</a>
+    <a style="--primary-color: #abcdef" href="group/vcg/">VCG</a>
+    <a style="--primary-color: #123456" href="group/bepis/">Bepis</a>
 </nav>
 `

--- a/tap-snapshots/test/snapshot/linkTemplate.js.test.cjs
+++ b/tap-snapshots/test/snapshot/linkTemplate.js.test.cjs
@@ -6,7 +6,7 @@
  */
 'use strict'
 exports[`test/snapshot/linkTemplate.js > TAP > linkTemplate (snapshot) > fill many slots 1`] = `
-<a href="https://hsmusic.wiki/media/cool%20file.pdf#fooey" style="--primary-color: #123456ff; --dim-color: #12345677" class="dog" id="cat1">My Cool Link</a>
+<a class="dog" id="cat1" href="https://hsmusic.wiki/media/cool%20file.pdf#fooey">My Cool Link</a>
 `
 
 exports[`test/snapshot/linkTemplate.js > TAP > linkTemplate (snapshot) > fill path slot & provide appendIndexHTML 1`] = `

--- a/tap-snapshots/test/snapshot/linkThing.js.test.cjs
+++ b/tap-snapshots/test/snapshot/linkThing.js.test.cjs
@@ -6,13 +6,13 @@
  */
 'use strict'
 exports[`test/snapshot/linkThing.js > TAP > linkThing (snapshot) > basic behavior 1`] = `
-<a href="track/foo/" style="--primary-color: #abcdef; --dim-color: #818181">Cool track!</a>
+<a style="--primary-color: #abcdef" href="track/foo/">Cool track!</a>
 `
 
 exports[`test/snapshot/linkThing.js > TAP > linkThing (snapshot) > color 1`] = `
 <a href="track/showtime-piano-refrain/">Showtime (Piano Refrain)</a>
-<a href="track/showtime-piano-refrain/" style="--primary-color: #38f43d; --dim-color: #389f33">Showtime (Piano Refrain)</a>
-<a href="track/showtime-piano-refrain/" style="--primary-color: #aaccff; --dim-color: #828282">Showtime (Piano Refrain)</a>
+<a style="--primary-color: #38f43d" href="track/showtime-piano-refrain/">Showtime (Piano Refrain)</a>
+<a style="--primary-color: #aaccff" href="track/showtime-piano-refrain/">Showtime (Piano Refrain)</a>
 `
 
 exports[`test/snapshot/linkThing.js > TAP > linkThing (snapshot) > nested links in content stripped 1`] = `

--- a/tap-snapshots/test/snapshot/transformContent.js.test.cjs
+++ b/tap-snapshots/test/snapshot/transformContent.js.test.cjs
@@ -52,16 +52,16 @@ All yor base r blong 2 us.
 exports[`test/snapshot/transformContent.js > TAP > transformContent (snapshot) > inline images 1`] = `
 <p><img src="snooping.png"> as USUAL...</p>
 <p>What do you know? <img src="cowabunga.png" width="24" height="32"></p>
-<p><a href="to-localized.album/cool-album" style="--primary-color: #123456; --dim-color: #000000">I'm on the left.</a><img src="im-on-the-right.jpg"></p>
-<p><img src="im-on-the-left.jpg"><a href="to-localized.album/cool-album" style="--primary-color: #123456; --dim-color: #000000">I'm on the right.</a></p>
+<p><a style="--primary-color: #123456" href="to-localized.album/cool-album">I'm on the left.</a><img src="im-on-the-right.jpg"></p>
+<p><img src="im-on-the-left.jpg"><a style="--primary-color: #123456" href="to-localized.album/cool-album">I'm on the right.</a></p>
 <p>Media time! <img src="to-media.path/misc/interesting.png"> Oh yeah!</p>
 <p><img src="must.png"><img src="stick.png"><img src="together.png"></p>
 <p>And... all done! <img src="end-of-source.png"></p>
 `
 
 exports[`test/snapshot/transformContent.js > TAP > transformContent (snapshot) > links to a thing 1`] = `
-<p>This is <a href="to-localized.album/cool-album" style="--primary-color: #123456; --dim-color: #000000">my favorite album</a>.</p>
-<p>That&#39;s right, <a href="to-localized.album/cool-album" style="--primary-color: #123456; --dim-color: #000000">Cool Album</a>!</p>
+<p>This is <a style="--primary-color: #123456" href="to-localized.album/cool-album">my favorite album</a>.</p>
+<p>That&#39;s right, <a style="--primary-color: #123456" href="to-localized.album/cool-album">Cool Album</a>!</p>
 `
 
 exports[`test/snapshot/transformContent.js > TAP > transformContent (snapshot) > lyrics - basic line breaks 1`] = `

--- a/test/snapshot/linkTemplate.js
+++ b/test/snapshot/linkTemplate.js
@@ -8,12 +8,7 @@ testContentFunctions(t, 'linkTemplate (snapshot)', async (t, evaluate) => {
   evaluate.snapshot('fill many slots', {
     name: 'linkTemplate',
 
-    extraDependencies: {
-      getColors: c => ({primary: c + 'ff', dim: c + '77'}),
-    },
-
     slots: {
-      'color': '#123456',
       'href': 'https://hsmusic.wiki/media/cool file.pdf',
       'hash': 'fooey',
       'attributes': {class: 'dog', id: 'cat1'},


### PR DESCRIPTION
Various changes bundled:

* New `type: 'attributes'` slot, analogous to `type: 'html'`, which passes in an `Attributes`-form object made/cloned from the provided slot value.
* Refactoring for attributes validation; the specialized behavior used to check the last argument of an `html.tag()` call is inlined there, and otherwise attributes are always validated with `isAttributesAdditionSingletValue`.
* `isAttributeValue` now accepts a (recursive) array of attribute values (ex. `class: ['a', ['b', 'c']]`), which gets flattened when setting or adding attributes.
* Inline color behavior is moved from `linkTemplate` to `linkThing`, which newly takes a `colorContext` attribute, analogous to `generateColorStyleAttribute`.