### PR TITLE
HTML inspection improvements

### DIFF
--- a/src/util/html.js
+++ b/src/util/html.js
@@ -929,7 +929,31 @@ export class Attributes {
   }
 
   [inspect.custom]() {
-    return `Attributes <${this.toString({color: true}) || 'no attributes'}>`;
+    const visiblePart = this.toString({color: true});
+
+    const numSymbols = Object.getOwnPropertySymbols(this.#attributes).length;
+    const numSymbolsPart =
+      (numSymbols >= 2
+        ? `${numSymbols} symbol`
+     : numSymbols === 1
+        ? `1 symbol`
+        : ``);
+
+    const symbolPart =
+      (visiblePart && numSymbolsPart
+        ? `(+${numSymbolsPart})`
+     : numSymbols
+        ? `(${numSymbolsPart})`
+        : ``);
+
+    const contentPart =
+      (visiblePart && symbolPart
+        ? `<${visiblePart} ${symbolPart}>`
+     : visiblePart || symbolPart
+        ? `<${visiblePart || symbolPart}>`
+        : `<no attributes>`);
+
+    return `Attributes ${contentPart}`;
   }
 }
 

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -487,6 +487,9 @@ export class Tag {
       if (this.attributes.has(attribute)) {
         const value = this.attributes.get(attribute);
 
+        if (!value) continue;
+        if (Array.isArray(value) && empty(value)) continue;
+
         let string;
         let suffix = '';
 


### PR DESCRIPTION
Various changes bundled:

* When inspecting a tag, nice attributes (`id`, `class`) are skipped if they're present but blank.
* When inspecting an attributes object, the number of symbol attributes (e.g. `{[html.joinChildren]: ''}`) is shown, though individual names and values are skipped.
* When showing an `error.cause` layer from stringifying a tag's content, the line where the tag was created is now shown.