### PR TITLE
New "mutable" option for html and attributes slots

### DIFF
--- a/src/content-function.js
+++ b/src/content-function.js
@@ -1,3 +1,5 @@
+import {Template} from '#html';
+
 import {
   annotateFunction,
   decorateErrorWithCause,
@@ -42,6 +44,10 @@ export default function contentFunction({
 
   if (slots && !expectedExtraDependencyKeys.has('html')) {
     throw new ContentFunctionSpecError(`Content functions with slots must specify html in extraDependencies`);
+  }
+
+  if (slots) {
+    Template.validateSlotsDescription(slots);
   }
 
   // Pass all the details to expectDependencies, which will recursively build

--- a/src/content/dependencies/generateArtistGroupContributionsInfo.js
+++ b/src/content/dependencies/generateArtistGroupContributionsInfo.js
@@ -117,7 +117,11 @@ export default {
   },
 
   slots: {
-    title: {type: 'html'},
+    title: {
+      type: 'html',
+      mutable: false,
+    },
+
     showBothColumns: {type: 'boolean'},
     showSortButton: {type: 'boolean'},
     visible: {type: 'boolean', default: true},

--- a/src/content/dependencies/generateArtistInfoPageChunk.js
+++ b/src/content/dependencies/generateArtistInfoPageChunk.js
@@ -6,8 +6,20 @@ export default {
       validate: v => v.is('flash', 'album'),
     },
 
-    albumLink: {type: 'html'},
-    flashActLink: {type: 'html'},
+    albumLink: {
+      type: 'html',
+      mutable: false,
+    },
+
+    flashActLink: {
+      type: 'html',
+      mutable: false,
+    },
+
+    items: {
+      type: 'html',
+      mutable: false,
+    },
 
     date: {validate: v => v.isDate},
     dateRangeStart: {validate: v => v.isDate},
@@ -15,8 +27,6 @@ export default {
 
     duration: {validate: v => v.isDuration},
     durationApproximate: {type: 'boolean'},
-
-    items: {type: 'html'},
   },
 
   generate(slots, {html, language}) {

--- a/src/content/dependencies/generateArtistInfoPageChunkItem.js
+++ b/src/content/dependencies/generateArtistInfoPageChunkItem.js
@@ -2,10 +2,20 @@ export default {
   extraDependencies: ['html', 'language'],
 
   slots: {
-    content: {type: 'html'},
+    content: {
+      type: 'html',
+      mutable: false,
+    },
 
-    otherArtistLinks: {validate: v => v.strictArrayOf(v.isHTML)},
-    contribution: {type: 'html'},
+    contribution: {
+      type: 'html',
+      mutable: false,
+    },
+
+    otherArtistLinks: {
+      validate: v => v.strictArrayOf(v.isHTML),
+    },
+
     rerelease: {type: 'boolean'},
   },
 

--- a/src/content/dependencies/generateArtistInfoPageChunkedList.js
+++ b/src/content/dependencies/generateArtistInfoPageChunkedList.js
@@ -2,8 +2,15 @@ export default {
   extraDependencies: ['html'],
 
   slots: {
-    groupInfo: {type: 'html'},
-    chunks: {type: 'html'},
+    groupInfo: {
+      type: 'html',
+      mutable: false,
+    },
+
+    chunks: {
+      type: 'html',
+      mutable: false,
+    },
   },
 
   generate(slots, {html}) {

--- a/src/content/dependencies/generateContentHeading.js
+++ b/src/content/dependencies/generateContentHeading.js
@@ -7,8 +7,15 @@ export default {
   }),
 
   slots: {
-    title: {type: 'html'},
-    accent: {type: 'html'},
+    title: {
+      type: 'html',
+      mutable: false,
+    },
+
+    accent: {
+      type: 'html',
+      mutable: false,
+    },
 
     color: {validate: v => v.isColor},
 

--- a/src/content/dependencies/generateDatetimestampTemplate.js
+++ b/src/content/dependencies/generateDatetimestampTemplate.js
@@ -2,8 +2,16 @@ export default {
   extraDependencies: ['html'],
 
   slots: {
-    mainContent: {type: 'html'},
-    tooltipContent: {type: 'html'},
+    mainContent: {
+      type: 'html',
+      mutable: false,
+    },
+
+    tooltipContent: {
+      type: 'html',
+      mutable: false,
+    },
+
     datetime: {type: 'string'},
   },
 

--- a/src/content/dependencies/generateListAllAdditionalFilesChunk.js
+++ b/src/content/dependencies/generateListAllAdditionalFilesChunk.js
@@ -4,7 +4,10 @@ export default {
   extraDependencies: ['html', 'language'],
 
   slots: {
-    title: {type: 'html'},
+    title: {
+      type: 'html',
+      mutable: false,
+    },
 
     additionalFileTitles: {
       validate: v => v.strictArrayOf(v.isHTML),

--- a/src/content/dependencies/generateListingPage.js
+++ b/src/content/dependencies/generateListingPage.js
@@ -104,7 +104,10 @@ export default {
       default: 'unordered',
     },
 
-    content: {type: 'html'},
+    content: {
+      type: 'html',
+      mutable: false,
+    },
   },
 
   generate(data, relations, slots, {html, language}) {

--- a/src/content/dependencies/generatePageLayout.js
+++ b/src/content/dependencies/generatePageLayout.js
@@ -4,7 +4,10 @@ function sidebarSlots(side) {
   return {
     // Content is a flat HTML array. It'll generate one sidebar section
     // if specified.
-    [side + 'Content']: {type: 'html'},
+    [side + 'Content']: {
+      type: 'html',
+      mutable: false,
+    },
 
     // A single class to apply to the whole sidebar. If specifying multiple
     // sections, this be added to the containing sidebar-column - specify a
@@ -105,14 +108,32 @@ export default {
   },
 
   slots: {
-    title: {type: 'html'},
-    showWikiNameInTitle: {type: 'boolean', default: true},
+    title: {
+      type: 'html',
+      mutable: false,
+    },
 
-    additionalNames: {type: 'html'},
+    showWikiNameInTitle: {
+      type: 'boolean',
+      default: true,
+    },
 
-    cover: {type: 'html'},
+    additionalNames: {
+      type: 'html',
+      mutable: false,
+    },
 
-    socialEmbed: {type: 'html'},
+    cover: {
+      type: 'html',
+      mutable: false,
+    },
+
+    // Strictly speaking we clone this each time we use it, so it doesn't
+    // need to be marked as mutable here.
+    socialEmbed: {
+      type: 'html',
+      mutable: true,
+    },
 
     color: {validate: v => v.isColor},
 
@@ -128,7 +149,10 @@ export default {
 
     // Main
 
-    mainContent: {type: 'html'},
+    mainContent: {
+      type: 'html',
+      mutable: false,
+    },
 
     headingMode: {
       validate: v => v.is('sticky', 'static'),
@@ -142,7 +166,11 @@ export default {
 
     // Banner
 
-    banner: {type: 'html'},
+    banner: {
+      type: 'html',
+      mutable: false,
+    },
+
     bannerPosition: {
       validate: v => v.is('top', 'bottom'),
       default: 'top',
@@ -150,8 +178,15 @@ export default {
 
     // Nav & Footer
 
-    navContent: {type: 'html'},
-    navBottomRowContent: {type: 'html'},
+    navContent: {
+      type: 'html',
+      mutable: false,
+    },
+
+    navBottomRowContent: {
+      type: 'html',
+      mutable: false,
+    },
 
     navLinkStyle: {
       validate: v => v.is('hierarchical', 'index'),
@@ -208,9 +243,15 @@ export default {
         })
     },
 
-    secondaryNav: {type: 'html'},
+    secondaryNav: {
+      type: 'html',
+      mutable: false,
+    },
 
-    footerContent: {type: 'html'},
+    footerContent: {
+      type: 'html',
+      mutable: false,
+    },
   },
 
   generate(data, relations, slots, {

--- a/src/content/dependencies/generatePreviousNextLinks.js
+++ b/src/content/dependencies/generatePreviousNextLinks.js
@@ -6,9 +6,20 @@ export default {
   extraDependencies: ['html', 'language'],
 
   slots: {
-    previousLink: {type: 'html'},
-    nextLink: {type: 'html'},
-    id: {type: 'boolean', default: true},
+    previousLink: {
+      type: 'html',
+      mutable: true,
+    },
+
+    nextLink: {
+      type: 'html',
+      mutable: true,
+    },
+
+    id: {
+      type: 'boolean',
+      default: true,
+    },
   },
 
   generate(slots, {html, language}) {

--- a/src/content/dependencies/generateSecondaryNav.js
+++ b/src/content/dependencies/generateSecondaryNav.js
@@ -2,7 +2,10 @@ export default {
   extraDependencies: ['html'],
 
   slots: {
-    content: {type: 'html'},
+    content: {
+      type: 'html',
+      mutable: false,
+    },
 
     class: {
       validate: v => v.oneOf(v.isString, v.sparseArrayOf(v.isString)),

--- a/src/content/dependencies/generateStickyHeadingContainer.js
+++ b/src/content/dependencies/generateStickyHeadingContainer.js
@@ -2,8 +2,15 @@ export default {
   extraDependencies: ['html'],
 
   slots: {
-    title: {type: 'html'},
-    cover: {type: 'html'},
+    title: {
+      type: 'html',
+      mutable: false,
+    },
+
+    cover: {
+      type: 'html',
+      mutable: true,
+    },
   },
 
   generate: (slots, {html}) =>

--- a/src/content/dependencies/generateWikiHomeContentRow.js
+++ b/src/content/dependencies/generateWikiHomeContentRow.js
@@ -11,7 +11,10 @@ export default {
     ({name: row.name}),
 
   slots: {
-    content: {type: 'html'},
+    content: {
+      type: 'html',
+      mutable: false,
+    },
   },
 
   generate: (data, relations, slots, {html}) =>

--- a/src/content/dependencies/image.js
+++ b/src/content/dependencies/image.js
@@ -64,7 +64,10 @@ export default {
     width: {type: 'number'},
     height: {type: 'number'},
 
-    missingSourceContent: {type: 'html'},
+    missingSourceContent: {
+      type: 'html',
+      mutable: false,
+    },
   },
 
   generate(data, relations, slots, {

--- a/src/content/dependencies/index.js
+++ b/src/content/dependencies/index.js
@@ -35,6 +35,7 @@ export function watchContentDependencies({
   const contentDependencies = {};
 
   let emittedReady = false;
+  let emittedErrorForFunctions = new Set();
   let closed = false;
 
   let _close = () => {};
@@ -201,7 +202,8 @@ export function watchContentDependencies({
         break main;
       }
 
-      if (logging && emittedReady) {
+      const emittedError = emittedErrorForFunctions.has(functionName);
+      if (logging && (emittedReady || emittedError)) {
         const timestamp = new Date().toLocaleString('en-US', {timeStyle: 'medium'});
         console.log(colors.green(`[${timestamp}] Updated ${functionName}`));
       }
@@ -221,6 +223,7 @@ export function watchContentDependencies({
     }
 
     events.emit('error', functionName, error);
+    emittedErrorForFunctions.add(functionName);
 
     if (logging) {
       if (contentDependencies[functionName]) {

--- a/src/content/dependencies/index.js
+++ b/src/content/dependencies/index.js
@@ -8,7 +8,11 @@ import {ESLint} from 'eslint';
 
 import {colors, logWarn} from '#cli';
 import contentFunction, {ContentFunctionSpecError} from '#content-function';
-import {annotateFunction} from '#sugar';
+
+import {
+  annotateFunction,
+  showAggregate as _showAggregate
+} from '#sugar';
 
 function cachebust(filePath) {
   if (filePath in cachebust.cache) {
@@ -25,6 +29,7 @@ cachebust.cache = Object.create(null);
 export function watchContentDependencies({
   mock = null,
   logging = true,
+  showAggregate = _showAggregate,
 } = {}) {
   const events = new EventEmitter();
   const contentDependencies = {};
@@ -229,7 +234,7 @@ export function watchContentDependencies({
       } else if (error instanceof ContentFunctionSpecError) {
         console.error(colors.yellow(error.message));
       } else {
-        console.error(error);
+        showAggregate(error);
       }
     }
 

--- a/src/content/dependencies/linkTemplate.js
+++ b/src/content/dependencies/linkTemplate.js
@@ -15,10 +15,17 @@ export default {
     path: {validate: v => v.validateArrayItems(v.isString)},
     hash: {type: 'string'},
     linkless: {type: 'boolean', default: false},
-
     tooltip: {type: 'string'},
-    attributes: {type: 'attributes'},
-    content: {type: 'html'},
+
+    attributes: {
+      type: 'attributes',
+      mutable: true,
+    },
+
+    content: {
+      type: 'html',
+      mutable: false,
+    },
   },
 
   generate(slots, {

--- a/src/content/dependencies/linkThing.js
+++ b/src/content/dependencies/linkThing.js
@@ -20,9 +20,20 @@ export default {
   }),
 
   slots: {
-    content: {type: 'html'},
+    content: {
+      type: 'html',
+      mutable: false,
+    },
 
-    preferShortName: {type: 'boolean', default: false},
+    attributes: {
+      type: 'attributes',
+      mutable: true,
+    },
+
+    preferShortName: {
+      type: 'boolean',
+      default: false,
+    },
 
     tooltip: {
       validate: v => v.oneOf(v.isBoolean, v.isHTML),
@@ -48,8 +59,6 @@ export default {
 
     anchor: {type: 'boolean', default: false},
     linkless: {type: 'boolean', default: false},
-
-    attributes: {type: 'attributes'},
     hash: {type: 'string'},
   },
 

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -1228,11 +1228,12 @@ export class Template {
         return blankAttributes();
       }
 
-      if (
-        providedValue instanceof Attributes &&
-        description.mutable
-      ) {
-        return providedValue.clone();
+      if (providedValue instanceof Attributes) {
+        if (description.mutable) {
+          return providedValue.clone();
+        } else {
+          return providedValue;
+        }
       }
 
       return new Attributes(providedValue);

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -1063,8 +1063,23 @@ export class Template {
           slotErrors.push(new TypeError(`(${slotName}) Functions shouldn't be provided to slots`));
         } else if (slotDescription.type === 'object') {
           slotErrors.push(new TypeError(`(${slotName}) Provide validate function instead of type: object`));
+        } else if (
+          (slotDescription.type === 'html' || slotDescription.type === 'attributes') &&
+          !('mutable' in slotDescription)
+        ) {
+          slotErrors.push(new TypeError(`(${slotName}) Specify mutable: true/false alongside type: ${slotDescription.type}`));
         } else if (!acceptableSlotTypes.includes(slotDescription.type)) {
           slotErrors.push(new TypeError(`(${slotName}) Expected slot type to be one of ${acceptableSlotTypes.join(', ')}`));
+        }
+      }
+
+      if ('mutable' in slotDescription) {
+        if (slotDescription.type !== 'html' && slotDescription.type !== 'attributes') {
+          slotErrors.push(new TypeError(`(${slotName}) Only specify mutable alongside type: html or attributes`));
+        }
+
+        if (typeof slotDescription.mutable !== 'boolean') {
+          slotErrors.push(new TypeError(`(${slotName}) Expected slot mutable to be boolean`));
         }
       }
     }
@@ -1198,7 +1213,10 @@ export class Template {
         return blank();
       }
 
-      if (providedValue instanceof Tag || providedValue instanceof Template) {
+      if (
+        (providedValue instanceof Tag || providedValue instanceof Template) &&
+        description.mutable
+      ) {
         return providedValue.clone();
       }
 
@@ -1210,7 +1228,10 @@ export class Template {
         return blankAttributes();
       }
 
-      if (providedValue instanceof Attributes) {
+      if (
+        providedValue instanceof Attributes &&
+        description.mutable
+      ) {
         return providedValue.clone();
       }
 

--- a/src/write/build-modes/live-dev-server.js
+++ b/src/write/build-modes/live-dev-server.js
@@ -106,7 +106,10 @@ export async function go({
   const skipServing = cliOptions['skip-serving'] ?? false;
   const serveSFX = cliOptions['serve-sfx'] ?? null;
 
-  const contentDependenciesWatcher = await watchContentDependencies();
+  const contentDependenciesWatcher = await watchContentDependencies({
+    showAggregate: niceShowAggregate,
+  });
+
   const {contentDependencies} = contentDependenciesWatcher;
 
   contentDependenciesWatcher.on('error', () => {});

--- a/src/write/build-modes/static-build.js
+++ b/src/write/build-modes/static-build.js
@@ -256,7 +256,9 @@ export async function go({
 
   let errored = false;
 
-  const contentDependencies = await quickLoadContentDependencies();
+  const contentDependencies = await quickLoadContentDependencies({
+    showAggregate: niceShowAggregate,
+  });
 
   const perLanguageFn = async (language, i, entries) => {
     const baseDirectory =

--- a/test/unit/util/html.js
+++ b/test/unit/util/html.js
@@ -723,7 +723,7 @@ t.test(`Template - description errors`, t => {
         slot3: {type: 'bigint'},
         slot4: {type: 'boolean'},
         slot5: {type: 'symbol'},
-        slot6: {type: 'html'},
+        slot6: {type: 'html', mutable: false},
       },
       content: () => {},
     }));
@@ -739,7 +739,7 @@ t.test(`Template - slot value errors`, t => {
       basicBigint: {type: 'bigint'},
       basicBoolean: {type: 'boolean'},
       basicSymbol: {type: 'symbol'},
-      basicHTML: {type: 'html'},
+      basicHTML: {type: 'html', mutable: false},
     },
 
     content: slots =>


### PR DESCRIPTION
In principle this ought to be determinable statically, but `generate` is a black box at the moment, so.

This PR adds a new `mutable` option which must be specified alongside `type: 'html'` and `type: 'attributes'` slots; it controls whether the template's content function is passed the original `Tag`/`Attributes` object or a clone of it.

In principle this should avoid unnecessary cloning, which should be a minor performance help (though probably not much, since tags themselves aren't deep cloned - an issue! - and cloning a template likely isn't much work).

Content function slots are also now validated as soon as they're loaded, instead of once dependencies are fulfilled (previously done via the call to `stationery`). This basically means all content function slots are validated at the start of each build.