### PR TITLE
Miscellaneous quick fixes!

### DIFF
--- a/src/data/composite/control-flow/raiseOutputWithoutDependency.js
+++ b/src/data/composite/control-flow/raiseOutputWithoutDependency.js
@@ -17,7 +17,7 @@ export default templateCompositeFrom({
 
   outputs: ({
     [input.staticValue('output')]: output,
-  }) => Object.keys(output),
+  }) => Object.keys(output ?? {}),
 
   steps: () => [
     withResultOfAvailabilityCheck({

--- a/src/data/composite/control-flow/raiseOutputWithoutUpdateValue.js
+++ b/src/data/composite/control-flow/raiseOutputWithoutUpdateValue.js
@@ -16,7 +16,7 @@ export default templateCompositeFrom({
 
   outputs: ({
     [input.staticValue('output')]: output,
-  }) => Object.keys(output),
+  }) => Object.keys(output ?? {}),
 
   steps: () => [
     withResultOfAvailabilityCheck({

--- a/src/find.js
+++ b/src/find.js
@@ -77,7 +77,7 @@ function findHelper({
   // errors for null matches (with details about the error), while 'warn' and
   // 'quiet' both return null, with 'warn' logging details directly to the
   // console.
-  return (fullRef, data, {mode = 'warn'}) => {
+  return (fullRef, data, {mode = 'warn'} = {}) => {
     if (!fullRef) return null;
     if (typeof fullRef !== 'string') {
       throw new TypeError(`Expected a string, got ${typeAppearance(fullRef)}`);

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -951,6 +951,11 @@ li > ul {
   display: none;
 }
 
+.group-contributions-sort-button {
+  text-decoration: underline;
+  text-decoration-style: dotted;
+}
+
 html[data-url-key="localized.albumCommentary"] li.no-commentary {
   opacity: 0.7;
 }


### PR DESCRIPTION
This PR pulls a couple of very small fixes out of #291:

* Fixes `find` complaining when an options object isn't passed, even though the only option (`mode`) already has a default (`'warn'`)! This didn't cause any problems in practice, but was annoying in the REPL.
* Fixes `raiseOutputWithoutDependency` and `raiseOutputWithoutUpdateValue` complaining when no particular output is actually provided, which is something that was ostensibly supported (the default for `output` is `{}`), but errored in practice.
* Adds a dotted underline effect to the "Sorting by..." button on group contribution info! This was always meant to get this look along with other page-interactive elements, but apparently it slipped by outside of networked tags, where the style was first introduced.
