### PR TITLE
General validation formatting cleanup!

### DIFF
--- a/src/content/dependencies/generateCoverCarousel.js
+++ b/src/content/dependencies/generateCoverCarousel.js
@@ -15,7 +15,7 @@ export default {
     images: {validate: v => v.strictArrayOf(v.isHTML)},
     links: {validate: v => v.strictArrayOf(v.isHTML)},
 
-    lazy: {validate: v => v.oneOf(v.isWholeNumber, v.isBoolean)},
+    lazy: {validate: v => v.anyOf(v.isWholeNumber, v.isBoolean)},
     actionLinks: {validate: v => v.sparseArrayOf(v.isHTML)},
   },
 

--- a/src/content/dependencies/generateCoverGrid.js
+++ b/src/content/dependencies/generateCoverGrid.js
@@ -16,7 +16,7 @@ export default {
     names: {validate: v => v.strictArrayOf(v.isHTML)},
     info: {validate: v => v.strictArrayOf(v.isHTML)},
 
-    lazy: {validate: v => v.oneOf(v.isWholeNumber, v.isBoolean)},
+    lazy: {validate: v => v.anyOf(v.isWholeNumber, v.isBoolean)},
     actionLinks: {validate: v => v.sparseArrayOf(v.isHTML)},
   },
 

--- a/src/content/dependencies/generateSecondaryNav.js
+++ b/src/content/dependencies/generateSecondaryNav.js
@@ -8,7 +8,7 @@ export default {
     },
 
     class: {
-      validate: v => v.oneOf(v.isString, v.sparseArrayOf(v.isString)),
+      validate: v => v.anyOf(v.isString, v.sparseArrayOf(v.isString)),
     },
   },
 

--- a/src/content/dependencies/image.js
+++ b/src/content/dependencies/image.js
@@ -46,7 +46,7 @@ export default {
     thumb: {type: 'string'},
 
     link: {
-      validate: v => v.oneOf(v.isBoolean, v.isString),
+      validate: v => v.anyOf(v.isBoolean, v.isString),
       default: false,
     },
 

--- a/src/content/dependencies/linkThing.js
+++ b/src/content/dependencies/linkThing.js
@@ -36,12 +36,12 @@ export default {
     },
 
     tooltip: {
-      validate: v => v.oneOf(v.isBoolean, v.isHTML),
+      validate: v => v.anyOf(v.isBoolean, v.isHTML),
       default: false,
     },
 
     color: {
-      validate: v => v.oneOf(v.isBoolean, v.isColor),
+      validate: v => v.anyOf(v.isBoolean, v.isColor),
       default: true,
     },
 

--- a/src/data/things/flash.js
+++ b/src/data/things/flash.js
@@ -2,11 +2,11 @@ import {input} from '#composite';
 import find from '#find';
 
 import {
+  anyOf,
   isColor,
   isDirectory,
   isNumber,
   isString,
-  oneOf,
 } from '#validators';
 
 import {exposeDependency, exposeUpdateValueOrContinue}
@@ -57,7 +57,7 @@ export class Flash extends Thing {
 
     page: {
       flags: {update: true, expose: true},
-      update: {validate: oneOf(isString, isNumber)},
+      update: {validate: anyOf(isString, isNumber)},
 
       expose: {
         transform: (value) => (value === null ? null : value.toString()),

--- a/src/data/things/homepage-layout.js
+++ b/src/data/things/homepage-layout.js
@@ -2,11 +2,11 @@ import {input} from '#composite';
 import find from '#find';
 
 import {
+  anyOf,
   is,
   isCountingNumber,
   isString,
   isStringNonEmpty,
-  oneOf,
   validateArrayItems,
   validateInstanceOf,
   validateReference,
@@ -124,7 +124,7 @@ export class HomepageLayoutAlbumsRow extends HomepageLayoutRow {
 
         update: {
           validate:
-            oneOf(
+            anyOf(
               is('new-releases', 'new-additions'),
               validateReference(Group[Thing.referenceType])),
         },

--- a/src/data/things/validators.js
+++ b/src/data/things/validators.js
@@ -625,7 +625,7 @@ export const isAdditionalName = validateProperties({
     // Double TODO: Explicitly allowing both references and
     // live objects to co-exist is definitely weird, and
     // altogether questions the way we define validators...
-    optional(oneOf(
+    optional(anyOf(
       validateReferenceList('track'),
       validateWikiData({referenceType: 'track'}))),
 });
@@ -634,7 +634,7 @@ export const isAdditionalNameList = validateArrayItems(isAdditionalName);
 
 // Compositional utilities
 
-export function oneOf(...validators) {
+export function anyOf(...validators) {
   const validConstants = new Set();
   const validConstructors = new Set();
   const validTypes = new Set();
@@ -724,7 +724,7 @@ export function oneOf(...validators) {
         constantValidators,
         offset++,
         new TypeError(
-          `Expected one of ${constants.join(' ')}` + gotPart),
+          `Expected any of ${constants.join(' ')}` + gotPart),
       ]);
     }
 
@@ -739,7 +739,7 @@ export function oneOf(...validators) {
         typeValidators,
         offset++,
         new TypeError(
-          `Expected one of ${types.join(', ')}` + gotPart),
+          `Expected any of ${types.join(', ')}` + gotPart),
       ]);
     }
 
@@ -755,7 +755,7 @@ export function oneOf(...validators) {
         constructorValidators,
         offset++,
         new TypeError(
-          `Expected one of ${names.join(', ')}` + gotPart),
+          `Expected any of ${names.join(', ')}` + gotPart),
       ]);
     }
 
@@ -779,7 +779,7 @@ export function oneOf(...validators) {
 
     const total = offset + leftoverValidators.length;
     throw new AggregateError(errors,
-      `Expected one of ${total} possible checks, ` +
+      `Expected any of ${total} possible checks, ` +
       `but none were true`);
   };
 }

--- a/src/data/things/validators.js
+++ b/src/data/things/validators.js
@@ -213,20 +213,12 @@ function validateArrayItemsHelper(itemValidator) {
       if (value !== true) {
         throw new Error(`Expected validator to return true`);
       }
-    } catch (error) {
-      const annotation = `(index: ${colors.yellow(`${index}`)}, item: ${inspect(item)})`;
-
-      error.message =
-        (error.message.includes('\n') || strlen(annotation) > 20
-          ? annotation + '\n' +
-            error.message
-              .split('\n')
-              .map(line => `  ${line}`)
-              .join('\n')
-          : `${annotation} ${error}`);
-
+    } catch (caughtError) {
+      const indexPart = colors.yellow(`zero-index ${index}`)
+      const itemPart = inspect(item);
+      const message = `Error at ${indexPart}: ${itemPart}`;
+      const error = new Error(message, {cause: caughtError});
       error[Symbol.for('hsmusic.annotateError.indexInSourceArray')] = index;
-
       throw error;
     }
   };

--- a/src/data/things/validators.js
+++ b/src/data/things/validators.js
@@ -374,9 +374,11 @@ export function validateProperties(spec) {
         const value = object[specKey];
         try {
           specValidator(value);
-        } catch (error) {
-          error.message = `(key: ${colors.green(specKey)}, value: ${inspect(value)}) ${error.message}`;
-          push(error);
+        } catch (caughtError) {
+          const keyPart = colors.green(specKey);
+          const valuePart = inspect(value);
+          const message = `Error for key ${keyPart}: ${valuePart}`;
+          push(new Error(message, {cause: caughtError}));
         }
       }
 

--- a/src/data/things/validators.js
+++ b/src/data/things/validators.js
@@ -766,8 +766,8 @@ export function anyOf(...validators) {
     for (const [validator, i, error] of prefaceErrorInfo.concat(errorInfo)) {
       error.message =
         (validator?.name
-          ? `(#${i + 1} "${validator.name}") ${error.message}`
-          : `(#${i + 1}) ${error.message}`);
+          ? `${i + 1}. "${validator.name}": ${error.message}`
+          : `${i + 1}. ${error.message}`);
 
       error.check =
         (Array.isArray(validator) && validator.length === 1

--- a/src/util/external-links.js
+++ b/src/util/external-links.js
@@ -1,10 +1,10 @@
 import {empty, stitchArrays} from '#sugar';
 
 import {
+  anyOf,
   is,
   isObject,
   isStringNonEmpty,
-  oneOf,
   optional,
   validateArrayItems,
   validateInstanceOf,
@@ -62,7 +62,7 @@ export const isExternalLinkSpec =
         queries: optional(validateArrayItems(isRegExp)),
 
         context:
-          optional(oneOf(
+          optional(anyOf(
             isExternalLinkContext,
             validateArrayItems(isExternalLinkContext))),
       }),

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -7,6 +7,7 @@ import {empty, typeAppearance, unique, withAggregate} from '#sugar';
 import * as commonValidators from '#validators';
 
 const {
+  anyOf,
   is,
   isArray,
   isBoolean,
@@ -14,7 +15,6 @@ const {
   isString,
   isSymbol,
   looseArrayOf,
-  oneOf,
   validateAllPropertyValues,
   validateArrayItems,
   validateInstanceOf,
@@ -1382,7 +1382,7 @@ export const isArrayOfHTML =
   validateArrayItems(value => isHTML(value));
 
 export const isHTML =
-  oneOf(
+  anyOf(
     is(null, undefined, false),
     isString,
     isTag,
@@ -1396,10 +1396,10 @@ export const isHTML =
     isArrayOfHTML);
 
 export const isAttributeKey =
-  oneOf(isString, isSymbol);
+  anyOf(isString, isSymbol);
 
 export const isAttributeValue =
-  oneOf(
+  anyOf(
     isString, isNumber, isBoolean, isArray,
     isTag, isTemplate,
     validateArrayItems(item => isAttributeValue(item)));
@@ -1429,7 +1429,7 @@ export const isAttributesAdditionPair = pair => {
 };
 
 export const isAttributesAdditionSinglet =
-  oneOf(
+  anyOf(
     validateInstanceOf(Template),
     validateInstanceOf(Attributes),
     validateAllPropertyValues(isAttributeValue),

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -122,7 +122,7 @@ export const validators = {
   },
 
   isAttributes(value) {
-    return isAttributesAdditionSingletValue(value);
+    return isAttributesAdditionSinglet(value);
   },
 };
 
@@ -645,18 +645,18 @@ export class Attributes {
   }
 
   add(...args) {
-    isAttributesAddition(args);
-    return this.#addHelper(...args);
-  }
+    switch (args.length) {
+      case 1:
+        isAttributesAdditionSinglet(args[0]);
+        return this.#addMultipleAttributes(args[0]);
 
-  #addHelper(...args) {
-    if (args.length === 1) {
-      return this.#addMultipleAttributes(args[0]);
-    } else if (args.length === 2) {
-      return this.#addOneAttribute(args[0], args[1]);
-    } else {
-      throw new Error(
-        `Expected array or object, or attribute and value`);
+      case 2:
+        isAttributesAdditionPair(args);
+        return this.#addOneAttribute(args[0], args[1]);
+
+      default:
+        throw new Error(
+          `Expected array or object, or attribute and value`);
     }
   }
 
@@ -690,7 +690,7 @@ export class Attributes {
 
     if (attributes instanceof Template) {
       const resolved = Template.resolve(attributes);
-      isAttributesAdditionSingletValue(resolved);
+      isAttributesAdditionSinglet(resolved);
       return resolved;
     }
 
@@ -1177,7 +1177,7 @@ export class Template {
         }
 
         case 'attributes': {
-          return isAttributesAdditionSingletValue(value);
+          return isAttributesAdditionSinglet(value);
         }
 
         case 'string': {
@@ -1411,7 +1411,7 @@ export const isAttributesAdditionPair = pair => {
     throw new TypeError(`Expected attributes pair to have two items`);
   }
 
-  withAggregate(({push}) => {
+  withAggregate({message: `Error validating attributes pair`}, ({push}) => {
     try {
       isAttributeKey(pair[0]);
     } catch (caughtError) {
@@ -1428,24 +1428,9 @@ export const isAttributesAdditionPair = pair => {
   return true;
 };
 
-export const isAttributesAdditionSingletValue =
+export const isAttributesAdditionSinglet =
   oneOf(
     validateInstanceOf(Template),
     validateInstanceOf(Attributes),
     validateAllPropertyValues(isAttributeValue),
-    looseArrayOf(value => isAttributesAdditionSingletValue(value)));
-
-export const isAttributesAdditionSinglet = singlet => {
-  isArray(singlet);
-
-  if (singlet.length !== 1) {
-    throw new TypeError(`Expected attributes singlet to have one item`);
-  }
-
-  isAttributesAdditionSingletValue(singlet[0]);
-
-  return true;
-}
-
-export const isAttributesAddition =
-  oneOf(isAttributesAdditionSinglet, isAttributesAdditionPair);
+    looseArrayOf(value => isAttributesAdditionSinglet(value)));

--- a/test/unit/data/things/validators.js
+++ b/test/unit/data/things/validators.js
@@ -115,7 +115,7 @@ test(t, 'isObject', t => {
 });
 
 test(t, 'validateArrayItems', t => {
-  t.plan(6);
+  t.plan(9);
 
   t.ok(validateArrayItems(isNumber)([3, 4, 5]));
   t.ok(validateArrayItems(validateArrayItems(isNumber))([[3, 4], [4, 5], [6, 7]]));
@@ -130,7 +130,10 @@ test(t, 'validateArrayItems', t => {
   t.not(caughtError, null);
   t.ok(caughtError instanceof AggregateError);
   t.equal(caughtError.errors.length, 1);
-  t.ok(caughtError.errors[0] instanceof TypeError);
+  t.ok(caughtError.errors[0] instanceof Error);
+  t.equal(caughtError.errors[0][Symbol.for('hsmusic.annotateError.indexInSourceArray')], 2);
+  t.not(caughtError.errors[0].cause, null);
+  t.ok(caughtError.errors[0].cause instanceof TypeError);
 });
 
 // Wiki data
@@ -267,7 +270,7 @@ test(t, 'validateReferenceList', t => {
   const track = validateReferenceList('track');
   const artist = validateReferenceList('artist');
 
-  t.plan(9);
+  t.plan(11);
 
   t.ok(track(['track:fallen-down', 'Once Upon a Time']));
   t.ok(artist(['artist:toby-fox', 'Mark Hadley']));
@@ -284,8 +287,10 @@ test(t, 'validateReferenceList', t => {
   t.not(caughtError, null);
   t.ok(caughtError instanceof AggregateError);
   t.equal(caughtError.errors.length, 2);
-  t.ok(caughtError.errors[0] instanceof TypeError);
-  t.ok(caughtError.errors[1] instanceof TypeError);
+  t.ok(caughtError.errors[0] instanceof Error);
+  t.ok(caughtError.errors[0].cause instanceof TypeError);
+  t.ok(caughtError.errors[1] instanceof Error);
+  t.ok(caughtError.errors[0].cause instanceof TypeError);
 });
 
 test(t, 'anyOf', t => {

--- a/test/unit/data/things/validators.js
+++ b/test/unit/data/things/validators.js
@@ -30,7 +30,7 @@ import {
   validateReferenceList,
 
   // Compositional utilities
-  oneOf,
+  anyOf,
 } from '#validators';
 
 function test(t, msg, fn) {
@@ -288,10 +288,10 @@ test(t, 'validateReferenceList', t => {
   t.ok(caughtError.errors[1] instanceof TypeError);
 });
 
-test(t, 'oneOf', t => {
+test(t, 'anyOf', t => {
   t.plan(11);
 
-  const isStringOrNumber = oneOf(isString, isNumber);
+  const isStringOrNumber = anyOf(isString, isNumber);
 
   t.ok(isStringOrNumber('hello world'));
   t.ok(isStringOrNumber(42));
@@ -302,7 +302,7 @@ test(t, 'oneOf', t => {
     throw mockError;
   };
 
-  const isStringOrGetRekt = oneOf(isString, neverSucceeds);
+  const isStringOrGetRekt = anyOf(isString, neverSucceeds);
 
   t.ok(isStringOrGetRekt('phew!'));
 


### PR DESCRIPTION
This PR tweaks a bunch of the stuff responsible for error formatting!

<img width="1065" alt="Very neat-looking error trace, despite its overall complexity." src="https://github.com/hsmusic/hsmusic-wiki/assets/9948030/4470fdae-d0cd-4479-b67e-ec0185bd36af">

* Gets rid of a generally non-informative layer from `Attributes.add`, differentiating singlet additions from pairs when that's never actually relevant to the programmer, and simplifies `add` / `#addHelper` logic to boot
* Renames `oneOf` to `anyOf` to better reflect its purpose, and to avoid numeric-verbiage noise where it isn't meaningful
* Changes list formatting in `anyOf` from `(#1 "foo")`, `(#2)`, `(#3)` to `1. "foo"`, `2.`, `2.`
* Nests errors in `cause` layers for both `validateArrayItems` and `validateProperties`, instead of mutating the message of the relevant error, and shows the same details as before (index/value, key/value) in cleaner fashion
* Puts an extra space before non-aggregate errors if any "sibling" errors on the same layer are aggregates, to make error messages line up across everything

Very cool, much pretty.