### PR TITLE
Add illustrator info to art tag gallery page

### DIFF
--- a/src/content/dependencies/generateArtTagGalleryPage.js
+++ b/src/content/dependencies/generateArtTagGalleryPage.js
@@ -74,6 +74,11 @@ export default {
           ? ['media.trackCover', thing.album.directory, thing.directory, thing.coverArtFileExtension]
           : ['media.albumCover', thing.directory, thing.coverArtFileExtension]));
 
+    data.coverArtists =
+      query.things.map(thing =>
+        thing.coverArtistContribs
+          .map(({who: artist}) => artist.name));
+
     return data;
   },
 
@@ -108,6 +113,14 @@ export default {
                   path: data.paths,
                 }).map(({image, path}) =>
                     image.slot('path', path)),
+
+              info:
+                data.coverArtists.map(names =>
+                  (names === null
+                    ? null
+                    : language.$('misc.albumGrid.details.coverArtists', {
+                        artists: language.formatUnitList(names),
+                      }))),
             }),
         ],
 


### PR DESCRIPTION
Extracted from #291! We're probably not getting that PR merged for this release, but this change is perfectly fine to merge separately.

Illustrator info is already present on album galleries! This PR makes it show up on tag galleries, too.

<img width="740" alt="Art tag gallery grid with three tracks, each showing the track name and the artist who illustrated its artwork" src="https://github.com/hsmusic/hsmusic-wiki/assets/9948030/82c8765d-8655-432a-a06d-8f7939095f58">
