### PR TITLE
Content string validation

### DIFF
--- a/src/data/composite/wiki-properties/contentString.js
+++ b/src/data/composite/wiki-properties/contentString.js
@@ -1,0 +1,15 @@
+// String type that's slightly more specific than simpleString. If the
+// property is a generic piece of human-reading content, this adds some
+// useful valiation on top of simpleString - but still check if more
+// particular properties like `name` are more appropriate.
+//
+// This type adapts validation for single- and multiline content.
+
+import {isContentString} from '#validators';
+
+export default function() {
+  return {
+    flags: {update: true, expose: true},
+    update: {validate: isContentString},
+  };
+}

--- a/src/data/composite/wiki-properties/index.js
+++ b/src/data/composite/wiki-properties/index.js
@@ -8,6 +8,7 @@ export {default as additionalNameList} from './additionalNameList.js';
 export {default as color} from './color.js';
 export {default as commentary} from './commentary.js';
 export {default as commentatorArtists} from './commentatorArtists.js';
+export {default as contentString} from './contentString.js';
 export {default as contribsPresent} from './contribsPresent.js';
 export {default as contributionList} from './contributionList.js';
 export {default as dimensions} from './dimensions.js';

--- a/src/data/composite/wiki-properties/simpleString.js
+++ b/src/data/composite/wiki-properties/simpleString.js
@@ -4,8 +4,6 @@
 
 import {isString} from '#validators';
 
-// TODO: Not templateCompositeFrom.
-
 export default function() {
   return {
     flags: {update: true, expose: true},

--- a/src/data/things/artist.js
+++ b/src/data/things/artist.js
@@ -3,11 +3,11 @@ import find from '#find';
 import {isName, validateArrayItems} from '#validators';
 
 import {
+  contentString,
   directory,
   fileExtension,
   flag,
   name,
-  simpleString,
   singleReference,
   urls,
   wikiData,
@@ -24,7 +24,8 @@ export class Artist extends Thing {
     name: name('Unnamed Artist'),
     directory: directory(),
     urls: urls(),
-    contextNotes: simpleString(),
+
+    contextNotes: contentString(),
 
     hasAvatar: flag(false),
     avatarFileExtension: fileExtension('jpg'),

--- a/src/data/things/flash.js
+++ b/src/data/things/flash.js
@@ -15,13 +15,13 @@ import {withPropertyFromObject} from '#composite/data';
 
 import {
   color,
+  contentString,
   contributionList,
   directory,
   fileExtension,
   name,
   referenceList,
   simpleDate,
-  simpleString,
   urls,
   wikiData,
 } from '#composite/wiki-properties';
@@ -145,9 +145,9 @@ export class FlashAct extends Thing {
     name: name('Unnamed Flash Act'),
     directory: directory(),
     color: color(),
-    listTerminology: simpleString(),
+    listTerminology: contentString(),
 
-    jump: simpleString(),
+    jump: contentString(),
 
     jumpColor: {
       flags: {update: true, expose: true},

--- a/src/data/things/group.js
+++ b/src/data/things/group.js
@@ -3,10 +3,10 @@ import find from '#find';
 
 import {
   color,
+  contentString,
   directory,
   name,
   referenceList,
-  simpleString,
   urls,
   wikiData,
 } from '#composite/wiki-properties';
@@ -22,7 +22,7 @@ export class Group extends Thing {
     name: name('Unnamed Group'),
     directory: directory(),
 
-    description: simpleString(),
+    description: contentString(),
 
     urls: urls(),
 

--- a/src/data/things/homepage-layout.js
+++ b/src/data/things/homepage-layout.js
@@ -17,9 +17,9 @@ import {withResolvedReference} from '#composite/wiki-data';
 
 import {
   color,
+  contentString,
   name,
   referenceList,
-  simpleString,
   wikiData,
 } from '#composite/wiki-properties';
 
@@ -31,7 +31,7 @@ export class HomepageLayout extends Thing {
   static [Thing.getPropertyDescriptors] = ({HomepageLayoutRow}) => ({
     // Update & expose
 
-    sidebarContent: simpleString(),
+    sidebarContent: contentString(),
 
     navbarLinks: {
       flags: {update: true, expose: true},

--- a/src/data/things/language.js
+++ b/src/data/things/language.js
@@ -15,7 +15,7 @@ import {
 import {
   externalFunction,
   flag,
-  simpleString,
+  name,
 } from '#composite/wiki-properties';
 
 import CacheableObject from './cacheable-object.js';
@@ -35,7 +35,7 @@ export class Language extends Thing {
 
     // Human-readable name. This should be the language's own native name, not
     // localized to any other language.
-    name: simpleString(),
+    name: name(`Unnamed Language`),
 
     // Language code specific to JavaScript's Internationalization (Intl) API.
     // Usually this will be the same as the language's general code, but it

--- a/src/data/things/news-entry.js
+++ b/src/data/things/news-entry.js
@@ -1,8 +1,8 @@
 import {
+  contentString,
   directory,
   name,
   simpleDate,
-  simpleString,
 } from '#composite/wiki-properties';
 
 import Thing from './thing.js';
@@ -18,7 +18,7 @@ export class NewsEntry extends Thing {
     directory: directory(),
     date: simpleDate(),
 
-    content: simpleString(),
+    content: contentString(),
 
     // Expose only
 

--- a/src/data/things/static-page.js
+++ b/src/data/things/static-page.js
@@ -1,6 +1,7 @@
 import {isName} from '#validators';
 
 import {
+  contentString,
   directory,
   name,
   simpleString,
@@ -28,7 +29,7 @@ export class StaticPage extends Thing {
     },
 
     directory: directory(),
-    content: simpleString(),
+    content: contentString(),
     stylesheet: simpleString(),
     script: simpleString(),
   });

--- a/src/data/things/track.js
+++ b/src/data/things/track.js
@@ -27,6 +27,7 @@ import {
   additionalNameList,
   commentary,
   commentatorArtists,
+  contentString,
   contributionList,
   directory,
   duration,
@@ -36,7 +37,6 @@ import {
   reverseReferenceList,
   simpleDate,
   singleReference,
-  simpleString,
   urls,
   wikiData,
 } from '#composite/wiki-properties';
@@ -153,7 +153,7 @@ export class Track extends Thing {
     ],
 
     commentary: commentary(),
-    lyrics: simpleString(),
+    lyrics: contentString(),
 
     additionalFiles: additionalFiles(),
     sheetMusicFiles: additionalFiles(),

--- a/src/data/things/validators.js
+++ b/src/data/things/validators.js
@@ -299,7 +299,7 @@ export function isColor(color) {
 }
 
 export function isCommentary(commentaryText) {
-  isString(commentaryText);
+  isContentString(commentaryText);
 
   const rawMatches =
     Array.from(commentaryText.matchAll(commentaryRegex));
@@ -546,15 +546,15 @@ export const isContribution = validateProperties({
 export const isContributionList = validateArrayItems(isContribution);
 
 export const isAdditionalFile = validateProperties({
-  title: isString,
-  description: optional(isStringNonEmpty),
+  title: isName,
+  description: optional(isContentString),
   files: validateArrayItems(isString),
 });
 
 export const isAdditionalFileList = validateArrayItems(isAdditionalFile);
 
 export const isTrackSection = validateProperties({
-  name: optional(isString),
+  name: optional(isName),
   color: optional(isColor),
   dateOriginallyReleased: optional(isDate),
   isDefaultTrackSection: optional(isBoolean),
@@ -614,7 +614,7 @@ export function isLanguageCode(string) {
 }
 
 export function isName(name) {
-  return isString(name);
+  return isContentString(name);
 }
 
 export function isURL(string) {
@@ -748,7 +748,7 @@ export function validateWikiData({
 
 export const isAdditionalName = validateProperties({
   name: isName,
-  annotation: optional(isStringNonEmpty),
+  annotation: optional(isContentString),
 
   // TODO: This only allows indicating sourcing from a track.
   // That's okay for the current limited use of "from", but

--- a/src/data/things/validators.js
+++ b/src/data/things/validators.js
@@ -511,13 +511,13 @@ export function isContentString(content) {
 
     const where =
       (match[0].length === containingLine.length
-        ? `all of ${linePart}`
+        ? `as all of ${linePart}`
      : columnNumber === 0
         ? (isMultiline
-            ? `start of ${linePart}`
+            ? `at start of ${linePart}`
             : `at start`)
         : (isMultiline
-            ? `end of ${linePart}`
+            ? `at end of ${linePart}`
             : `at end`));
 
     const whitespacePart =
@@ -525,7 +525,7 @@ export function isContentString(content) {
 
     const parts = [
       `Matched ${whitespacePart}`,
-      `(${where})`,
+      where,
     ];
 
     trimWhitespaceAggregate.push(new TypeError(parts.join(` `)));

--- a/src/data/things/wiki-info.js
+++ b/src/data/things/wiki-info.js
@@ -3,10 +3,10 @@ import find from '#find';
 import {isColor, isLanguageCode, isName, isURL} from '#validators';
 
 import {
+  contentString,
   flag,
   name,
   referenceList,
-  simpleString,
   wikiData,
 } from '#composite/wiki-properties';
 
@@ -41,9 +41,9 @@ export class WikiInfo extends Thing {
     },
 
     // One-line description used for <meta rel="description"> tag.
-    description: simpleString(),
+    description: contentString(),
 
-    footerContent: simpleString(),
+    footerContent: contentString(),
 
     defaultLanguage: {
       flags: {update: true, expose: true},

--- a/src/data/yaml.js
+++ b/src/data/yaml.js
@@ -159,9 +159,9 @@ function makeProcessDocument(
 
     const constructorPart =
       (thingConstructor[Thing.friendlyName]
-        ? colors.green(thingConstructor[Thing.friendlyName])
+        ? thingConstructor[Thing.friendlyName]
      : thingConstructor.name
-        ? colors.green(thingConstructor.name)
+        ? thingConstructor.name
         : `document`);
 
     const aggregate = openAggregate({

--- a/src/util/sugar.js
+++ b/src/util/sugar.js
@@ -280,16 +280,18 @@ export function* matchMultiline(content, matchRegexp, {
   let startOfLine = 0;
   let previousIndex = 0;
 
-  const countLineBreaks = range => {
+  const countLineBreaks = (offset, range) => {
     const lineBreaks = Array.from(range.matchAll(lineRegexp));
     if (!empty(lineBreaks)) {
       lineNumber += lineBreaks.length;
-      startOfLine = lineBreaks.at(-1).index + 1;
+      startOfLine = offset + lineBreaks.at(-1).index + 1;
     }
   };
 
   for (const match of content.matchAll(matchRegexp)) {
-    countLineBreaks(content.slice(previousIndex, match.index));
+    countLineBreaks(
+      previousIndex,
+      content.slice(previousIndex, match.index));
 
     const matchStartOfLine = startOfLine;
 
@@ -306,7 +308,7 @@ export function* matchMultiline(content, matchRegexp, {
             : `pos: ${match.index}`));
     }
 
-    countLineBreaks(match[0]);
+    countLineBreaks(match.index, match[0]);
 
     let containingLine = null;
     if (getContainingLine) {

--- a/src/util/sugar.js
+++ b/src/util/sugar.js
@@ -305,7 +305,7 @@ export function* matchMultiline(content, matchRegexp, {
         colors.yellow(
           (isMultiline
             ? `line: ${lineNumber + 1}, col: ${columnNumber + 1}`
-            : `pos: ${match.index}`));
+            : `pos: ${match.index + 1}`));
     }
 
     countLineBreaks(match.index, match[0]);

--- a/test/unit/data/things/validators.js
+++ b/test/unit/data/things/validators.js
@@ -227,7 +227,7 @@ t.test('isName', t => {
   t.plan(4);
   t.ok(isName('Dogz 2.0'));
   t.ok(isName('album:this-track-is-only-named-thusly-to-give-niklink-a-headache'));
-  t.ok(isName(''));
+  t.throws(() => isName(''));
   t.throws(() => isName(612));
 });
 


### PR DESCRIPTION
Merge alongside hsmusic/hsmusic-data#388, because this catches a bunch of little things throughout HSMusic's data.

This PR adds two kinds of validation for "content" strings (most names, descriptions, and annotations, as well as commentary entries, news entry bodies, static page content, etc):

* Detect and report "illegal characters". The only one of these at the moment is `\u200b`, which is the non-breaking space (and can't readily be told apart from a normal space in most text editors) — if more come up, they can be added later.
* Detect and report whitespace that should be trimmed. This is at the start and end for single-line strings, and at the end of each line for multiline strings. (Whitespace at the first column in a multiline string is OK, since that usually represents deliberate indentation.)

Supporting internal changes:

* The `determineCause` and `determineHelpers` parts of `showAggregate` have been refactored to use a recursive style, and are a bit easier to extend with new logic. They're kind of awkward functions so they might still need some work for clarity in the future.
* `showAggregate` (as well as `openAggregate` and related utilities) now support a `translucent: 'single'` option - this extends the true/false translucency symbol to indicate that the aggregate should only be displayed if it contains at least two errors; basically, that it's useful only as a grouping of multiple errors, and should be brushed over if it has just a single item!
* There's a new `matchMultiline` utility in `#sugar`, which is (finally) a generator function that yields each match of a regular expression as well as some useful positional information (as raw numbers or automatically formatted), plus the match's whole containing line(s), if requested.

Other notes:

* At the moment, names now have to have at least one character.
* Constructor names aren't colored anymore (in errors like "Errors processing Track named...") - this was pretty much just visual noise, since you can get that detail from the file or data step which includes the error too. It's a useful cue, but it doesn't need special focus, especially when these new errors are making more particular use of color.
* Adds unit tests for `isContentString` too (which includes its *usage* of `matchMultiline`, but not `matchMultiline` in general, yet).