### PR TITLE
Don't transform when update validation fails + related fixes

### DIFF
--- a/src/data/things/cacheable-object.js
+++ b/src/data/things/cacheable-object.js
@@ -180,7 +180,7 @@ export default class CacheableObject {
             throw new TypeError(`Validation failed for value ${newValue}`);
           }
         } catch (caughtError) {
-          throw new CacheableObjectPropertyValueError(property, this[property], newValue, caughtError);
+          throw new CacheableObjectPropertyValueError(property, oldValue, newValue, caughtError);
         }
       }
 

--- a/src/data/things/cacheable-object.js
+++ b/src/data/things/cacheable-object.js
@@ -358,10 +358,10 @@ export default class CacheableObject {
 export class CacheableObjectPropertyValueError extends Error {
   [Symbol.for('hsmusic.aggregate.translucent')] = true;
 
-  constructor(property, oldValue, newValue, error) {
+  constructor(property, oldValue, newValue, options) {
     super(
       `Error setting ${colors.green(property)} (${inspect(oldValue)} -> ${inspect(newValue)})`,
-      {cause: error});
+      options);
 
     this.property = property;
   }

--- a/src/data/things/cacheable-object.js
+++ b/src/data/things/cacheable-object.js
@@ -356,6 +356,8 @@ export default class CacheableObject {
 }
 
 export class CacheableObjectPropertyValueError extends Error {
+  [Symbol.for('hsmusic.aggregate.translucent')] = true;
+
   constructor(property, oldValue, newValue, error) {
     super(
       `Error setting ${colors.green(property)} (${inspect(oldValue)} -> ${inspect(newValue)})`,

--- a/src/data/yaml.js
+++ b/src/data/yaml.js
@@ -346,12 +346,7 @@ export class FieldValueAggregateError extends AggregateError {
 }
 
 export class FieldValueError extends Error {
-  constructor(field, property, value, caughtError) {
-    const cause =
-      (caughtError instanceof CacheableObjectPropertyValueError
-        ? caughtError.cause
-        : caughtError);
-
+  constructor(field, property, value, cause) {
     const fieldText =
       colors.green(`"${field}"`);
 

--- a/src/data/yaml.js
+++ b/src/data/yaml.js
@@ -262,12 +262,14 @@ function makeProcessDocument(
         thing[property] = value;
       } catch (caughtError) {
         skippedFields.add(field);
-        fieldValueErrors.push(new FieldValueError(field, value, caughtError));
+        fieldValueErrors.push(new FieldValueError(
+          field, value, {cause: caughtError}));
       }
     }
 
     if (!empty(fieldValueErrors)) {
-      aggregate.push(new FieldValueAggregateError(thingConstructor, fieldValueErrors));
+      aggregate.push(new FieldValueAggregateError(
+        fieldValueErrors, thingConstructor));
     }
 
     if (skippedFields.size >= 1) {
@@ -335,7 +337,7 @@ export class FieldCombinationError extends Error {
 export class FieldValueAggregateError extends AggregateError {
   [Symbol.for('hsmusic.aggregate.translucent')] = true;
 
-  constructor(thingConstructor, errors) {
+  constructor(errors, thingConstructor) {
     const constructorText =
       colors.green(thingConstructor.name);
 
@@ -346,7 +348,7 @@ export class FieldValueAggregateError extends AggregateError {
 }
 
 export class FieldValueError extends Error {
-  constructor(field, value, cause) {
+  constructor(field, value, options) {
     const fieldText =
       colors.green(`"${field}"`);
 
@@ -355,7 +357,7 @@ export class FieldValueError extends Error {
 
     super(
       `Failed to set ${fieldText} field to ${valueText}`,
-      {cause});
+      options);
   }
 }
 

--- a/src/data/yaml.js
+++ b/src/data/yaml.js
@@ -262,7 +262,7 @@ function makeProcessDocument(
         thing[property] = value;
       } catch (caughtError) {
         skippedFields.add(field);
-        fieldValueErrors.push(new FieldValueError(field, property, value, caughtError));
+        fieldValueErrors.push(new FieldValueError(field, value, caughtError));
       }
     }
 
@@ -346,18 +346,15 @@ export class FieldValueAggregateError extends AggregateError {
 }
 
 export class FieldValueError extends Error {
-  constructor(field, property, value, cause) {
+  constructor(field, value, cause) {
     const fieldText =
       colors.green(`"${field}"`);
-
-    const propertyText =
-      colors.green(property);
 
     const valueText =
       inspect(value, {maxStringLength: 40});
 
     super(
-      `Failed to set ${fieldText} field (${propertyText}) to ${valueText}`,
+      `Failed to set ${fieldText} field to ${valueText}`,
       {cause});
   }
 }

--- a/test/unit/data/cacheable-object.js
+++ b/test/unit/data/cacheable-object.js
@@ -213,6 +213,101 @@ t.test(`CacheableObject validate on update`, t => {
   t.equal(obj.date, date);
 });
 
+t.test(`CacheableObject transform on null value`, t => {
+  let computed = false;
+
+  const obj = newCacheableObject({
+    spookyFactor: {
+      flags: {
+        update: true,
+        expose: true,
+      },
+
+      expose: {
+        transform: value => {
+          computed = true;
+          return (value ? 2 * value : -1);
+        },
+      },
+    },
+  });
+
+  t.plan(4);
+
+  t.equal(obj.spookyFactor, -1);
+  t.ok(computed);
+
+  computed = false;
+  obj.spookyFactor = 1;
+
+  t.equal(obj.spookyFactor, 2);
+  t.ok(computed);
+});
+
+t.test(`CacheableObject don't transform on successful update`, t => {
+  let computed = false;
+
+  const obj = newCacheableObject({
+    original: {
+      flags: {
+        update: true,
+        expose: true,
+      },
+
+      update: {
+        validate: value => value.startsWith('track:'),
+      },
+
+      expose: {
+        transform: value => {
+          computed = true;
+          return (value ? value.split(':')[1] : null);
+        },
+      },
+    },
+  });
+
+  t.plan(4);
+
+  t.doesNotThrow(() => obj.original = 'track:foo');
+  t.notOk(computed);
+
+  t.equal(obj.original, 'foo');
+  t.ok(computed);
+});
+
+t.test(`CacheableObject don't transform on failed update`, t => {
+  let computed = false;
+
+  const obj = newCacheableObject({
+    original: {
+      flags: {
+        update: true,
+        expose: true,
+      },
+
+      update: {
+        validate: value => value.startsWith('track:'),
+      },
+
+      expose: {
+        transform: value => {
+          computed = true;
+          return (value ? value.split(':')[1] : null);
+        },
+      },
+    },
+  });
+
+  t.plan(4);
+
+  t.throws(() => obj.original = 'album:foo');
+  t.notOk(computed);
+
+  t.equal(obj.original, null);
+  t.ok(computed);
+});
+
 t.test(`CacheableObject default update property value`, t => {
   const obj = newCacheableObject({
     fruit: {


### PR DESCRIPTION
Bundles some related changes to do with error processing:

* Don't compute (i.e. call `expose.transform`) the previous value when setting a new value on a cacheable object fails! It doesn't make sense for a property's `update` to inadvertently interact with its `expose` description, and this was causing an error koba encountered - for a part of an error message which doesn't even ordinarily get displayed! ([Via Discord, #software-support.](https://discord.com/channels/749042497610842152/1153707535895908584/1193073646315515984))
* Add a unit test for the above, and some related transform/update relationships.
* Make `CacheableObjectPropertyValue` into a formally "translucent" error, causing it to get skipped by `showAggregate` when showing the cause for a parent error. And update `FieldValueError` to not make any assumptions about its own cause - no need to hard-code special mechanics for pulling the cause out of a nested cacheable object error, anymore!
* Get rid of the property part in `FieldValueError` - that's an internal detail which generally doesn't matter when working with data, and now it's visible via the (properly) nested `CacheableObjectPropertyValue`, if you're debugging with `--show-traces`.
* Tidy up a few constructors for classes extending `Error` and `AggregateError`, so that their parameters more closely match JavaScript's own constructors.