### PR TITLE
Redesign appearance of artwork "reveal" interaction / content warnings

### DIFF
--- a/src/content/dependencies/image.js
+++ b/src/content/dependencies/image.js
@@ -184,10 +184,18 @@ export default {
     let reveal = null;
     if (willReveal) {
       reveal = [
-        language.$('misc.contentWarnings', {
-          warnings: language.formatUnitList(data.contentWarnings),
-        }),
+        html.tag('span', {class: 'reveal-heading'},
+          language.$('misc.contentWarnings.heading')),
+
         html.tag('br'),
+
+        html.tag('span', {class: 'reveal-warnings'},
+          language.$('misc.contentWarnings.warnings', {
+            warnings: language.formatUnitList(data.contentWarnings),
+          })),
+
+        html.tag('br'),
+
         html.tag('span', {class: 'reveal-interaction'},
           language.$('misc.contentWarnings.reveal')),
       ];

--- a/src/content/dependencies/image.js
+++ b/src/content/dependencies/image.js
@@ -3,6 +3,7 @@ import {empty} from '#sugar';
 
 export default {
   extraDependencies: [
+    'cachebust',
     'checkIfImagePathHasCachedThumbnails',
     'getDimensionsOfImagePath',
     'getSizeOfImagePath',
@@ -71,6 +72,7 @@ export default {
   },
 
   generate(data, relations, slots, {
+    cachebust,
     checkIfImagePathHasCachedThumbnails,
     getDimensionsOfImagePath,
     getSizeOfImagePath,
@@ -186,8 +188,8 @@ export default {
     let reveal = null;
     if (willReveal) {
       reveal = [
-        html.tag('span', {class: 'reveal-heading'},
-          language.$('misc.contentWarnings.heading')),
+        html.tag('img', {class: 'reveal-symbol'},
+          {src: to('shared.staticFile', 'warning.svg', cachebust)}),
 
         html.tag('br'),
 

--- a/src/content/dependencies/image.js
+++ b/src/content/dependencies/image.js
@@ -338,14 +338,25 @@ export default {
       }
 
       wrapped =
+        html.tag('div', {class: 'image-inner-area'},
+          wrapped);
+
+      if (willLink) {
+        wrapped =
+          html.tag('a', {class: 'image-link'},
+            linkAttributes,
+
+            wrapped);
+      }
+
+      wrapped =
         html.tag('div', {class: 'image-container'},
           containerAttributes,
 
           !originalSrc &&
             {class: 'placeholder-image'},
 
-          html.tag('div', {class: 'image-inner-area'},
-            wrapped));
+          wrapped);
 
       if (willReveal) {
         wrapped =
@@ -365,17 +376,6 @@ export default {
 
             html.tag('div', {class: 'square-content'},
               wrapped));
-      }
-
-      if (willLink) {
-        wrapped =
-          html.tag('a', {class: ['box', 'image-link']},
-            linkAttributes,
-
-            visibility === 'hidden' &&
-              {class: 'js-hide'},
-
-            wrapped);
       }
 
       return wrapped;

--- a/src/content/dependencies/image.js
+++ b/src/content/dependencies/image.js
@@ -127,6 +127,8 @@ export default {
     const willSquare = slots.square;
 
     const imgAttributes = html.attributes([
+      {class: 'image'},
+
       slots.alt && {alt: slots.alt},
       slots.width && {width: slots.width},
       slots.height && {height: slots.height},

--- a/src/content/dependencies/image.js
+++ b/src/content/dependencies/image.js
@@ -140,9 +140,6 @@ export default {
       (customLink
         ? {href: slots.link}
         : {href: originalSrc}),
-
-      customLink &&
-        {class: 'no-image-preview'},
     ]);
 
     const containerAttributes = html.attributes();
@@ -352,6 +349,12 @@ export default {
       wrapped =
         html.tag('div', {class: 'image-container'},
           containerAttributes,
+
+          willLink &&
+            {class: 'has-link'},
+
+          customLink &&
+            {class: 'no-image-preview'},
 
           !originalSrc &&
             {class: 'placeholder-image'},

--- a/src/content/dependencies/linkThing.js
+++ b/src/content/dependencies/linkThing.js
@@ -95,6 +95,8 @@ export default {
           selectColors = {
             '--primary-color': 'primary',
             '--dim-color': 'dim',
+            '--deep-color': 'deep',
+            '--bg-black-color': 'bgBlack',
           };
           break;
 

--- a/src/gen-thumbs.js
+++ b/src/gen-thumbs.js
@@ -131,6 +131,12 @@ const thumbnailSpec = {
     size: 250,
     quality: 85,
   },
+
+  'mini': {
+    tackbust: 2,
+    size: 8,
+    quality: 95,
+  },
 };
 
 import {spawn} from 'node:child_process';

--- a/src/static/client3.js
+++ b/src/static/client3.js
@@ -1679,7 +1679,11 @@ function addImageOverlayClickHandlers() {
     return;
   }
 
-  for (const link of document.querySelectorAll('.image-link:not(.no-image-preview)')) {
+  for (const link of document.querySelectorAll('.image-link')) {
+    if (link.closest('.no-image-preview')) {
+      continue;
+    }
+
     link.addEventListener('click', handleImageLinkClicked);
   }
 

--- a/src/static/client3.js
+++ b/src/static/client3.js
@@ -205,7 +205,9 @@ function getScriptedLinkReferences() {
     document.querySelectorAll('[data-random]');
 
   scriptedLinkInfo.revealLinks =
-    document.querySelectorAll('.reveal .image-inner-area');
+    document.querySelectorAll(
+      '.reveal .image-container > .image-link, ' +
+      '.reveal .image-container > .image-inner-area');
 
   scriptedLinkInfo.revealContainers =
     Array.from(scriptedLinkInfo.revealLinks)
@@ -394,9 +396,8 @@ function handleRevealLinkClicked(domEvent, _revealLink, revealContainer) {
     return;
   }
 
-  revealContainer.classList.add('revealed');
   domEvent.preventDefault();
-  domEvent.stopPropagation();
+  revealContainer.classList.add('revealed');
   revealContainer.dispatchEvent(new CustomEvent('hsmusic-reveal'));
 }
 
@@ -1718,7 +1719,7 @@ function handleImageLinkClicked(evt) {
   evt.preventDefault();
 
   // Don't show the overlay if the image still needs to be revealed.
-  if (evt.target.closest('a').querySelector('.reveal:not(.revealed)')) {
+  if (evt.target.closest('.reveal:not(.revealed)')) {
     return;
   }
 

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -659,7 +659,7 @@ p .current {
   border-top-color: var(--deep-color);
 }
 
-#cover-art img {
+#cover-art .image {
   display: block;
   width: 100%;
   height: 100%;
@@ -726,7 +726,7 @@ a.box:focus:not(:focus-visible) {
   outline: none;
 }
 
-a.box img {
+a.box .image {
   display: block;
   max-width: 100%;
   height: auto;
@@ -1128,7 +1128,7 @@ img.pixelate {
   height: 100%;
 }
 
-.reveal img {
+.reveal .image {
   filter: blur(20px);
   opacity: 0.4;
 }
@@ -1173,7 +1173,7 @@ img.pixelate {
   opacity: 0.8;
 }
 
-.reveal.revealed img {
+.reveal.revealed .image {
   filter: none;
   opacity: 1;
 }
@@ -1225,7 +1225,7 @@ img.pixelate {
   box-shadow: none;
 }
 
-.grid-item img {
+.grid-item .image {
   width: 100%;
   height: 100% !important;
   margin-top: auto;
@@ -1421,7 +1421,7 @@ html[data-url-key="localized.home"] .carousel-container {
   padding: 0;
 }
 
-.carousel-item img {
+.carousel-item .image {
   width: 100%;
   height: 100%;
   margin-top: auto;
@@ -1719,7 +1719,7 @@ main.long-content .content-sticky-heading-container .content-sticky-subheading-r
   border-radius: 1.75px;
 }
 
-.content-sticky-heading-cover img {
+.content-sticky-heading-cover .image {
   display: block;
   width: 100%;
   height: 100%;

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -1096,7 +1096,7 @@ h1 a[href="#additional-names-box"]:hover {
 
 .image-link {
   border-bottom: 1px solid #ffffff03;
-  border-radius: 2.5px;
+  border-radius: 2.5px 2.5px 3px 3px;
   box-shadow:
     0 1px 8px -3px var(--bg-black-color);
 }

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -1141,13 +1141,32 @@ img.pixelate {
   bottom: 10px;
   display: flex;
   flex-direction: column;
-  justify-content: flex-start;
+  justify-content: center;
+}
+
+.grid-item .reveal-text {
+  font-size: 0.9em;
+}
+
+.reveal:not(.revealed) .image-inner-area {
+  background: var(--deep-color);
 }
 
 .reveal-text {
   color: white;
   text-align: center;
   font-weight: bold;
+  padding-bottom: 0.5em;
+}
+
+.reveal-heading {
+  font-size: 1.2em;
+  opacity: 0.8;
+  font-weight: 800;
+  width: 1em;
+  height: 1em;
+  margin-bottom: 0.4em;
+  display: inline-block;
 }
 
 .reveal-interaction {

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -1128,11 +1128,6 @@ img.pixelate {
   height: 100%;
 }
 
-.reveal .image {
-  filter: blur(20px);
-  opacity: 0.4;
-}
-
 .reveal-text-container {
   position: absolute;
   top: 15px;
@@ -1146,10 +1141,6 @@ img.pixelate {
 
 .grid-item .reveal-text {
   font-size: 0.9em;
-}
-
-.reveal:not(.revealed) .image-inner-area {
-  background: var(--deep-color);
 }
 
 .reveal-text {
@@ -1172,6 +1163,25 @@ img.pixelate {
 
 .reveal-interaction {
   opacity: 0.8;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+}
+
+.reveal .image {
+  opacity: 0.7;
+  filter: blur(20px) brightness(0.7);
+}
+
+.reveal .image.reveal-thumbnail {
+  image-rendering: pixelated;
+}
+
+.reveal.has-reveal-thumbnail:not(.revealed) .image:not(.reveal-thumbnail) {
+  display: none !important;
+}
+
+.reveal.revealed.has-reveal-thumbnail .image.reveal-thumbnail {
+  display: none !important;
 }
 
 .reveal.revealed .image {
@@ -1181,6 +1191,27 @@ img.pixelate {
 
 .reveal.revealed .reveal-text {
   display: none;
+}
+
+.reveal:not(.revealed) .image-inner-area {
+  background: var(--deep-color);
+
+  box-sizing: border-box;
+  border: 1px dotted var(--primary-color);
+  border-radius: 6px;
+}
+
+.reveal .image-inner-area:hover .reveal-interaction {
+  text-decoration-style: solid;
+}
+
+.reveal:not(.revealed) .image-inner-area:hover {
+  border-style: solid;
+}
+
+.reveal:not(.revealed) .image-inner-area:hover .image {
+  filter: blur(20px) brightness(0.6);
+  opacity: 0.6;
 }
 
 .image-link:not(.no-image-preview) .image-container {

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -718,15 +718,20 @@ ul.image-details li {
   margin-bottom: 1em;
 }
 
-a.box:focus {
-  outline: 3px double var(--primary-color);
+.image-link {
+  display: block;
+  overflow: hidden;
 }
 
-a.box:focus:not(:focus-visible) {
+.image-link:focus {
+  outline: 3px double white;
+}
+
+.image-link:focus:not(:focus-visible) {
   outline: none;
 }
 
-a.box .image {
+.image-link .image {
   display: block;
   max-width: 100%;
   height: auto;
@@ -1088,16 +1093,17 @@ h1 a[href="#additional-names-box"]:hover {
   text-shadow: 0 2px 5px rgba(0, 0, 0, 0.75);
 }
 
-.image-inner-area {
-  position: relative;
-  width: 100%;
-  height: 100%;
-  overflow: hidden;
-
+.image-link {
   border-bottom: 1px solid #ffffff03;
   border-radius: 2.5px;
   box-shadow:
     0 1px 8px -3px var(--bg-black-color);
+}
+
+.image-inner-area {
+  position: relative;
+  width: 100%;
+  height: 100%;
 }
 
 img {
@@ -1108,6 +1114,7 @@ img {
   content: "";
   display: block;
   position: absolute;
+  pointer-events: none;
   top: 0;
   left: 0;
   right: 0;
@@ -1193,25 +1200,32 @@ img.pixelate {
   display: none;
 }
 
-.reveal:not(.revealed) .image-inner-area {
-  background: var(--deep-color);
-
+.reveal:not(.revealed) .image-container > .image-link,
+.reveal:not(.revealed) .image-container > .image-inner-area {
   box-sizing: border-box;
   border: 1px dotted var(--primary-color);
   border-radius: 6px;
+  overflow: hidden;
 }
 
-.reveal .image-inner-area:hover .reveal-interaction {
-  text-decoration-style: solid;
+.reveal:not(.revealed) .image-inner-area {
+  background: var(--deep-color);
 }
 
-.reveal:not(.revealed) .image-inner-area:hover {
+.reveal:not(.revealed) .image-container > .image-link:hover,
+.reveal:not(.revealed) .image-container > .image-inner-area:hover {
   border-style: solid;
 }
 
-.reveal:not(.revealed) .image-inner-area:hover .image {
+.reveal:not(.revealed) .image-container > .image-link:hover .image,
+.reveal:not(.revealed) .image-container > .image-inner-area:hover .image {
   filter: blur(20px) brightness(0.6);
   opacity: 0.6;
+}
+
+.reveal:not(.revealed) .image-container > .image-link:hover .reveal-interaction,
+.reveal:not(.revealed) .image-container > .image-inner-area:hover .reveal-interaction {
+  text-decoration-style: solid;
 }
 
 .image-link:not(.no-image-preview) .image-container {

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -737,7 +737,8 @@ ul.image-details li {
   height: auto;
 }
 
-.square .image-container {
+.square .image-container,
+.square .image-link {
   width: 100%;
   height: 100%;
 }
@@ -1104,6 +1105,15 @@ h1 a[href="#additional-names-box"]:hover {
   position: relative;
   width: 100%;
   height: 100%;
+}
+
+.image-link .image-inner-area {
+  /* Jankily fix a rendering issue with border-radius on Safari.
+   * The `-webkit-` prefix is only to keep this from applying on
+   * other browsers (well, Firefox), where it doesn't *break*
+   * anything, but also isn't necessary.
+   */
+  -webkit-transform: translateZ(0);
 }
 
 img {

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -1159,14 +1159,15 @@ img.pixelate {
   padding-bottom: 0.5em;
 }
 
-.reveal-heading {
-  font-size: 1.2em;
-  opacity: 0.8;
-  font-weight: 800;
+.reveal-symbol {
+  display: inline-block;
   width: 1em;
   height: 1em;
-  margin-bottom: 0.4em;
-  display: inline-block;
+  margin-bottom: 0.1em;
+
+  font-size: 1.6em;
+  opacity: 0.8;
+  background-image: url("warning.svg");
 }
 
 .reveal-interaction {

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -1228,7 +1228,7 @@ img.pixelate {
   text-decoration-style: solid;
 }
 
-.image-link:not(.no-image-preview) .image-container {
+.image-container.has-link:not(.no-image-preview) {
   background: var(--deep-color);
   box-shadow: none;
   border-radius: 0 0 4px 4px;

--- a/src/static/warning.svg
+++ b/src/static/warning.svg
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="64mm"
+   height="64mm"
+   viewBox="0 0 64 64"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.2 (b0a84865, 2022-12-01)"
+   sodipodi:docname="warning.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="2.2162213"
+     inkscape:cx="164.24353"
+     inkscape:cy="147.77405"
+     inkscape:window-width="1309"
+     inkscape:window-height="865"
+     inkscape:window-x="172"
+     inkscape:window-y="117"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs2">
+    <inkscape:path-effect
+       effect="bool_op"
+       operand-path="#path1050"
+       id="path-effect1430"
+       is_visible="true"
+       lpeversion="1"
+       operation="diff"
+       swap-operands="false"
+       filltype-this="positive"
+       filter=""
+       filltype-operand="nonzero" />
+    <filter
+       id="selectable_hidder_filter"
+       width="1"
+       height="1"
+       x="0"
+       y="0"
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="LPE boolean visibility">
+      <feComposite
+         id="boolops_hidder_primitive"
+         result="composite1"
+         operator="arithmetic"
+         in2="SourceGraphic"
+         in="BackgroundImage" />
+    </filter>
+    <inkscape:path-effect
+       effect="bool_op"
+       operand-path=""
+       id="path-effect1410"
+       is_visible="true"
+       lpeversion="1"
+       operation="diff"
+       swap-operands="false"
+       filltype-this="from-curve"
+       filter=""
+       filltype-operand="from-curve" />
+    <linearGradient
+       id="linearGradient1106"
+       inkscape:swatch="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop1104" />
+    </linearGradient>
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       id="path1458"
+       style="color:#000000;fill:#ffffff;stroke-width:11;stroke-linejoin:round;-inkscape-stroke:none;paint-order:fill markers stroke"
+       d="M 32.000114 8.4041382 A 5.50055 5.50055 0 0 0 27.320296 11.013798 L 4.9805745 47.209005 A 5.50055 5.50055 0 0 0 9.6619425 55.59764 L 54.337769 55.59764 A 5.50055 5.50055 0 0 0 59.019653 47.209005 L 36.679932 11.013798 A 5.50055 5.50055 0 0 0 32.000114 8.4041382 z M 29.123287 18.81849 L 34.876941 18.81849 A 1.069827 1.069827 0 0 1 35.945093 19.935734 L 35.052641 39.585697 A 1.069827 1.069827 0 0 1 33.808789 40.593905 C 33.210998 40.494454 32.606121 40.443789 32.000114 40.443526 C 31.395269 40.445711 30.791425 40.496549 30.195056 40.597522 A 1.069827 1.069827 0 0 1 28.94707 39.591899 L 28.054618 19.935734 A 1.069827 1.069827 0 0 1 29.123287 18.81849 z M 32.000114 42.910042 A 3.5582614 3.5582614 0 0 1 35.558036 46.468481 A 3.5582614 3.5582614 0 0 1 32.000114 50.026404 A 3.5582614 3.5582614 0 0 1 28.441675 46.468481 A 3.5582614 3.5582614 0 0 1 32.000114 42.910042 z " />
+  </g>
+</svg>

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -646,7 +646,6 @@ misc:
 
   contentWarnings:
     warnings: "{WARNINGS}"
-    heading: "ⓘ"
     reveal: "click to show"
 
   # albumGrid:

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -645,7 +645,8 @@ misc:
   #   clicking through.
 
   contentWarnings:
-    _: "cw: {WARNINGS}"
+    warnings: "{WARNINGS}"
+    heading: "ⓘ"
     reveal: "click to show"
 
   # albumGrid:


### PR DESCRIPTION
This PR tweaks the way artworks with content warnings are stylized. We haven't decided on exact specifics yet, but this PR fills out the layout and makes it fairly easy to use either an "info" (ⓘ) or "warning" (⚠) symbol, or an icon instead.

* Removes the "cw:" text, which is a somewhat niche abbreviation, and provides layout for using a more universal symbol instead.
* ~~At the moment uses an "info" symbol as a shift away from "warning" presentation and towards more emotionally neutral presentation, but this might change.~~
* Currently using a warning symbol (created by us), mostly to emphasize and be very clear about the effect of the interaction. 
* Vertically center aligns the CW text, making it visually fit in better, and putting more forefront attention on the details of the interaction.
* Various changes to detail the interaction before you actually take it:
  * In general, the image interaction bounding box (i.e. `.image-link`) is now the inner area, not the container. This most notably goes for a page's main cover art (but also content images), and expands the range where clicking in a grid item brings you to the page *instead of* revealing the artwork.
  * The interaction box is clearly rounded for reveals.
  * The interaction box gets a dotted border for reveals, which is solid when hovered.
  * The blurred preview image is made darker when hovered (to bring greater emphasis to the interaction text).
  * The "click to show" text is dotted-underlined by default, and solid when the interaction box is hovered.
* New "mini" thumb is added, which renders only a tiny amount of detail (8x8). This is used for the preview when a reveal hasn't been interacted with yet. Blurring still functionally encodes a certain degree of detail; this reduces the information available in the first place.

The internals of the `image` component (as well as related CSS styling) are largely reworked to support changes to the HTML hierarchy, embedding two images instead of one, and so on. It's hopefully a bit clearer than before, but `image` also has more complex behavior in total.
