### PR TITLE
Per-thumbtack versioning + thumbs cache future-proofing + speed!

### DIFF
--- a/src/gen-thumbs.js
+++ b/src/gen-thumbs.js
@@ -869,7 +869,7 @@ export default async function genThumbs({
 
   quietInfo`Running up to ${magickThreads + ' magick threads'} simultaneously.`;
 
-  let cache = null;
+  let cache = {};
   let firstRun = false;
 
   try {

--- a/src/gen-thumbs.js
+++ b/src/gen-thumbs.js
@@ -788,18 +788,28 @@ export async function refreshThumbnailCache(cache, {mediaPath, queueSize}) {
           try {
             const filePathInMedia = path.join(mediaPath, imagePath);
 
-            if (!md5) {
+            if (md5 === null) {
               md5 = await readFileMD5(filePathInMedia);
               updatedAnything = true;
             }
 
-            if (!mtime) {
+            if (mtime === null) {
               const statResults = await stat(filePathInMedia);
               mtime = +statResults.mtime;
               updatedAnything = true;
             }
           } catch (error) {
-            if (error.code !== 'ENOENT') {
+            if (error.code === 'ENOENT') {
+              if (md5 === null) {
+                md5 = "-";
+                updatedAnything = true;
+              }
+
+              if (mtime === null) {
+                mtime = 0;
+                updatedAnything = true;
+              }
+            } else {
               throw error;
             }
           }

--- a/src/util/wiki-data.js
+++ b/src/util/wiki-data.js
@@ -71,6 +71,10 @@ export function chunkMultipleArrays(...args) {
   const arrays = args.slice(0, -1);
   const fn = args.at(-1);
 
+  if (arrays[0].length === 0) {
+    return [];
+  }
+
   const newChunk = index => arrays.map(array => [array[index]]);
   const results = [newChunk(0)];
 


### PR DESCRIPTION
Wow! This PR does three things:

* **Future-proofs the `thumbnail-cache.json` format.** Well, more or less. Cache entries are an object instead of an array now (storage here isn't that much of a factor compared to, you know, the size of an actual image and its thumbnails), and record a `specbust` value, which is basically a version number for the entry's format. Old caches are treated as `0`, and the current version is `2` - we were messing around with an array-based middle version (`1`), but it didn't seem too flexible for extending later on. The code form is also future-proofed, primarily by isolating cache entry processing into new utilities, `thumbnailCacheEntryToDetails` and `detailsToThumbnailCacheEntry` (and helepr `getSpecbustForCacheEntry`).
* **Versions individual thumbtacks.** We've got a new `tackbust` concept - where `specbust` is for the cache entry's format, `tackbust` indicates the contents and specification of individual *thumbnails.* The bust for each thumbtack is saved in an object on each cache entry. (Arrays are more compact, but unwieldy, and not worth much if we're using an object for the overall entry anyway.) The tackbust itself is retrieved from that thumbtack's spec; as a given spec is updated, its tackbust is bumped. Any thumbnail whose cache entry's tackbust mismatches the current spec's tackbust (on the corresponding thumbtack, of course) will get regenerated; thumbtacks whose busts *do* match the spec *won't* be regenerated. So updating a single spec, for example, means regenerating around 4800 thumbnails, instead of 24000!
* **Speeds up checking for updated source images.** We now store the `mtime` (timestamp for when last modified) of source images in the cache. We read `mtime` and compare it against the cache; if it matches, that's *not* grounds to regenerate the thumbnail, but it does enable checking the MD5 hash against the cache (like we used to do for *every* image, every* time). Basically this means we're avoiding reading literally six gigabytes of images every single time thumbnails are processed, only reading files (to check MD5) when the file appears to have been changed or replaced with one with a different `mtime`. Sorry for the probably terabytes of reads we've wasted on everyone's drives prior to this!!

We've also refactored the whole main `genThumbs` function, which now works with `filterMultipleArrays` and so on for relatively more declarative style, catching it up to date with all sorts of other recent code.

Plus the cache file is now written one entry per line, so it's a heck of a lot easier to browse in a text editor, and should be reasonably friendly to git later on.