### PR TITLE
Refactor tooltip classes, offset icon tooltips in lists properly

### DIFF
--- a/src/content/dependencies/generateAbsoluteDatetimestamp.js
+++ b/src/content/dependencies/generateAbsoluteDatetimestamp.js
@@ -1,12 +1,21 @@
 export default {
-  contentDependencies: ['generateDatetimestampTemplate'],
+  contentDependencies: [
+    'generateDatetimestampTemplate',
+    'generateTooltip',
+  ],
+
   extraDependencies: ['html', 'language'],
 
   data: (date) =>
     ({date}),
 
-  relations: (relation) =>
-    ({template: relation('generateDatetimestampTemplate')}),
+  relations: (relation) => ({
+    template:
+      relation('generateDatetimestampTemplate'),
+
+    tooltip:
+      relation('generateTooltip'),
+  }),
 
   slots: {
     style: {
@@ -30,10 +39,13 @@ export default {
           ? data.date.getFullYear().toString()
           : null),
 
-      tooltipContent:
+      tooltip:
         slots.tooltip &&
         slots.style === 'year' &&
-          language.formatDate(data.date),
+          relations.tooltip.slots({
+            content:
+              language.formatDate(data.date),
+          }),
 
       datetime:
         data.date.toISOString(),

--- a/src/content/dependencies/generateDatetimestampTemplate.js
+++ b/src/content/dependencies/generateDatetimestampTemplate.js
@@ -28,8 +28,8 @@ export default {
           slots.mainContent),
 
         slots.tooltipContent &&
-          html.tag('span', {class: 'datetimestamp-tooltip'},
-            html.tag('span', {class: 'datetimestamp-tooltip-content'},
+          html.tag('span', {class: ['tooltip', 'datetimestamp-tooltip']},
+            html.tag('span', {class: 'tooltip-content'},
               slots.tooltipContent)),
       ]),
 };

--- a/src/content/dependencies/generateDatetimestampTemplate.js
+++ b/src/content/dependencies/generateDatetimestampTemplate.js
@@ -1,5 +1,11 @@
 export default {
+  contentDependencies: ['generateTextWithTooltip'],
   extraDependencies: ['html'],
+
+  relations: (relation) => ({
+    textWithTooltip:
+      relation('generateTextWithTooltip'),
+  }),
 
   slots: {
     mainContent: {
@@ -15,20 +21,18 @@ export default {
     datetime: {type: 'string'},
   },
 
-  generate: (slots, {html}) =>
-    html.tag('span', {class: 'datetimestamp'},
-      {[html.joinChildren]: ''},
+  generate: (relations, slots, {html}) =>
+    relations.textWithTooltip.slots({
+      attributes: {class: 'datetimestamp'},
 
-      !html.isBlank(slots.tooltip) &&
-        {class: 'has-tooltip'},
-
-      [
+      text:
         html.tag('time',
           {datetime: slots.datetime},
           slots.mainContent),
 
+      tooltip:
         slots.tooltip?.slots({
           attributes: [{class: 'datetimestamp-tooltip'}],
         }),
-      ]),
+    }),
 };

--- a/src/content/dependencies/generateDatetimestampTemplate.js
+++ b/src/content/dependencies/generateDatetimestampTemplate.js
@@ -7,9 +7,9 @@ export default {
       mutable: false,
     },
 
-    tooltipContent: {
+    tooltip: {
       type: 'html',
-      mutable: false,
+      mutable: true,
     },
 
     datetime: {type: 'string'},
@@ -19,7 +19,7 @@ export default {
     html.tag('span', {class: 'datetimestamp'},
       {[html.joinChildren]: ''},
 
-      slots.tooltipContent &&
+      !html.isBlank(slots.tooltip) &&
         {class: 'has-tooltip'},
 
       [
@@ -27,9 +27,8 @@ export default {
           {datetime: slots.datetime},
           slots.mainContent),
 
-        slots.tooltipContent &&
-          html.tag('span', {class: ['tooltip', 'datetimestamp-tooltip']},
-            html.tag('span', {class: 'tooltip-content'},
-              slots.tooltipContent)),
+        slots.tooltip?.slots({
+          attributes: [{class: 'datetimestamp-tooltip'}],
+        }),
       ]),
 };

--- a/src/content/dependencies/generateRelativeDatetimestamp.js
+++ b/src/content/dependencies/generateRelativeDatetimestamp.js
@@ -2,6 +2,7 @@ export default {
   contentDependencies: [
     'generateAbsoluteDatetimestamp',
     'generateDatetimestampTemplate',
+    'generateTooltip',
   ],
 
   extraDependencies: ['html', 'language'],
@@ -11,9 +12,16 @@ export default {
       ? {equal: true, date: currentDate}
       : {equal: false, currentDate, referenceDate}),
 
-  relations: (relation, currentDate) =>
-    ({template: relation('generateDatetimestampTemplate'),
-      fallback: relation('generateAbsoluteDatetimestamp', currentDate)}),
+  relations: (relation, currentDate) => ({
+    template:
+      relation('generateDatetimestampTemplate'),
+
+    fallback:
+      relation('generateAbsoluteDatetimestamp', currentDate),
+
+    tooltip:
+      relation('generateTooltip'),
+  }),
 
   slots: {
     style: {
@@ -43,12 +51,15 @@ export default {
           ? data.currentDate.getFullYear().toString()
           : null),
 
-      tooltipContent:
+      tooltip:
         slots.tooltip &&
-          language.formatRelativeDate(data.currentDate, data.referenceDate, {
-            considerRoundingDays: true,
-            approximate: true,
-            absolute: slots.style === 'year',
+          relations.tooltip.slots({
+            content:
+              language.formatRelativeDate(data.currentDate, data.referenceDate, {
+                considerRoundingDays: true,
+                approximate: true,
+                absolute: slots.style === 'year',
+              }),
           }),
 
       datetime:

--- a/src/content/dependencies/generateTextWithTooltip.js
+++ b/src/content/dependencies/generateTextWithTooltip.js
@@ -1,0 +1,47 @@
+export default {
+  extraDependencies: ['html'],
+
+  slots: {
+    attributes: {
+      type: 'attributes',
+      mutable: false,
+    },
+
+    text: {
+      type: 'html',
+      mutable: false,
+    },
+
+    tooltip: {
+      type: 'html',
+      mutable: false,
+    },
+  },
+
+  generate(slots, {html}) {
+    const hasTooltip =
+      !html.isBlank(slots.tooltip);
+
+    if (slots.attributes.blank && !hasTooltip) {
+      return slots.text;
+    }
+
+    let {attributes} = slots;
+
+    if (hasTooltip) {
+      attributes = attributes.clone();
+      attributes.add({
+        [html.joinChildren]: '',
+        [html.noEdgeWhitespace]: true,
+        class: 'text-with-tooltip',
+      });
+    }
+
+    const content =
+      (hasTooltip
+        ? [slots.text, slots.tooltip]
+        : slots.text);
+
+    return html.tag('span', attributes, content);
+  },
+};

--- a/src/content/dependencies/generateTooltip.js
+++ b/src/content/dependencies/generateTooltip.js
@@ -1,0 +1,30 @@
+export default {
+  extraDependencies: ['html'],
+
+  slots: {
+    attributes: {
+      type: 'attributes',
+      mutable: false,
+    },
+
+    contentAttributes: {
+      type: 'attributes',
+      mutable: false,
+    },
+
+    content: {
+      type: 'html',
+      mutable: false,
+    },
+  },
+
+  generate: (slots, {html}) =>
+    html.tag('span', {class: 'tooltip'},
+      {[html.noEdgeWhitespace]: true},
+      slots.attributes,
+
+      html.tag('span', {class: 'tooltip-content'},
+        {[html.noEdgeWhitespace]: true},
+        slots.contentAttributes,
+        slots.content)),
+};

--- a/src/content/dependencies/linkContribution.js
+++ b/src/content/dependencies/linkContribution.js
@@ -1,7 +1,12 @@
 import {empty} from '#sugar';
 
 export default {
-  contentDependencies: ['linkArtist', 'linkExternalAsIcon'],
+  contentDependencies: [
+    'generateTooltip',
+    'linkArtist',
+    'linkExternalAsIcon',
+  ],
+
   extraDependencies: ['html', 'language'],
 
   relations(relation, contribution) {
@@ -9,6 +14,9 @@ export default {
 
     relations.artistLink =
       relation('linkArtist', contribution.who);
+
+    relations.tooltip =
+      relation('generateTooltip');
 
     if (!empty(contribution.who.urls)) {
       relations.artistIcons =
@@ -64,19 +72,21 @@ export default {
     if (hasExternalIcons && slots.iconMode === 'tooltip') {
       content = [
         content,
-        html.tag('span', {class: ['icons', 'tooltip', 'icons-tooltip']},
-          {[html.noEdgeWhitespace]: true},
+        relations.tooltip.slots({
+          attributes:
+            {class: ['icons', 'icons-tooltip']},
 
-          html.tag('span', {class: 'tooltip-content'},
-            {[html.noEdgeWhitespace]: true},
+          contentAttributes:
             {[html.joinChildren]: ''},
 
+          content:
             relations.artistIcons
               .map(icon =>
                 icon.slots({
                   context: 'artist',
                   withText: true,
-                })))),
+                })),
+        }),
       ];
     }
 

--- a/src/content/dependencies/linkContribution.js
+++ b/src/content/dependencies/linkContribution.js
@@ -66,7 +66,6 @@ export default {
         content,
         html.tag('span', {class: ['icons', 'tooltip', 'icons-tooltip']},
           {[html.noEdgeWhitespace]: true},
-          {inert: true},
 
           html.tag('span', {class: 'tooltip-content'},
             {[html.noEdgeWhitespace]: true},

--- a/src/content/dependencies/linkContribution.js
+++ b/src/content/dependencies/linkContribution.js
@@ -64,11 +64,11 @@ export default {
     if (hasExternalIcons && slots.iconMode === 'tooltip') {
       content = [
         content,
-        html.tag('span', {class: ['icons', 'icons-tooltip']},
+        html.tag('span', {class: ['icons', 'tooltip', 'icons-tooltip']},
           {[html.noEdgeWhitespace]: true},
           {inert: true},
 
-          html.tag('span', {class: 'icons-tooltip-content'},
+          html.tag('span', {class: 'tooltip-content'},
             {[html.noEdgeWhitespace]: true},
             {[html.joinChildren]: ''},
 

--- a/src/static/client3.js
+++ b/src/static/client3.js
@@ -2086,28 +2086,28 @@ for (const info of groupContributionsTableInfo) {
   });
 }
 
-// Artist link icon tooltips ------------------------------
+// Generic links with tooltips ----------------------------
 
-const externalIconTooltipInfo = initInfo('externalIconTooltipInfo', {
+const textWithTooltipInfo = initInfo('textWithTooltipInfo', {
   hoverables: null,
   tooltips: null,
 });
 
-function getExternalIconTooltipReferences() {
-  const info = externalIconTooltipInfo;
+function getTextWithTooltipReferences() {
+  const info = textWithTooltipInfo;
 
   const spans =
-    Array.from(document.querySelectorAll('span.contribution.has-tooltip'));
+    Array.from(document.querySelectorAll('.text-with-tooltip'));
 
   info.hoverables =
-    spans.map(span => span.querySelector('a'));
+    spans.map(span => span.children[0]);
 
   info.tooltips =
-    spans.map(span => span.querySelector('span.icons-tooltip'));
+    spans.map(span => span.children[1]);
 }
 
-function addExternalIconTooltipPageListeners() {
-  const info = externalIconTooltipInfo;
+function addTextWithTooltipPageListeners() {
+  const info = textWithTooltipInfo;
 
   for (const {hoverable, tooltip} of stitchArrays({
     hoverable: info.hoverables,
@@ -2118,8 +2118,8 @@ function addExternalIconTooltipPageListeners() {
   }
 }
 
-clientSteps.getPageReferences.push(getExternalIconTooltipReferences);
-clientSteps.addPageListeners.push(addExternalIconTooltipPageListeners);
+clientSteps.getPageReferences.push(getTextWithTooltipReferences);
+clientSteps.addPageListeners.push(addTextWithTooltipPageListeners);
 
 // Datetimestamp tooltips ---------------------------------
 

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -503,26 +503,22 @@ a:not([href]):hover {
   display: inline-block;
 }
 
-.contribution.has-tooltip,
-.datetimestamp.has-tooltip {
+.text-with-tooltip {
   position: relative;
 }
 
-.contribution.has-tooltip > a,
-.datetimestamp.has-tooltip > time {
+.text-with-tooltip > :first-child {
   text-decoration: underline;
   text-decoration-style: dotted;
 }
 
-.datetimestamp.has-tooltip > time {
-  cursor: default;
+.text-with-tooltip > :first-child:hover,
+.text-with-tooltip > :first-child.has-visible-tooltip {
+  text-decoration-style: wavy !important;
 }
 
-.contribution.has-tooltip > a:hover,
-.contribution.has-tooltip > a.has-visible-tooltip,
-.datetimestamp.has-tooltip > time:hover,
-.datetimestamp.has-tooltip > time.has-visible-tooltip {
-  text-decoration-style: wavy !important;
+.text-with-tooltip.datetimestamp > :first-child {
+  cursor: default;
 }
 
 .tooltip {

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -525,32 +525,20 @@ a:not([href]):hover {
   text-decoration-style: wavy !important;
 }
 
-.icons-tooltip,
-.datetimestamp-tooltip {
+.tooltip {
   position: absolute;
   z-index: 3;
-  left: -34px;
+  left: -10px;
   top: calc(1em + 1px);
   display: none;
 }
 
-.icons-tooltip {
-  padding: 3px 6px 6px 6px;
-  left: -34px;
-}
-
-.datetimestamp-tooltip {
-  padding: 3px 4px 2px 2px;
-  left: -10px;
-}
-
-li:not(:first-child:last-child) .datetimestamp-tooltip,
-.offset-tooltips > :not(:first-child:last-child) .datetimestamp-tooltip {
+li:not(:first-child:last-child) .tooltip,
+.offset-tooltips > :not(:first-child:last-child) .tooltip {
   left: 14px;
 }
 
-.icons-tooltip-content,
-.datetimestamp-tooltip-content {
+.tooltip-content {
   display: block;
 
   background: var(--bg-black-color);
@@ -568,7 +556,17 @@ li:not(:first-child:last-child) .datetimestamp-tooltip,
     0 -2px 4px -2px var(--primary-color) inset;
 }
 
-.icons-tooltip-content {
+.icons-tooltip {
+  padding: 3px 6px 6px 6px;
+  left: -34px;
+}
+
+.datetimestamp-tooltip {
+  padding: 3px 4px 2px 2px;
+  left: -10px;
+}
+
+.icons-tooltip .tooltip-content {
   padding: 6px 2px 2px 2px;
 
   -webkit-user-select: none;
@@ -577,7 +575,7 @@ li:not(:first-child:last-child) .datetimestamp-tooltip,
   cursor: default;
 }
 
-.datetimestamp-tooltip-content {
+.datetimestamp-tooltip .tooltip-content {
   padding: 5px 6px;
   white-space: nowrap;
   font-size: 0.9em;

--- a/src/upd8.js
+++ b/src/upd8.js
@@ -82,7 +82,7 @@ import * as buildModes from './write/build-modes/index.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const CACHEBUST = 22;
+const CACHEBUST = 23;
 
 let COMMIT;
 try {

--- a/tap-snapshots/test/snapshot/generateAlbumReleaseInfo.js.test.cjs
+++ b/tap-snapshots/test/snapshot/generateAlbumReleaseInfo.js.test.cjs
@@ -7,10 +7,10 @@
 'use strict'
 exports[`test/snapshot/generateAlbumReleaseInfo.js > TAP > generateAlbumReleaseInfo (snapshot) > basic behavior 1`] = `
 <p>
-    By <span class="contribution nowrap"><a href="artist/toby-fox/">Toby Fox</a> (music probably)</span> and <span class="contribution has-tooltip nowrap"><a href="artist/tensei/">Tensei</a> (hot jams)<span class="icons tooltip icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://tenseimusic.bandcamp.com/">
-                    <svg><use href="static/icons.svg#icon-bandcamp"></use></svg>
-                    <span class="icon-text">tenseimusic</span>
-                </a></span></span></span>.
+    By <span class="contribution nowrap"><a href="artist/toby-fox/">Toby Fox</a> (music probably)</span> and <span class="contribution nowrap"><span class="text-with-tooltip"><a href="artist/tensei/">Tensei</a><span class="tooltip icons icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://tenseimusic.bandcamp.com/">
+                        <svg><use href="static/icons.svg#icon-bandcamp"></use></svg>
+                        <span class="icon-text">tenseimusic</span>
+                    </a></span></span></span> (hot jams)</span>.
     <br>
     Cover art by <a href="artist/hb/">Hanni Brosh</a>.
     <br>

--- a/tap-snapshots/test/snapshot/generateAlbumReleaseInfo.js.test.cjs
+++ b/tap-snapshots/test/snapshot/generateAlbumReleaseInfo.js.test.cjs
@@ -7,7 +7,7 @@
 'use strict'
 exports[`test/snapshot/generateAlbumReleaseInfo.js > TAP > generateAlbumReleaseInfo (snapshot) > basic behavior 1`] = `
 <p>
-    By <span class="contribution nowrap"><a href="artist/toby-fox/">Toby Fox</a> (music probably)</span> and <span class="contribution has-tooltip nowrap"><a href="artist/tensei/">Tensei</a> (hot jams)<span class="icons icons-tooltip" inert><span class="icons-tooltip-content"><a class="icon has-text" href="https://tenseimusic.bandcamp.com/">
+    By <span class="contribution nowrap"><a href="artist/toby-fox/">Toby Fox</a> (music probably)</span> and <span class="contribution has-tooltip nowrap"><a href="artist/tensei/">Tensei</a> (hot jams)<span class="icons tooltip icons-tooltip" inert><span class="tooltip-content"><a class="icon has-text" href="https://tenseimusic.bandcamp.com/">
                     <svg><use href="static/icons.svg#icon-bandcamp"></use></svg>
                     <span class="icon-text">tenseimusic</span>
                 </a></span></span></span>.

--- a/tap-snapshots/test/snapshot/generateAlbumReleaseInfo.js.test.cjs
+++ b/tap-snapshots/test/snapshot/generateAlbumReleaseInfo.js.test.cjs
@@ -7,7 +7,7 @@
 'use strict'
 exports[`test/snapshot/generateAlbumReleaseInfo.js > TAP > generateAlbumReleaseInfo (snapshot) > basic behavior 1`] = `
 <p>
-    By <span class="contribution nowrap"><a href="artist/toby-fox/">Toby Fox</a> (music probably)</span> and <span class="contribution has-tooltip nowrap"><a href="artist/tensei/">Tensei</a> (hot jams)<span class="icons tooltip icons-tooltip" inert><span class="tooltip-content"><a class="icon has-text" href="https://tenseimusic.bandcamp.com/">
+    By <span class="contribution nowrap"><a href="artist/toby-fox/">Toby Fox</a> (music probably)</span> and <span class="contribution has-tooltip nowrap"><a href="artist/tensei/">Tensei</a> (hot jams)<span class="icons tooltip icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://tenseimusic.bandcamp.com/">
                     <svg><use href="static/icons.svg#icon-bandcamp"></use></svg>
                     <span class="icon-text">tenseimusic</span>
                 </a></span></span></span>.

--- a/tap-snapshots/test/snapshot/linkContribution.js.test.cjs
+++ b/tap-snapshots/test/snapshot/linkContribution.js.test.cjs
@@ -30,31 +30,31 @@ exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) >
 `
 
 exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) > loads of links (tooltip) 1`] = `
-<span class="contribution has-tooltip"><a href="artist/lorem-ipsum-lover/">Lorem Ipsum Lover</a><span class="icons tooltip icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://loremipsum.io">
-                <svg><use href="static/icons.svg#icon-globe"></use></svg>
-                <span class="icon-text">loremipsum.io</span>
-            </a><a class="icon has-text" href="https://loremipsum.io/generator/">
-                <svg><use href="static/icons.svg#icon-globe"></use></svg>
-                <span class="icon-text">loremipsum.io</span>
-            </a><a class="icon has-text" href="https://loremipsum.io/#meaning">
-                <svg><use href="static/icons.svg#icon-globe"></use></svg>
-                <span class="icon-text">loremipsum.io</span>
-            </a><a class="icon has-text" href="https://loremipsum.io/#usage-and-examples">
-                <svg><use href="static/icons.svg#icon-globe"></use></svg>
-                <span class="icon-text">loremipsum.io</span>
-            </a><a class="icon has-text" href="https://loremipsum.io/#controversy">
-                <svg><use href="static/icons.svg#icon-globe"></use></svg>
-                <span class="icon-text">loremipsum.io</span>
-            </a><a class="icon has-text" href="https://loremipsum.io/#when-to-use-lorem-ipsum">
-                <svg><use href="static/icons.svg#icon-globe"></use></svg>
-                <span class="icon-text">loremipsum.io</span>
-            </a><a class="icon has-text" href="https://loremipsum.io/#lorem-ipsum-all-the-things">
-                <svg><use href="static/icons.svg#icon-globe"></use></svg>
-                <span class="icon-text">loremipsum.io</span>
-            </a><a class="icon has-text" href="https://loremipsum.io/#original-source">
-                <svg><use href="static/icons.svg#icon-globe"></use></svg>
-                <span class="icon-text">loremipsum.io</span>
-            </a></span></span></span>
+<span class="contribution"><span class="text-with-tooltip"><a href="artist/lorem-ipsum-lover/">Lorem Ipsum Lover</a><span class="tooltip icons icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://loremipsum.io">
+                    <svg><use href="static/icons.svg#icon-globe"></use></svg>
+                    <span class="icon-text">loremipsum.io</span>
+                </a><a class="icon has-text" href="https://loremipsum.io/generator/">
+                    <svg><use href="static/icons.svg#icon-globe"></use></svg>
+                    <span class="icon-text">loremipsum.io</span>
+                </a><a class="icon has-text" href="https://loremipsum.io/#meaning">
+                    <svg><use href="static/icons.svg#icon-globe"></use></svg>
+                    <span class="icon-text">loremipsum.io</span>
+                </a><a class="icon has-text" href="https://loremipsum.io/#usage-and-examples">
+                    <svg><use href="static/icons.svg#icon-globe"></use></svg>
+                    <span class="icon-text">loremipsum.io</span>
+                </a><a class="icon has-text" href="https://loremipsum.io/#controversy">
+                    <svg><use href="static/icons.svg#icon-globe"></use></svg>
+                    <span class="icon-text">loremipsum.io</span>
+                </a><a class="icon has-text" href="https://loremipsum.io/#when-to-use-lorem-ipsum">
+                    <svg><use href="static/icons.svg#icon-globe"></use></svg>
+                    <span class="icon-text">loremipsum.io</span>
+                </a><a class="icon has-text" href="https://loremipsum.io/#lorem-ipsum-all-the-things">
+                    <svg><use href="static/icons.svg#icon-globe"></use></svg>
+                    <span class="icon-text">loremipsum.io</span>
+                </a><a class="icon has-text" href="https://loremipsum.io/#original-source">
+                    <svg><use href="static/icons.svg#icon-globe"></use></svg>
+                    <span class="icon-text">loremipsum.io</span>
+                </a></span></span></span></span>
 `
 
 exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) > no accents 1`] = `
@@ -112,18 +112,18 @@ exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) >
 `
 
 exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) > only showIcons (tooltip) 1`] = `
-<span class="contribution has-tooltip"><a href="artist/clark-powell/">Clark Powell</a><span class="icons tooltip icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://soundcloud.com/plazmataz">
-                <svg><use href="static/icons.svg#icon-soundcloud"></use></svg>
-                <span class="icon-text">plazmataz</span>
-            </a></span></span></span>
+<span class="contribution"><span class="text-with-tooltip"><a href="artist/clark-powell/">Clark Powell</a><span class="tooltip icons icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://soundcloud.com/plazmataz">
+                    <svg><use href="static/icons.svg#icon-soundcloud"></use></svg>
+                    <span class="icon-text">plazmataz</span>
+                </a></span></span></span></span>
 <span class="contribution nowrap"><a href="artist/the-big-baddies/">Grounder &amp; Scratch</a> (Snooping)</span>
-<span class="contribution has-tooltip nowrap"><a href="artist/toby-fox/">Toby Fox</a> (Arrangement)<span class="icons tooltip icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://tobyfox.bandcamp.com/">
-                <svg><use href="static/icons.svg#icon-bandcamp"></use></svg>
-                <span class="icon-text">tobyfox</span>
-            </a><a class="icon has-text" href="https://toby.fox/">
-                <svg><use href="static/icons.svg#icon-globe"></use></svg>
-                <span class="icon-text">toby.fox</span>
-            </a></span></span></span>
+<span class="contribution nowrap"><span class="text-with-tooltip"><a href="artist/toby-fox/">Toby Fox</a><span class="tooltip icons icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://tobyfox.bandcamp.com/">
+                    <svg><use href="static/icons.svg#icon-bandcamp"></use></svg>
+                    <span class="icon-text">tobyfox</span>
+                </a><a class="icon has-text" href="https://toby.fox/">
+                    <svg><use href="static/icons.svg#icon-globe"></use></svg>
+                    <span class="icon-text">toby.fox</span>
+                </a></span></span></span> (Arrangement)</span>
 `
 
 exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) > showContribution & showIcons (inline) 1`] = `
@@ -148,16 +148,16 @@ exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) >
 `
 
 exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) > showContribution & showIcons (tooltip) 1`] = `
-<span class="contribution has-tooltip"><a href="artist/clark-powell/">Clark Powell</a><span class="icons tooltip icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://soundcloud.com/plazmataz">
-                <svg><use href="static/icons.svg#icon-soundcloud"></use></svg>
-                <span class="icon-text">plazmataz</span>
-            </a></span></span></span>
+<span class="contribution"><span class="text-with-tooltip"><a href="artist/clark-powell/">Clark Powell</a><span class="tooltip icons icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://soundcloud.com/plazmataz">
+                    <svg><use href="static/icons.svg#icon-soundcloud"></use></svg>
+                    <span class="icon-text">plazmataz</span>
+                </a></span></span></span></span>
 <span class="contribution nowrap"><a href="artist/the-big-baddies/">Grounder &amp; Scratch</a> (Snooping)</span>
-<span class="contribution has-tooltip nowrap"><a href="artist/toby-fox/">Toby Fox</a> (Arrangement)<span class="icons tooltip icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://tobyfox.bandcamp.com/">
-                <svg><use href="static/icons.svg#icon-bandcamp"></use></svg>
-                <span class="icon-text">tobyfox</span>
-            </a><a class="icon has-text" href="https://toby.fox/">
-                <svg><use href="static/icons.svg#icon-globe"></use></svg>
-                <span class="icon-text">toby.fox</span>
-            </a></span></span></span>
+<span class="contribution nowrap"><span class="text-with-tooltip"><a href="artist/toby-fox/">Toby Fox</a><span class="tooltip icons icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://tobyfox.bandcamp.com/">
+                    <svg><use href="static/icons.svg#icon-bandcamp"></use></svg>
+                    <span class="icon-text">tobyfox</span>
+                </a><a class="icon has-text" href="https://toby.fox/">
+                    <svg><use href="static/icons.svg#icon-globe"></use></svg>
+                    <span class="icon-text">toby.fox</span>
+                </a></span></span></span> (Arrangement)</span>
 `

--- a/tap-snapshots/test/snapshot/linkContribution.js.test.cjs
+++ b/tap-snapshots/test/snapshot/linkContribution.js.test.cjs
@@ -30,7 +30,7 @@ exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) >
 `
 
 exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) > loads of links (tooltip) 1`] = `
-<span class="contribution has-tooltip"><a href="artist/lorem-ipsum-lover/">Lorem Ipsum Lover</a><span class="icons icons-tooltip" inert><span class="icons-tooltip-content"><a class="icon has-text" href="https://loremipsum.io">
+<span class="contribution has-tooltip"><a href="artist/lorem-ipsum-lover/">Lorem Ipsum Lover</a><span class="icons tooltip icons-tooltip" inert><span class="tooltip-content"><a class="icon has-text" href="https://loremipsum.io">
                 <svg><use href="static/icons.svg#icon-globe"></use></svg>
                 <span class="icon-text">loremipsum.io</span>
             </a><a class="icon has-text" href="https://loremipsum.io/generator/">
@@ -112,12 +112,12 @@ exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) >
 `
 
 exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) > only showIcons (tooltip) 1`] = `
-<span class="contribution has-tooltip"><a href="artist/clark-powell/">Clark Powell</a><span class="icons icons-tooltip" inert><span class="icons-tooltip-content"><a class="icon has-text" href="https://soundcloud.com/plazmataz">
+<span class="contribution has-tooltip"><a href="artist/clark-powell/">Clark Powell</a><span class="icons tooltip icons-tooltip" inert><span class="tooltip-content"><a class="icon has-text" href="https://soundcloud.com/plazmataz">
                 <svg><use href="static/icons.svg#icon-soundcloud"></use></svg>
                 <span class="icon-text">plazmataz</span>
             </a></span></span></span>
 <span class="contribution nowrap"><a href="artist/the-big-baddies/">Grounder &amp; Scratch</a> (Snooping)</span>
-<span class="contribution has-tooltip nowrap"><a href="artist/toby-fox/">Toby Fox</a> (Arrangement)<span class="icons icons-tooltip" inert><span class="icons-tooltip-content"><a class="icon has-text" href="https://tobyfox.bandcamp.com/">
+<span class="contribution has-tooltip nowrap"><a href="artist/toby-fox/">Toby Fox</a> (Arrangement)<span class="icons tooltip icons-tooltip" inert><span class="tooltip-content"><a class="icon has-text" href="https://tobyfox.bandcamp.com/">
                 <svg><use href="static/icons.svg#icon-bandcamp"></use></svg>
                 <span class="icon-text">tobyfox</span>
             </a><a class="icon has-text" href="https://toby.fox/">
@@ -148,12 +148,12 @@ exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) >
 `
 
 exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) > showContribution & showIcons (tooltip) 1`] = `
-<span class="contribution has-tooltip"><a href="artist/clark-powell/">Clark Powell</a><span class="icons icons-tooltip" inert><span class="icons-tooltip-content"><a class="icon has-text" href="https://soundcloud.com/plazmataz">
+<span class="contribution has-tooltip"><a href="artist/clark-powell/">Clark Powell</a><span class="icons tooltip icons-tooltip" inert><span class="tooltip-content"><a class="icon has-text" href="https://soundcloud.com/plazmataz">
                 <svg><use href="static/icons.svg#icon-soundcloud"></use></svg>
                 <span class="icon-text">plazmataz</span>
             </a></span></span></span>
 <span class="contribution nowrap"><a href="artist/the-big-baddies/">Grounder &amp; Scratch</a> (Snooping)</span>
-<span class="contribution has-tooltip nowrap"><a href="artist/toby-fox/">Toby Fox</a> (Arrangement)<span class="icons icons-tooltip" inert><span class="icons-tooltip-content"><a class="icon has-text" href="https://tobyfox.bandcamp.com/">
+<span class="contribution has-tooltip nowrap"><a href="artist/toby-fox/">Toby Fox</a> (Arrangement)<span class="icons tooltip icons-tooltip" inert><span class="tooltip-content"><a class="icon has-text" href="https://tobyfox.bandcamp.com/">
                 <svg><use href="static/icons.svg#icon-bandcamp"></use></svg>
                 <span class="icon-text">tobyfox</span>
             </a><a class="icon has-text" href="https://toby.fox/">

--- a/tap-snapshots/test/snapshot/linkContribution.js.test.cjs
+++ b/tap-snapshots/test/snapshot/linkContribution.js.test.cjs
@@ -30,7 +30,7 @@ exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) >
 `
 
 exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) > loads of links (tooltip) 1`] = `
-<span class="contribution has-tooltip"><a href="artist/lorem-ipsum-lover/">Lorem Ipsum Lover</a><span class="icons tooltip icons-tooltip" inert><span class="tooltip-content"><a class="icon has-text" href="https://loremipsum.io">
+<span class="contribution has-tooltip"><a href="artist/lorem-ipsum-lover/">Lorem Ipsum Lover</a><span class="icons tooltip icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://loremipsum.io">
                 <svg><use href="static/icons.svg#icon-globe"></use></svg>
                 <span class="icon-text">loremipsum.io</span>
             </a><a class="icon has-text" href="https://loremipsum.io/generator/">
@@ -112,12 +112,12 @@ exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) >
 `
 
 exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) > only showIcons (tooltip) 1`] = `
-<span class="contribution has-tooltip"><a href="artist/clark-powell/">Clark Powell</a><span class="icons tooltip icons-tooltip" inert><span class="tooltip-content"><a class="icon has-text" href="https://soundcloud.com/plazmataz">
+<span class="contribution has-tooltip"><a href="artist/clark-powell/">Clark Powell</a><span class="icons tooltip icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://soundcloud.com/plazmataz">
                 <svg><use href="static/icons.svg#icon-soundcloud"></use></svg>
                 <span class="icon-text">plazmataz</span>
             </a></span></span></span>
 <span class="contribution nowrap"><a href="artist/the-big-baddies/">Grounder &amp; Scratch</a> (Snooping)</span>
-<span class="contribution has-tooltip nowrap"><a href="artist/toby-fox/">Toby Fox</a> (Arrangement)<span class="icons tooltip icons-tooltip" inert><span class="tooltip-content"><a class="icon has-text" href="https://tobyfox.bandcamp.com/">
+<span class="contribution has-tooltip nowrap"><a href="artist/toby-fox/">Toby Fox</a> (Arrangement)<span class="icons tooltip icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://tobyfox.bandcamp.com/">
                 <svg><use href="static/icons.svg#icon-bandcamp"></use></svg>
                 <span class="icon-text">tobyfox</span>
             </a><a class="icon has-text" href="https://toby.fox/">
@@ -148,12 +148,12 @@ exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) >
 `
 
 exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) > showContribution & showIcons (tooltip) 1`] = `
-<span class="contribution has-tooltip"><a href="artist/clark-powell/">Clark Powell</a><span class="icons tooltip icons-tooltip" inert><span class="tooltip-content"><a class="icon has-text" href="https://soundcloud.com/plazmataz">
+<span class="contribution has-tooltip"><a href="artist/clark-powell/">Clark Powell</a><span class="icons tooltip icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://soundcloud.com/plazmataz">
                 <svg><use href="static/icons.svg#icon-soundcloud"></use></svg>
                 <span class="icon-text">plazmataz</span>
             </a></span></span></span>
 <span class="contribution nowrap"><a href="artist/the-big-baddies/">Grounder &amp; Scratch</a> (Snooping)</span>
-<span class="contribution has-tooltip nowrap"><a href="artist/toby-fox/">Toby Fox</a> (Arrangement)<span class="icons tooltip icons-tooltip" inert><span class="tooltip-content"><a class="icon has-text" href="https://tobyfox.bandcamp.com/">
+<span class="contribution has-tooltip nowrap"><a href="artist/toby-fox/">Toby Fox</a> (Arrangement)<span class="icons tooltip icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://tobyfox.bandcamp.com/">
                 <svg><use href="static/icons.svg#icon-bandcamp"></use></svg>
                 <span class="icon-text">tobyfox</span>
             </a><a class="icon has-text" href="https://toby.fox/">


### PR DESCRIPTION
This tweaks the main tooltip containers to have a consistent class, `tooltip`, as well as the more particular existing class, `datetimestamp-tooltip` or `icons-tooltip`; the two `-tooltip-content` classes have also been merged into one. And it sticks that layout into a new component, `generateTooltip`, which is generally more portable and obviously can be updated to affect all tooltips at once.

This makes `icons-tooltip` get horizontally offset the way any tooltip is supposed to when placed inside a list (with at least two items), and obviously makes it easier to bring that behavior into new tooltips as well.

It also refactors a few functions to work with a new `generateTextWithTooltip` component; the greatest impact is on `linkContribution`, though it doesn't actually change any content apart from adapting the new class layouts - and moving the accent after the tooltip. (Which doesn't have a visual effect, but puts the tooltip closer to where it's displayed!)
