### PR TITLE
Various fixes for handling art tags on things without cover art

### DIFF
--- a/src/data/things/album.js
+++ b/src/data/things/album.js
@@ -113,11 +113,18 @@ export class Album extends Thing {
       data: 'groupData',
     }),
 
-    artTags: referenceList({
-      class: input.value(ArtTag),
-      find: input.value(find.artTag),
-      data: 'artTagData',
-    }),
+    artTags: [
+      exitWithoutContribs({
+        contribs: 'coverArtistContribs',
+        value: input.value([]),
+      }),
+
+      referenceList({
+        class: input.value(ArtTag),
+        find: input.value(find.artTag),
+        data: 'artTagData',
+      }),
+    ],
 
     // Update only
 

--- a/src/data/things/track.js
+++ b/src/data/things/track.js
@@ -255,11 +255,17 @@ export class Track extends Thing {
       }),
     ],
 
-    artTags: referenceList({
-      class: input.value(ArtTag),
-      find: input.value(find.artTag),
-      data: 'artTagData',
-    }),
+    artTags: [
+      exitWithoutUniqueCoverArt({
+        value: input.value([]),
+      }),
+
+      referenceList({
+        class: input.value(ArtTag),
+        find: input.value(find.artTag),
+        data: 'artTagData',
+      }),
+    ],
 
     // Update only
 

--- a/src/data/yaml.js
+++ b/src/data/yaml.js
@@ -1902,23 +1902,31 @@ export function filterReferenceErrors(wikiData) {
 
             let newPropertyValue = value;
 
-            if (findFnKey === '_commentary') {
-              // Commentary doesn't write a property value, so no need to set.
-              filter(
-                value, {message: errorMessage},
-                decorateErrorWithIndex(refs =>
-                  (refs.length === 1
-                    ? suppress(findFn)(refs[0])
-                    : filterAggregate(
-                        refs, {message: `Errors in entry's artist references`},
-                        decorateErrorWithIndex(suppress(findFn)))
-                          .aggregate
-                          .close())));
-            } else if (Array.isArray(value)) {
-              newPropertyValue = filter(
-                value, {message: errorMessage},
-                decorateErrorWithIndex(suppress(findFn)));
-            } else {
+            determineNewPropertyValue: {
+              if (findFnKey === '_commentary') {
+                filter(
+                  value, {message: errorMessage},
+                  decorateErrorWithIndex(refs =>
+                    (refs.length === 1
+                      ? suppress(findFn)(refs[0])
+                      : filterAggregate(
+                          refs, {message: `Errors in entry's artist references`},
+                          decorateErrorWithIndex(suppress(findFn)))
+                            .aggregate
+                            .close())));
+
+                // Commentary doesn't write a property value, so no need to set
+                // anything on `newPropertyValue`.
+                break determineNewPropertyValue;
+              }
+
+              if (Array.isArray(value)) {
+                newPropertyValue = filter(
+                  value, {message: errorMessage},
+                  decorateErrorWithIndex(suppress(findFn)));
+                break determineNewPropertyValue;
+              }
+
               nest({message: errorMessage},
                 suppress(({call}) => {
                   try {

--- a/test/unit/data/things/album.js
+++ b/test/unit/data/things/album.js
@@ -5,9 +5,17 @@ import thingConstructors from '#things';
 
 const {
   Album,
+  ArtTag,
   Artist,
   Track,
 } = thingConstructors;
+
+function stubArtTag(tagName = `Test Art Tag`) {
+  const tag = new ArtTag();
+  tag.name = tagName;
+
+  return tag;
+}
 
 function stubArtistAndContribs() {
   const artist = new Artist();
@@ -25,6 +33,34 @@ function stubTrack(directory = 'foo') {
 
   return track;
 }
+
+t.test(`Album.artTags`, t => {
+  t.plan(3);
+
+  const {artist, contribs} = stubArtistAndContribs();
+  const album = new Album();
+  const tag1 = stubArtTag(`Tag 1`);
+  const tag2 = stubArtTag(`Tag 2`);
+
+  const {XXX_decacheWikiData} = linkAndBindWikiData({
+    albumData: [album],
+    artistData: [artist],
+    artTagData: [tag1, tag2],
+  });
+
+  t.same(album.artTags, [],
+    `artTags #1: defaults to empty array`);
+
+  album.artTags = [`Tag 1`, `Tag 2`];
+
+  t.same(album.artTags, [],
+    `artTags #2: is empty if album doesn't have cover artists`);
+
+  album.coverArtistContribs = contribs;
+
+  t.same(album.artTags, [tag1, tag2],
+    `artTags #3: resolves if album has cover artists`);
+});
 
 t.test(`Album.bannerDimensions`, t => {
   t.plan(4);


### PR DESCRIPTION
This PR bundles a bunch of related fixes:

* Prevents art tags from being returned on tracks without unique cover art, and on albums without cover art.
* Adds test cases to make sure the above is working! (This also checks tracks, in data, don't inherit art tags from albums.)
* Reports instances of `Art Tags` being specified on albums or tracks which don't have any cover art.
  * This is implemented somewhat jankily with custom handling in reference validation, which is unfortunate — it's pretty similar behavior to `fieldCombinationErrors` (on `makeProcessDocument`), but that doesn't quite suffice, because tracks might inherit the state of having cover art from the album document, which `makeProcessDocument` doesn't have access to at the moment.
  * Minor refactoring in `filterReferenceErrors` to make adding new custom ways of determining `newPropertyValue` cleaner.

Although art tags weren't directly accessed for display on track pages (if the album cover was being displayed instead), this was causing an error on the art tag gallery, which was counting tracks without cover art at all as featuring the tag! (And then expecting values on null properties, i.e. `coverArtFileExtension`, which was a throw.)