### PR TITLE
Image hierarchy cleanup! Again...

### DIFF
--- a/src/content/dependencies/generateCoverArtwork.js
+++ b/src/content/dependencies/generateCoverArtwork.js
@@ -80,11 +80,13 @@ export default {
           alt: slots.alt,
           color: slots.color,
           thumb: 'medium',
-          class: 'commentary-art',
           reveal: true,
           link: true,
           square: true,
           lazy: true,
+
+          attributes:
+            {class: 'commentary-art'},
         });
 
       default:

--- a/src/content/dependencies/generateCoverArtwork.js
+++ b/src/content/dependencies/generateCoverArtwork.js
@@ -50,7 +50,6 @@ export default {
             alt: slots.alt,
             color: slots.color,
             thumb: 'medium',
-            id: 'cover-art',
             reveal: true,
             link: true,
             square: true,

--- a/src/content/dependencies/image.js
+++ b/src/content/dependencies/image.js
@@ -317,13 +317,10 @@ export default {
 
       wrapped =
         html.tag('div', {class: 'image-outer-area'},
-          wrapped);
+          willSquare &&
+            {class: 'square-content'},
 
-      if (willSquare) {
-        wrapped =
-          html.tag('div', {class: 'square-content'},
-            wrapped);
-      }
+          wrapped);
 
       wrapped =
         html.tag('div', {class: 'image-container'},

--- a/src/content/dependencies/image.js
+++ b/src/content/dependencies/image.js
@@ -59,7 +59,6 @@ export default {
     lazy: {type: 'boolean', default: false},
     square: {type: 'boolean', default: false},
 
-    id: {type: 'string'},
     class: {type: 'string'},
     alt: {type: 'string'},
     width: {type: 'number'},
@@ -143,14 +142,6 @@ export default {
     ]);
 
     const containerAttributes = html.attributes();
-
-    if (slots.id) {
-      if (willLink) {
-        linkAttributes.set('id', slots.id);
-      } else {
-        imgAttributes.set('id', slots.id);
-      }
-    }
 
     if (slots.class) {
       if (willLink) {

--- a/src/content/dependencies/image.js
+++ b/src/content/dependencies/image.js
@@ -136,12 +136,17 @@ export default {
       slots.height && {height: slots.height},
     ]);
 
-    if (!originalSrc || isMissingImageFile) {
-      return prepare(
-        html.tag('div', {class: 'image-text-area'},
-          (html.isBlank(slots.missingSourceContent)
-            ? language.$('misc.missingImage')
-            : slots.missingSourceContent)));
+    const isPlaceholder =
+      !originalSrc || isMissingImageFile;
+
+    if (isPlaceholder) {
+      return (
+        prepare(
+          html.tag('div', {class: 'image-text-area'},
+            (html.isBlank(slots.missingSourceContent)
+              ? language.$('misc.missingImage')
+              : slots.missingSourceContent)),
+          'visible'));
     }
 
     let reveal = null;
@@ -314,15 +319,6 @@ export default {
         html.tag('div', {class: 'image-outer-area'},
           wrapped);
 
-      if (willReveal) {
-        wrapped =
-          html.tag('div', {class: 'reveal'},
-            images.revealStatic &&
-              {class: 'has-reveal-thumbnail'},
-
-            wrapped);
-      }
-
       if (willSquare) {
         wrapped =
           html.tag('div', {class: 'square-content'},
@@ -331,17 +327,24 @@ export default {
 
       wrapped =
         html.tag('div', {class: 'image-container'},
-          willLink &&
-            {class: 'has-link'},
-
           willSquare &&
             {class: 'square'},
 
           typeof slots.link === 'string' &&
             {class: 'no-image-preview'},
 
-          !originalSrc &&
-            {class: 'placeholder-image'},
+          (isPlaceholder
+            ? {class: 'placeholder-image'}
+            : [
+                willLink &&
+                  {class: 'has-link'},
+
+                willReveal &&
+                  {class: 'reveal'},
+
+                revealSrc &&
+                  {class: 'has-reveal-thumbnail'},
+              ]),
 
           visibility === 'hidden' &&
             {class: 'js-hide'},

--- a/src/content/dependencies/image.js
+++ b/src/content/dependencies/image.js
@@ -59,10 +59,14 @@ export default {
     lazy: {type: 'boolean', default: false},
     square: {type: 'boolean', default: false},
 
-    class: {type: 'string'},
     alt: {type: 'string'},
     width: {type: 'number'},
     height: {type: 'number'},
+
+    attributes: {
+      type: 'attributes',
+      mutable: false,
+    },
 
     missingSourceContent: {
       type: 'html',
@@ -116,9 +120,6 @@ export default {
       !isMissingImageFile &&
       (typeof slots.link === 'string' || slots.link);
 
-    const customLink =
-      typeof slots.link === 'string';
-
     const willReveal =
       slots.reveal &&
       originalSrc &&
@@ -134,36 +135,6 @@ export default {
       slots.width && {width: slots.width},
       slots.height && {height: slots.height},
     ]);
-
-    const linkAttributes = html.attributes([
-      (customLink
-        ? {href: slots.link}
-        : {href: originalSrc}),
-    ]);
-
-    const containerAttributes = html.attributes();
-
-    if (slots.class) {
-      if (willLink) {
-        linkAttributes.set('class', slots.class);
-      } else {
-        imgAttributes.set('class', slots.class);
-      }
-    }
-
-    if (slots.color) {
-      const colorStyle =
-        relations.colorStyle.slots({
-          color: slots.color,
-          context: 'image-box',
-        });
-
-      if (willLink) {
-        linkAttributes.add(colorStyle);
-      } else {
-        containerAttributes.add(colorStyle);
-      }
-    }
 
     if (!originalSrc || isMissingImageFile) {
       return prepare(
@@ -332,24 +303,15 @@ export default {
       if (willLink) {
         wrapped =
           html.tag('a', {class: 'image-link'},
-            linkAttributes,
+            (typeof slots.link === 'string'
+              ? {href: slots.link}
+              : {href: originalSrc}),
 
             wrapped);
       }
 
       wrapped =
-        html.tag('div', {class: 'image-container'},
-          containerAttributes,
-
-          willLink &&
-            {class: 'has-link'},
-
-          customLink &&
-            {class: 'no-image-preview'},
-
-          !originalSrc &&
-            {class: 'placeholder-image'},
-
+        html.tag('div', {class: 'image-outer-area'},
           wrapped);
 
       if (willReveal) {
@@ -363,14 +325,36 @@ export default {
 
       if (willSquare) {
         wrapped =
-          html.tag('div', {class: 'square'},
-            visibility === 'hidden' &&
-            !willLink &&
-              {class: 'js-hide'},
-
-            html.tag('div', {class: 'square-content'},
-              wrapped));
+          html.tag('div', {class: 'square-content'},
+            wrapped);
       }
+
+      wrapped =
+        html.tag('div', {class: 'image-container'},
+          willLink &&
+            {class: 'has-link'},
+
+          willSquare &&
+            {class: 'square'},
+
+          typeof slots.link === 'string' &&
+            {class: 'no-image-preview'},
+
+          !originalSrc &&
+            {class: 'placeholder-image'},
+
+          visibility === 'hidden' &&
+            {class: 'js-hide'},
+
+          slots.color &&
+            relations.colorStyle.slots({
+              color: slots.color,
+              context: 'image-box',
+            }),
+
+          slots.attributes,
+
+          wrapped);
 
       return wrapped;
     }

--- a/src/content/dependencies/transformContent.js
+++ b/src/content/dependencies/transformContent.js
@@ -388,11 +388,16 @@ export default {
                 html.tag('div', {class: 'content-image'},
                   image.slots({
                     src,
+
                     link: link ?? true,
                     width: width ?? null,
                     height: height ?? null,
                     thumb: slots.thumb,
-                    class: pixelate ? 'pixelate' : null,
+
+                    attributes:
+                      (pixelate
+                        ? {class: 'pixelate'}
+                        : null),
                   })),
             };
           }

--- a/src/static/client3.js
+++ b/src/static/client3.js
@@ -205,9 +205,7 @@ function getScriptedLinkReferences() {
     document.querySelectorAll('[data-random]');
 
   scriptedLinkInfo.revealLinks =
-    document.querySelectorAll(
-      '.reveal .image-container > .image-link, ' +
-      '.reveal .image-container > .image-inner-area');
+    document.querySelectorAll('.reveal .image-outer-area > *');
 
   scriptedLinkInfo.revealContainers =
     Array.from(scriptedLinkInfo.revealLinks)

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -3,6 +3,32 @@
  * no need to re-run upd8.js when tweaking values here. Handy!
  */
 
+/* Squares */
+
+/* This styling is kind of awkwardly placed at the very top. Sorry!
+ * We need to rework what order sets of styles get applied in to be
+ * much more explicit (so that overriding isn't a headache), and
+ * hopefully that can be done through @imports, but it'll take some
+ * reworking and cleaning up.
+ */
+
+.square {
+  position: relative;
+  width: 100%;
+}
+
+.square::after {
+  content: "";
+  display: block;
+  padding-bottom: 100%;
+}
+
+.square-content {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+}
+
 /* Layout - Common */
 
 body {
@@ -1061,7 +1087,6 @@ h1 a[href="#additional-names-box"]:hover {
   box-sizing: border-box;
   position: relative;
   height: 100%;
-  padding: 5px;
   overflow: hidden;
 
   background-color: var(--dim-color);
@@ -1092,6 +1117,13 @@ h1 a[href="#additional-names-box"]:hover {
   color: var(--primary-color);
   font-style: oblique;
   text-shadow: 0 2px 5px rgba(0, 0, 0, 0.75);
+}
+
+.image-outer-area {
+  width: 100%;
+  height: 100%;
+  padding: 5px;
+  box-sizing: border-box;
 }
 
 .image-link {
@@ -1135,7 +1167,7 @@ img {
     6px -6px 2px -4px white inset;
 }
 
-img.pixelate {
+img.pixelate, .pixelate img {
   image-rendering: crisp-edges;
 }
 
@@ -1210,8 +1242,7 @@ img.pixelate {
   display: none;
 }
 
-.reveal:not(.revealed) .image-container > .image-link,
-.reveal:not(.revealed) .image-container > .image-inner-area {
+.reveal:not(.revealed) .image-outer-area > * {
   box-sizing: border-box;
   border: 1px dotted var(--primary-color);
   border-radius: 6px;
@@ -1222,19 +1253,16 @@ img.pixelate {
   background: var(--deep-color);
 }
 
-.reveal:not(.revealed) .image-container > .image-link:hover,
-.reveal:not(.revealed) .image-container > .image-inner-area:hover {
+.reveal:not(.revealed) .image-outer-area > *:hover {
   border-style: solid;
 }
 
-.reveal:not(.revealed) .image-container > .image-link:hover .image,
-.reveal:not(.revealed) .image-container > .image-inner-area:hover .image {
+.reveal:not(.revealed) .image-outer-area > *:hover .image {
   filter: blur(20px) brightness(0.6);
   opacity: 0.6;
 }
 
-.reveal:not(.revealed) .image-container > .image-link:hover .reveal-interaction,
-.reveal:not(.revealed) .image-container > .image-inner-area:hover .reveal-interaction {
+.reveal:not(.revealed) .image-outer-area > *:hover .reveal-interaction {
   text-decoration-style: solid;
 }
 
@@ -1270,6 +1298,10 @@ img.pixelate {
   border-radius: 2px;
   padding: 5px;
   margin: 10px;
+}
+
+.grid-item .image-container {
+  width: 100%;
 }
 
 .grid-item .image-inner-area {
@@ -1474,6 +1506,9 @@ html[data-url-key="localized.home"] .carousel-container {
 
 .carousel-item .image-container {
   border: none;
+}
+
+.carousel-item .image-outer-area {
   padding: 0;
 }
 
@@ -1488,25 +1523,6 @@ html[data-url-key="localized.home"] .carousel-container {
 .carousel-item:hover {
   filter: brightness(1);
   background: var(--dim-color);
-}
-
-/* Squares */
-
-.square {
-  position: relative;
-  width: 100%;
-}
-
-.square::after {
-  content: "";
-  display: block;
-  padding-bottom: 100%;
-}
-
-.square-content {
-  position: absolute;
-  width: 100%;
-  height: 100%;
 }
 
 /* Info card */
@@ -1766,13 +1782,17 @@ main.long-content .content-sticky-heading-container .content-sticky-subheading-r
 
 .content-sticky-heading-cover .image-container {
   border-width: 1px;
-  padding: 3px;
   border-radius: 1.25px;
   box-shadow: none;
 }
 
+.content-sticky-heading-container .image-outer-area {
+  padding: 3px;
+}
+
 .content-sticky-heading-container .image-inner-area {
   border-radius: 1.75px;
+  overflow: hidden;
 }
 
 .content-sticky-heading-cover .image {

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -1171,12 +1171,6 @@ img.pixelate, .pixelate img {
   image-rendering: crisp-edges;
 }
 
-.reveal {
-  position: relative;
-  width: 100%;
-  height: 100%;
-}
-
 .reveal-text-container {
   position: absolute;
   top: 15px;

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -659,7 +659,7 @@ p .current {
   border-top-color: var(--deep-color);
 }
 
-#cover-art .image {
+#cover-art-container .image {
   display: block;
   width: 100%;
   height: 100%;

--- a/tap-snapshots/test/snapshot/generateAlbumCoverArtwork.js.test.cjs
+++ b/tap-snapshots/test/snapshot/generateAlbumCoverArtwork.js.test.cjs
@@ -15,7 +15,7 @@ exports[`test/snapshot/generateAlbumCoverArtwork.js > TAP > generateAlbumCoverAr
      { name: 'creepy crawlies', isContentWarning: true }
    ]
  ]
- slots: { path: [ 'media.albumCover', 'bee-forus-seatbelt-safebee', 'png' ], color: '#f28514', thumb: 'medium', id: 'cover-art', reveal: true, link: true, square: true }]
+ slots: { path: [ 'media.albumCover', 'bee-forus-seatbelt-safebee', 'png' ], color: '#f28514', thumb: 'medium', reveal: true, link: true, square: true }]
 <ul class="image-details">
     <li><a href="tag/damara/">Damara</a></li>
     <li><a href="tag/cronus/">Cronus</a></li>

--- a/tap-snapshots/test/snapshot/generateCoverArtwork.js.test.cjs
+++ b/tap-snapshots/test/snapshot/generateCoverArtwork.js.test.cjs
@@ -15,7 +15,7 @@ exports[`test/snapshot/generateCoverArtwork.js > TAP > generateCoverArtwork (sna
      { name: 'creepy crawlies', isContentWarning: true }
    ]
  ]
- slots: { path: [ 'media.albumCover', 'bee-forus-seatbelt-safebee', 'png' ], thumb: 'medium', id: 'cover-art', reveal: true, link: true, square: true }]
+ slots: { path: [ 'media.albumCover', 'bee-forus-seatbelt-safebee', 'png' ], thumb: 'medium', reveal: true, link: true, square: true }]
 <ul class="image-details">
     <li><a href="tag/damara/">Damara</a></li>
     <li><a href="tag/cronus/">Cronus</a></li>

--- a/tap-snapshots/test/snapshot/generateTrackCoverArtwork.js.test.cjs
+++ b/tap-snapshots/test/snapshot/generateTrackCoverArtwork.js.test.cjs
@@ -15,7 +15,7 @@ exports[`test/snapshot/generateTrackCoverArtwork.js > TAP > generateTrackCoverAr
      { name: 'creepy crawlies', isContentWarning: true }
    ]
  ]
- slots: { path: [ 'media.albumCover', 'bee-forus-seatbelt-safebee', 'png' ], color: '#abcdef', thumb: 'medium', id: 'cover-art', reveal: true, link: true, square: true }]
+ slots: { path: [ 'media.albumCover', 'bee-forus-seatbelt-safebee', 'png' ], color: '#abcdef', thumb: 'medium', reveal: true, link: true, square: true }]
 <ul class="image-details">
     <li><a href="tag/damara/">Damara</a></li>
     <li><a href="tag/cronus/">Cronus</a></li>
@@ -26,7 +26,7 @@ exports[`test/snapshot/generateTrackCoverArtwork.js > TAP > generateTrackCoverAr
 exports[`test/snapshot/generateTrackCoverArtwork.js > TAP > generateTrackCoverArtwork (snapshot) > display: primary - unique art 1`] = `
 [mocked: image
  args: [ [ { name: 'Bees', directory: 'bees', isContentWarning: false } ] ]
- slots: { path: [ 'media.trackCover', 'bee-forus-seatbelt-safebee', 'beesmp3', 'jpg' ], color: '#f28514', thumb: 'medium', id: 'cover-art', reveal: true, link: true, square: true }]
+ slots: { path: [ 'media.trackCover', 'bee-forus-seatbelt-safebee', 'beesmp3', 'jpg' ], color: '#f28514', thumb: 'medium', reveal: true, link: true, square: true }]
 <ul class="image-details"><li><a href="tag/bees/">Bees</a></li></ul>
 `
 

--- a/tap-snapshots/test/snapshot/image.js.test.cjs
+++ b/tap-snapshots/test/snapshot/image.js.test.cjs
@@ -6,21 +6,19 @@
  */
 'use strict'
 exports[`test/snapshot/image.js > TAP > image (snapshot) > content warnings via tags 1`] = `
-<div class="image-container">
-    <div class="reveal">
-        <div class="image-outer-area">
-            <div class="image-inner-area">
-                <img class="image" src="media/album-art/beyond-canon/cover.png">
-                <span class="reveal-text-container">
-                    <span class="reveal-text">
-                        <img class="reveal-symbol" src="static/warning.svg?413">
-                        <br>
-                        <span class="reveal-warnings">too cool for school</span>
-                        <br>
-                        <span class="reveal-interaction">click to show</span>
-                    </span>
+<div class="image-container reveal">
+    <div class="image-outer-area">
+        <div class="image-inner-area">
+            <img class="image" src="media/album-art/beyond-canon/cover.png">
+            <span class="reveal-text-container">
+                <span class="reveal-text">
+                    <img class="reveal-symbol" src="static/warning.svg?413">
+                    <br>
+                    <span class="reveal-warnings">too cool for school</span>
+                    <br>
+                    <span class="reveal-interaction">click to show</span>
                 </span>
-            </div>
+            </span>
         </div>
     </div>
 </div>
@@ -36,11 +34,11 @@ exports[`test/snapshot/image.js > TAP > image (snapshot) > link with file size 1
 `
 
 exports[`test/snapshot/image.js > TAP > image (snapshot) > missing image path 1`] = `
-<div class="image-container"><div class="image-outer-area"><div class="image-inner-area"><div class="image-text-area">(This image file is missing)</div></div></div></div>
+<div class="image-container placeholder-image"><div class="image-outer-area"><div class="image-inner-area"><div class="image-text-area">(This image file is missing)</div></div></div></div>
 `
 
 exports[`test/snapshot/image.js > TAP > image (snapshot) > missing image path w/ missingSourceContent 1`] = `
-<div class="image-container"><div class="image-outer-area"><div class="image-inner-area"><div class="image-text-area">Cover's missing, whoops</div></div></div></div>
+<div class="image-container placeholder-image"><div class="image-outer-area"><div class="image-inner-area"><div class="image-text-area">Cover's missing, whoops</div></div></div></div>
 `
 
 exports[`test/snapshot/image.js > TAP > image (snapshot) > source missing 1`] = `

--- a/tap-snapshots/test/snapshot/image.js.test.cjs
+++ b/tap-snapshots/test/snapshot/image.js.test.cjs
@@ -25,8 +25,8 @@ exports[`test/snapshot/image.js > TAP > image (snapshot) > content warnings via 
 `
 
 exports[`test/snapshot/image.js > TAP > image (snapshot) > lazy with square 1`] = `
-<noscript><div class="image-container square"><div class="square-content"><div class="image-outer-area"><div class="image-inner-area"><img class="image" src="foobar"></div></div></div></div></noscript>
-<div class="image-container square js-hide"><div class="square-content"><div class="image-outer-area"><div class="image-inner-area"><img class="image lazy" data-original="foobar"></div></div></div></div>
+<noscript><div class="image-container square"><div class="image-outer-area square-content"><div class="image-inner-area"><img class="image" src="foobar"></div></div></div></noscript>
+<div class="image-container square js-hide"><div class="image-outer-area square-content"><div class="image-inner-area"><img class="image lazy" data-original="foobar"></div></div></div>
 `
 
 exports[`test/snapshot/image.js > TAP > image (snapshot) > link with file size 1`] = `
@@ -54,7 +54,7 @@ exports[`test/snapshot/image.js > TAP > image (snapshot) > source via src 1`] = 
 `
 
 exports[`test/snapshot/image.js > TAP > image (snapshot) > square 1`] = `
-<div class="image-container square"><div class="square-content"><div class="image-outer-area"><div class="image-inner-area"><img class="image" src="foobar"></div></div></div></div>
+<div class="image-container square"><div class="image-outer-area square-content"><div class="image-inner-area"><img class="image" src="foobar"></div></div></div>
 `
 
 exports[`test/snapshot/image.js > TAP > image (snapshot) > thumb requested but source is gif 1`] = `

--- a/tap-snapshots/test/snapshot/image.js.test.cjs
+++ b/tap-snapshots/test/snapshot/image.js.test.cjs
@@ -6,65 +6,67 @@
  */
 'use strict'
 exports[`test/snapshot/image.js > TAP > image (snapshot) > content warnings via tags 1`] = `
-<div class="reveal">
-    <div class="image-container">
-        <div class="image-inner-area">
-            <img class="image" src="media/album-art/beyond-canon/cover.png">
-            <span class="reveal-text-container">
-                <span class="reveal-text">
-                    <img class="reveal-symbol" src="static/warning.svg?413">
-                    <br>
-                    <span class="reveal-warnings">too cool for school</span>
-                    <br>
-                    <span class="reveal-interaction">click to show</span>
+<div class="image-container">
+    <div class="reveal">
+        <div class="image-outer-area">
+            <div class="image-inner-area">
+                <img class="image" src="media/album-art/beyond-canon/cover.png">
+                <span class="reveal-text-container">
+                    <span class="reveal-text">
+                        <img class="reveal-symbol" src="static/warning.svg?413">
+                        <br>
+                        <span class="reveal-warnings">too cool for school</span>
+                        <br>
+                        <span class="reveal-interaction">click to show</span>
+                    </span>
                 </span>
-            </span>
+            </div>
         </div>
     </div>
 </div>
 `
 
 exports[`test/snapshot/image.js > TAP > image (snapshot) > lazy with square 1`] = `
-<noscript><div class="square"><div class="square-content"><div class="image-container"><div class="image-inner-area"><img class="image" src="foobar"></div></div></div></div></noscript>
-<div class="square js-hide"><div class="square-content"><div class="image-container"><div class="image-inner-area"><img class="image lazy" data-original="foobar"></div></div></div></div>
+<noscript><div class="image-container square"><div class="square-content"><div class="image-outer-area"><div class="image-inner-area"><img class="image" src="foobar"></div></div></div></div></noscript>
+<div class="image-container square js-hide"><div class="square-content"><div class="image-outer-area"><div class="image-inner-area"><img class="image lazy" data-original="foobar"></div></div></div></div>
 `
 
 exports[`test/snapshot/image.js > TAP > image (snapshot) > link with file size 1`] = `
-<div class="image-container has-link"><a class="image-link" href="media/album-art/pingas/cover.png"><div class="image-inner-area"><img class="image" src="media/album-art/pingas/cover.png"></div></a></div>
+<div class="image-container has-link"><div class="image-outer-area"><a class="image-link" href="media/album-art/pingas/cover.png"><div class="image-inner-area"><img class="image" src="media/album-art/pingas/cover.png"></div></a></div></div>
 `
 
 exports[`test/snapshot/image.js > TAP > image (snapshot) > missing image path 1`] = `
-<div class="image-container"><div class="image-inner-area"><div class="image-text-area">(This image file is missing)</div></div></div>
+<div class="image-container"><div class="image-outer-area"><div class="image-inner-area"><div class="image-text-area">(This image file is missing)</div></div></div></div>
 `
 
 exports[`test/snapshot/image.js > TAP > image (snapshot) > missing image path w/ missingSourceContent 1`] = `
-<div class="image-container"><div class="image-inner-area"><div class="image-text-area">Cover's missing, whoops</div></div></div>
+<div class="image-container"><div class="image-outer-area"><div class="image-inner-area"><div class="image-text-area">Cover's missing, whoops</div></div></div></div>
 `
 
 exports[`test/snapshot/image.js > TAP > image (snapshot) > source missing 1`] = `
-<div class="image-container placeholder-image"><div class="image-inner-area"><div class="image-text-area">Example of missing source message.</div></div></div>
+<div class="image-container placeholder-image"><div class="image-outer-area"><div class="image-inner-area"><div class="image-text-area">Example of missing source message.</div></div></div></div>
 `
 
 exports[`test/snapshot/image.js > TAP > image (snapshot) > source via path 1`] = `
-<div class="image-container"><div class="image-inner-area"><img class="image" src="media/album-art/beyond-canon/cover.png"></div></div>
+<div class="image-container"><div class="image-outer-area"><div class="image-inner-area"><img class="image" src="media/album-art/beyond-canon/cover.png"></div></div></div>
 `
 
 exports[`test/snapshot/image.js > TAP > image (snapshot) > source via src 1`] = `
-<div class="image-container"><div class="image-inner-area"><img class="image" src="https://example.com/bananas.gif"></div></div>
+<div class="image-container"><div class="image-outer-area"><div class="image-inner-area"><img class="image" src="https://example.com/bananas.gif"></div></div></div>
 `
 
 exports[`test/snapshot/image.js > TAP > image (snapshot) > square 1`] = `
-<div class="square"><div class="square-content"><div class="image-container"><div class="image-inner-area"><img class="image" src="foobar"></div></div></div></div>
+<div class="image-container square"><div class="square-content"><div class="image-outer-area"><div class="image-inner-area"><img class="image" src="foobar"></div></div></div></div>
 `
 
 exports[`test/snapshot/image.js > TAP > image (snapshot) > thumb requested but source is gif 1`] = `
-<div class="image-container"><div class="image-inner-area"><img class="image" src="media/flash-art/5426.gif"></div></div>
+<div class="image-container"><div class="image-outer-area"><div class="image-inner-area"><img class="image" src="media/flash-art/5426.gif"></div></div></div>
 `
 
 exports[`test/snapshot/image.js > TAP > image (snapshot) > thumbnail details 1`] = `
-<div class="image-container"><div class="image-inner-area"><img class="image" data-original-length="1200" data-thumbs="voluminous:1200 middling:900 petite:20" src="thumb/album-art/beyond-canon/cover.voluminous.jpg"></div></div>
+<div class="image-container"><div class="image-outer-area"><div class="image-inner-area"><img class="image" data-original-length="1200" data-thumbs="voluminous:1200 middling:900 petite:20" src="thumb/album-art/beyond-canon/cover.voluminous.jpg"></div></div></div>
 `
 
 exports[`test/snapshot/image.js > TAP > image (snapshot) > width & height 1`] = `
-<div class="image-container"><div class="image-inner-area"><img class="image" width="600" height="400" src="foobar"></div></div>
+<div class="image-container"><div class="image-outer-area"><div class="image-inner-area"><img class="image" width="600" height="400" src="foobar"></div></div></div>
 `

--- a/tap-snapshots/test/snapshot/image.js.test.cjs
+++ b/tap-snapshots/test/snapshot/image.js.test.cjs
@@ -24,18 +24,6 @@ exports[`test/snapshot/image.js > TAP > image (snapshot) > content warnings via 
 </div>
 `
 
-exports[`test/snapshot/image.js > TAP > image (snapshot) > id with link 1`] = `
-<div class="image-container has-link"><a class="image-link" href="foobar" id="banana"><div class="image-inner-area"><img class="image" src="foobar"></div></a></div>
-`
-
-exports[`test/snapshot/image.js > TAP > image (snapshot) > id with square 1`] = `
-<div class="square"><div class="square-content"><div class="image-container"><div class="image-inner-area"><img class="image" id="banana" src="foobar"></div></div></div></div>
-`
-
-exports[`test/snapshot/image.js > TAP > image (snapshot) > id without link 1`] = `
-<div class="image-container"><div class="image-inner-area"><img class="image" id="banana" src="foobar"></div></div>
-`
-
 exports[`test/snapshot/image.js > TAP > image (snapshot) > lazy with square 1`] = `
 <noscript><div class="square"><div class="square-content"><div class="image-container"><div class="image-inner-area"><img class="image" src="foobar"></div></div></div></div></noscript>
 <div class="square js-hide"><div class="square-content"><div class="image-container"><div class="image-inner-area"><img class="image lazy" data-original="foobar"></div></div></div></div>

--- a/tap-snapshots/test/snapshot/image.js.test.cjs
+++ b/tap-snapshots/test/snapshot/image.js.test.cjs
@@ -7,36 +7,42 @@
 'use strict'
 exports[`test/snapshot/image.js > TAP > image (snapshot) > content warnings via tags 1`] = `
 <div class="reveal">
-    <div class="image-container"><div class="image-inner-area"><img src="media/album-art/beyond-canon/cover.png"></div></div>
-    <span class="reveal-text-container">
-        <span class="reveal-text">
-            cw: too cool for school
-            <br>
-            <span class="reveal-interaction">click to show</span>
-        </span>
-    </span>
+    <div class="image-container">
+        <div class="image-inner-area">
+            <img class="image" src="media/album-art/beyond-canon/cover.png">
+            <span class="reveal-text-container">
+                <span class="reveal-text">
+                    <img class="reveal-symbol" src="static/warning.svg?413">
+                    <br>
+                    <span class="reveal-warnings">too cool for school</span>
+                    <br>
+                    <span class="reveal-interaction">click to show</span>
+                </span>
+            </span>
+        </div>
+    </div>
 </div>
 `
 
 exports[`test/snapshot/image.js > TAP > image (snapshot) > id with link 1`] = `
-<a class="box image-link" href="foobar" id="banana"><div class="image-container"><div class="image-inner-area"><img src="foobar"></div></div></a>
+<div class="image-container has-link"><a class="image-link" href="foobar" id="banana"><div class="image-inner-area"><img class="image" src="foobar"></div></a></div>
 `
 
 exports[`test/snapshot/image.js > TAP > image (snapshot) > id with square 1`] = `
-<div class="square"><div class="square-content"><div class="image-container"><div class="image-inner-area"><img id="banana" src="foobar"></div></div></div></div>
+<div class="square"><div class="square-content"><div class="image-container"><div class="image-inner-area"><img class="image" id="banana" src="foobar"></div></div></div></div>
 `
 
 exports[`test/snapshot/image.js > TAP > image (snapshot) > id without link 1`] = `
-<div class="image-container"><div class="image-inner-area"><img id="banana" src="foobar"></div></div>
+<div class="image-container"><div class="image-inner-area"><img class="image" id="banana" src="foobar"></div></div>
 `
 
 exports[`test/snapshot/image.js > TAP > image (snapshot) > lazy with square 1`] = `
-<noscript><div class="square"><div class="square-content"><div class="image-container"><div class="image-inner-area"><img src="foobar"></div></div></div></div></noscript>
-<div class="square js-hide"><div class="square-content"><div class="image-container"><div class="image-inner-area"><img class="lazy" data-original="foobar"></div></div></div></div>
+<noscript><div class="square"><div class="square-content"><div class="image-container"><div class="image-inner-area"><img class="image" src="foobar"></div></div></div></div></noscript>
+<div class="square js-hide"><div class="square-content"><div class="image-container"><div class="image-inner-area"><img class="image lazy" data-original="foobar"></div></div></div></div>
 `
 
 exports[`test/snapshot/image.js > TAP > image (snapshot) > link with file size 1`] = `
-<a class="box image-link" href="media/album-art/pingas/cover.png"><div class="image-container"><div class="image-inner-area"><img src="media/album-art/pingas/cover.png"></div></div></a>
+<div class="image-container has-link"><a class="image-link" href="media/album-art/pingas/cover.png"><div class="image-inner-area"><img class="image" src="media/album-art/pingas/cover.png"></div></a></div>
 `
 
 exports[`test/snapshot/image.js > TAP > image (snapshot) > missing image path 1`] = `
@@ -52,25 +58,25 @@ exports[`test/snapshot/image.js > TAP > image (snapshot) > source missing 1`] = 
 `
 
 exports[`test/snapshot/image.js > TAP > image (snapshot) > source via path 1`] = `
-<div class="image-container"><div class="image-inner-area"><img src="media/album-art/beyond-canon/cover.png"></div></div>
+<div class="image-container"><div class="image-inner-area"><img class="image" src="media/album-art/beyond-canon/cover.png"></div></div>
 `
 
 exports[`test/snapshot/image.js > TAP > image (snapshot) > source via src 1`] = `
-<div class="image-container"><div class="image-inner-area"><img src="https://example.com/bananas.gif"></div></div>
+<div class="image-container"><div class="image-inner-area"><img class="image" src="https://example.com/bananas.gif"></div></div>
 `
 
 exports[`test/snapshot/image.js > TAP > image (snapshot) > square 1`] = `
-<div class="square"><div class="square-content"><div class="image-container"><div class="image-inner-area"><img src="foobar"></div></div></div></div>
+<div class="square"><div class="square-content"><div class="image-container"><div class="image-inner-area"><img class="image" src="foobar"></div></div></div></div>
 `
 
 exports[`test/snapshot/image.js > TAP > image (snapshot) > thumb requested but source is gif 1`] = `
-<div class="image-container"><div class="image-inner-area"><img src="media/flash-art/5426.gif"></div></div>
+<div class="image-container"><div class="image-inner-area"><img class="image" src="media/flash-art/5426.gif"></div></div>
 `
 
 exports[`test/snapshot/image.js > TAP > image (snapshot) > thumbnail details 1`] = `
-<div class="image-container"><div class="image-inner-area"><img data-original-length="1200" data-thumbs="voluminous:1200 middling:900 petite:20" src="thumb/album-art/beyond-canon/cover.voluminous.jpg"></div></div>
+<div class="image-container"><div class="image-inner-area"><img class="image" data-original-length="1200" data-thumbs="voluminous:1200 middling:900 petite:20" src="thumb/album-art/beyond-canon/cover.voluminous.jpg"></div></div>
 `
 
 exports[`test/snapshot/image.js > TAP > image (snapshot) > width & height 1`] = `
-<div class="image-container"><div class="image-inner-area"><img width="600" height="400" src="foobar"></div></div>
+<div class="image-container"><div class="image-inner-area"><img class="image" width="600" height="400" src="foobar"></div></div>
 `

--- a/test/lib/content-function.js
+++ b/test/lib/content-function.js
@@ -51,6 +51,7 @@ export function testContentFunctions(t, message, fn) {
             to,
             urls,
 
+            cachebust: 413,
             pagePath: ['home'],
             appendIndexHTML: false,
             getColors: c => getColors(c, {chroma}),

--- a/test/snapshot/image.js
+++ b/test/snapshot/image.js
@@ -38,29 +38,6 @@ testContentFunctions(t, 'image (snapshot)', async (t, evaluate) => {
     },
   });
 
-  quickSnapshot('id without link', {
-    slots: {
-      src: 'foobar',
-      id: 'banana',
-    },
-  });
-
-  quickSnapshot('id with link', {
-    slots: {
-      src: 'foobar',
-      link: true,
-      id: 'banana',
-    },
-  });
-
-  quickSnapshot('id with square', {
-    slots: {
-      src: 'foobar',
-      square: true,
-      id: 'banana',
-    },
-  });
-
   quickSnapshot('width & height', {
     slots: {
       src: 'foobar',


### PR DESCRIPTION
This PR once again alters the `image` component to try to cut out complex attributes manipulation and make the general hierarchy of images more predictable.

* The top-level element is always `.image-container` now, and various attributes reliably show up here; notably, the `js-hide` attribute that's just put on "the top element" no longer moves based on the `square` slot. This also simplifies adding the color style.
* Although `.image-container` is still responsible for controlling the image's border (if applicable), it no longer controls padding. That's moved to `.image-outer-area`.
* Elements which only had layout functionality (but no visual styling) are "flattened". So `.image-container` is now responsible for both `.square` and `.reveal`, and `.image-outer-area` is now responsible for `.square-content`.
* The `id` and `class` slots are both removed, and replaced by a generic `attributes` class, which always only applies to the top-level `.image-container`.
* Reveal styling and interactivity now uses a wildcard selector for the first thing under `.image-outer-area`. It *might* be possible to flatten `image-link` into `image-inner-area`, but we're not totally sure - it might necessitate some rearrangement with box shadows or other visual styling.

The total hierarchy now looks like:

```html
<div class="image-container">
  <div class="image-outer-area">
    <a   class="image-link"> (optional)
      <div class="image-inner-area">
        <img class="image">
```

Squares look like this:

```html
<div class="image-container square">
  <div class="image-outer-area square-content">
    <a   class="image-link"> (optional)
      <div class="image-inner-area">
        <img class="image">
```

Reveals look like this:

```html
<div class="image-container reveal">
  <div class="image-outer-area">
    <a   class="image-link"> (optional)
      <div class="image-inner-area">
        <img class="image">
        <img class="image reveal-thumbnail">
        <div class="reveal-text-container">
          <!-- usual reveal content -->
```

So as far as wrapping goes, the only dynamics are in whether or not the `<a class="image-link">` element is present; otherwise, layout and identifying is completely handled by adding classes onto the appropriate, always-present parts of the hierarchy.
