### PR TITLE
Art tag tooltips & disambiguation!

### DIFF
--- a/src/content/dependencies/generateChronologyLinks.js
+++ b/src/content/dependencies/generateChronologyLinks.js
@@ -61,13 +61,13 @@ export default {
               html.tag('span', {class: 'buttons'},
                 language.formatUnitList([
                   previousLink?.slots({
-                    tooltip: true,
+                    tooltipStyle: 'browser',
                     color: false,
                     content: language.$('misc.nav.previous'),
                   }),
 
                   nextLink?.slots({
-                    tooltip: true,
+                    tooltipStyle: 'browser',
                     color: false,
                     content: language.$('misc.nav.next'),
                   }),

--- a/src/content/dependencies/generatePreviousNextLinks.js
+++ b/src/content/dependencies/generatePreviousNextLinks.js
@@ -28,7 +28,7 @@ export default {
     if (!html.isBlank(slots.previousLink)) {
       previousNext.push(
         slots.previousLink.slots({
-          tooltip: true,
+          tooltipStyle: 'browser',
           color: false,
           attributes: {id: slots.id && 'previous-button'},
           content: language.$('misc.nav.previous'),
@@ -38,7 +38,7 @@ export default {
     if (!html.isBlank(slots.nextLink)) {
       previousNext.push(
         slots.nextLink.slots({
-          tooltip: true,
+          tooltipStyle: 'browser',
           color: false,
           attributes: {id: slots.id && 'next-button'},
           content: language.$('misc.nav.next'),

--- a/src/content/dependencies/linkThing.js
+++ b/src/content/dependencies/linkThing.js
@@ -76,10 +76,11 @@ export default {
   },
 
   generate(data, relations, slots, {html, language}) {
-    const {attributes} = slots;
-
     const path =
       slots.path ?? data.path;
+
+    const linkAttributes = slots.attributes;
+    const wrapperAttributes = html.attributes();
 
     const showShortName =
       (slots.preferShortName
@@ -104,7 +105,7 @@ export default {
         });
 
     if (slots.tooltipStyle === 'browser') {
-      attributes.add('title', data.name);
+      linkAttributes.add('title', data.name);
     }
 
     const content =
@@ -121,18 +122,24 @@ export default {
         colorStyle.setSlot('color', slots.color);
       }
 
-      attributes.add(colorStyle);
+      if (showWikiTooltip) {
+        wrapperAttributes.add(colorStyle);
+      } else {
+        linkAttributes.add(colorStyle);
+      }
     }
 
     return relations.textWithTooltip.slots({
+      attributes: wrapperAttributes,
+
       text:
         relations.linkTemplate.slots({
           path: slots.anchor ? [] : path,
           href: slots.anchor ? '' : null,
-          content,
-          attributes,
+          attributes: linkAttributes,
           hash: slots.hash,
           linkless: slots.linkless,
+          content,
         }),
 
       tooltip:

--- a/src/content/dependencies/linkThing.js
+++ b/src/content/dependencies/linkThing.js
@@ -36,9 +36,9 @@ export default {
       default: false,
     },
 
-    tooltip: {
-      validate: v => v.anyOf(v.isBoolean, v.isHTML),
-      default: false,
+    tooltipStyle: {
+      validate: v => v.is('none', 'browser'),
+      default: 'none',
     },
 
     color: {
@@ -69,10 +69,19 @@ export default {
     const path =
       slots.path ?? data.path;
 
-    const name =
+    const showShortName =
       (slots.preferShortName
-        ? data.nameShort ?? data.name ?? null
-        : data.name ?? null);
+        ? data.nameShort && data.nameShort !== data.name
+        : false);
+
+    const name =
+      (showShortName
+        ? data.nameShort
+        : data.name);
+
+    if (slots.tooltipStyle === 'browser') {
+      attributes.add('title', data.name);
+    }
 
     const content =
       (html.isBlank(slots.content)
@@ -91,19 +100,11 @@ export default {
       attributes.add(colorStyle);
     }
 
-    let tooltip = null;
-    if (slots.tooltip === true) {
-      tooltip = name;
-    } else if (typeof slots.tooltip === 'string') {
-      tooltip = slots.tooltip;
-    }
-
     return relations.linkTemplate
       .slots({
         path: slots.anchor ? [] : path,
         href: slots.anchor ? '' : null,
         content,
-        tooltip,
         attributes,
         hash: slots.hash,
         linkless: slots.linkless,

--- a/src/content/dependencies/linkThing.js
+++ b/src/content/dependencies/linkThing.js
@@ -1,5 +1,11 @@
 export default {
-  contentDependencies: ['generateColorStyleAttribute', 'linkTemplate'],
+  contentDependencies: [
+    'generateColorStyleAttribute',
+    'generateTextWithTooltip',
+    'generateTooltip',
+    'linkTemplate',
+  ],
+
   extraDependencies: ['html', 'language'],
 
   relations: (relation, _pathKey, thing) => ({
@@ -8,6 +14,12 @@ export default {
 
     colorStyle:
       relation('generateColorStyleAttribute', thing.color ?? null),
+
+    textWithTooltip:
+      relation('generateTextWithTooltip'),
+
+    tooltip:
+      relation('generateTooltip'),
   }),
 
   data: (pathKey, thing) => ({
@@ -37,8 +49,8 @@ export default {
     },
 
     tooltipStyle: {
-      validate: v => v.is('none', 'browser'),
-      default: 'none',
+      validate: v => v.is('none', 'auto', 'browser', 'wiki'),
+      default: 'auto',
     },
 
     color: {
@@ -79,6 +91,18 @@ export default {
         ? data.nameShort
         : data.name);
 
+    const showWikiTooltip =
+      (slots.tooltipStyle === 'auto'
+        ? showShortName
+        : slots.tooltipStyle === 'wiki');
+
+    const wikiTooltip =
+      showWikiTooltip &&
+        relations.tooltip.slots({
+          attributes: {class: 'thing-name-tooltip'},
+          content: data.name,
+        });
+
     if (slots.tooltipStyle === 'browser') {
       attributes.add('title', data.name);
     }
@@ -100,14 +124,19 @@ export default {
       attributes.add(colorStyle);
     }
 
-    return relations.linkTemplate
-      .slots({
-        path: slots.anchor ? [] : path,
-        href: slots.anchor ? '' : null,
-        content,
-        attributes,
-        hash: slots.hash,
-        linkless: slots.linkless,
-      });
+    return relations.textWithTooltip.slots({
+      text:
+        relations.linkTemplate.slots({
+          path: slots.anchor ? [] : path,
+          href: slots.anchor ? '' : null,
+          content,
+          attributes,
+          hash: slots.hash,
+          linkless: slots.linkless,
+        }),
+
+      tooltip:
+        wikiTooltip ?? null,
+    });
   },
 }

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -562,6 +562,11 @@ li:not(:first-child:last-child) .tooltip,
   left: -10px;
 }
 
+.thing-name-tooltip {
+  padding: 3px 4px 2px 2px;
+  left: -6px !important;
+}
+
 .icons-tooltip .tooltip-content {
   padding: 6px 2px 2px 2px;
 
@@ -575,6 +580,12 @@ li:not(:first-child:last-child) .tooltip,
   padding: 5px 6px;
   white-space: nowrap;
   font-size: 0.9em;
+}
+
+.thing-name-tooltip .tooltip-content {
+  padding: 3px 4.5px;
+  white-space: nowrap;
+  max-width: 120px;
 }
 
 .icons {

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -661,7 +661,10 @@ p .current {
     0 0 12px 12px #00000080;
 
   border-radius: 0 0 4px 4px;
-  overflow: hidden;
+  background: var(--bg-black-color);
+
+  -webkit-backdrop-filter: blur(3px);
+          backdrop-filter: blur(3px);
 }
 
 #cover-art-container:has(.image-details),
@@ -691,11 +694,7 @@ p .current {
   padding: 6px 9px 4px 9px;
   margin-top: 0;
   margin-bottom: 0;
-  background: var(--bg-black-color);
   border-top: 1px dashed var(--dim-color);
-
-  -webkit-backdrop-filter: blur(3px);
-          backdrop-filter: blur(3px);
 }
 
 ul.image-details li {

--- a/tap-snapshots/test/snapshot/generateAlbumSecondaryNav.js.test.cjs
+++ b/tap-snapshots/test/snapshot/generateAlbumSecondaryNav.js.test.cjs
@@ -9,11 +9,11 @@ exports[`test/snapshot/generateAlbumSecondaryNav.js > TAP > generateAlbumSeconda
 <nav id="secondary-nav" class="nav-links-groups">
     <span style="--primary-color: #abcdef">
         <a href="group/vcg/">VCG</a>
-        (<a href="album/first/" title="First">Previous</a>, <a href="album/last/" title="Last">Next</a>)
+        (<a title="First" href="album/first/">Previous</a>, <a title="Last" href="album/last/">Next</a>)
     </span>
     <span style="--primary-color: #123456">
         <a href="group/bepis/">Bepis</a>
-        (<a href="album/second/" title="Second">Next</a>)
+        (<a title="Second" href="album/second/">Next</a>)
     </span>
 </nav>
 `

--- a/tap-snapshots/test/snapshot/generatePreviousNextLinks.js.test.cjs
+++ b/tap-snapshots/test/snapshot/generatePreviousNextLinks.js.test.cjs
@@ -6,13 +6,13 @@
  */
 'use strict'
 exports[`test/snapshot/generatePreviousNextLinks.js > TAP > generatePreviousNextLinks (snapshot) > basic behavior 1`] = `
-previous: { tooltip: true, color: false, attributes: { id: 'previous-button' }, content: Tag (no name, 1 items) }
-next: { tooltip: true, color: false, attributes: { id: 'next-button' }, content: Tag (no name, 1 items) }
+previous: { tooltipStyle: 'browser', color: false, attributes: { id: 'previous-button' }, content: Tag (no name, 1 items) }
+next: { tooltipStyle: 'browser', color: false, attributes: { id: 'next-button' }, content: Tag (no name, 1 items) }
 `
 
 exports[`test/snapshot/generatePreviousNextLinks.js > TAP > generatePreviousNextLinks (snapshot) > disable id 1`] = `
-previous: { tooltip: true, color: false, attributes: { id: false }, content: Tag (no name, 1 items) }
-next: { tooltip: true, color: false, attributes: { id: false }, content: Tag (no name, 1 items) }
+previous: { tooltipStyle: 'browser', color: false, attributes: { id: false }, content: Tag (no name, 1 items) }
+next: { tooltipStyle: 'browser', color: false, attributes: { id: false }, content: Tag (no name, 1 items) }
 `
 
 exports[`test/snapshot/generatePreviousNextLinks.js > TAP > generatePreviousNextLinks (snapshot) > neither link present 1`] = `
@@ -20,9 +20,9 @@ exports[`test/snapshot/generatePreviousNextLinks.js > TAP > generatePreviousNext
 `
 
 exports[`test/snapshot/generatePreviousNextLinks.js > TAP > generatePreviousNextLinks (snapshot) > next missing 1`] = `
-previous: { tooltip: true, color: false, attributes: { id: 'previous-button' }, content: Tag (no name, 1 items) }
+previous: { tooltipStyle: 'browser', color: false, attributes: { id: 'previous-button' }, content: Tag (no name, 1 items) }
 `
 
 exports[`test/snapshot/generatePreviousNextLinks.js > TAP > generatePreviousNextLinks (snapshot) > previous missing 1`] = `
-next: { tooltip: true, color: false, attributes: { id: 'next-button' }, content: Tag (no name, 1 items) }
+next: { tooltipStyle: 'browser', color: false, attributes: { id: 'next-button' }, content: Tag (no name, 1 items) }
 `

--- a/tap-snapshots/test/snapshot/linkArtist.js.test.cjs
+++ b/tap-snapshots/test/snapshot/linkArtist.js.test.cjs
@@ -10,5 +10,5 @@ exports[`test/snapshot/linkArtist.js > TAP > linkArtist (snapshot) > basic behav
 `
 
 exports[`test/snapshot/linkArtist.js > TAP > linkArtist (snapshot) > prefer short name 1`] = `
-<a href="artist/55gore/">55gore</a>
+<span class="text-with-tooltip"><a href="artist/55gore/">55gore</a><span class="tooltip thing-name-tooltip"><span class="tooltip-content">ICCTTCMDMIROTMCWMWFTPFTDDOTARHPOESWGBTWEATFCWSEBTSSFOFG</span></span></span>
 `

--- a/tap-snapshots/test/snapshot/linkThing.js.test.cjs
+++ b/tap-snapshots/test/snapshot/linkThing.js.test.cjs
@@ -13,6 +13,7 @@ exports[`test/snapshot/linkThing.js > TAP > linkThing (snapshot) > color 1`] = `
 <a href="track/showtime-piano-refrain/">Showtime (Piano Refrain)</a>
 <a style="--primary-color: #38f43d" href="track/showtime-piano-refrain/">Showtime (Piano Refrain)</a>
 <a style="--primary-color: #aaccff" href="track/showtime-piano-refrain/">Showtime (Piano Refrain)</a>
+<span style="--primary-color: #aaccff" class="text-with-tooltip"><a href="track/showtime-piano-refrain/">Showtime (Piano Refrain)</a><span class="tooltip thing-name-tooltip"><span class="tooltip-content">Showtime (Piano Refrain)</span></span></span>
 `
 
 exports[`test/snapshot/linkThing.js > TAP > linkThing (snapshot) > nested links in content stripped 1`] = `

--- a/tap-snapshots/test/snapshot/linkThing.js.test.cjs
+++ b/tap-snapshots/test/snapshot/linkThing.js.test.cjs
@@ -32,8 +32,7 @@ exports[`test/snapshot/linkThing.js > TAP > linkThing (snapshot) > tags in name 
 
 exports[`test/snapshot/linkThing.js > TAP > linkThing (snapshot) > tooltip & content 1`] = `
 <a href="album/beyond-canon/">Beyond Canon</a>
-<a href="album/beyond-canon/" title="Beyond Canon">Beyond Canon</a>
-<a href="album/beyond-canon/" title="Beyond Canon">Next</a>
-<a href="album/beyond-canon/" title="Apple">Banana</a>
+<a title="Beyond Canon" href="album/beyond-canon/">Beyond Canon</a>
+<a title="Beyond Canon" href="album/beyond-canon/">Next</a>
 <a href="album/beyond-canon/">Banana</a>
 `

--- a/tap-snapshots/test/snapshot/linkThing.js.test.cjs
+++ b/tap-snapshots/test/snapshot/linkThing.js.test.cjs
@@ -20,7 +20,7 @@ exports[`test/snapshot/linkThing.js > TAP > linkThing (snapshot) > nested links 
 `
 
 exports[`test/snapshot/linkThing.js > TAP > linkThing (snapshot) > preferShortName 1`] = `
-<a href="tag/five-oceanfalls/">Five</a>
+<span class="text-with-tooltip"><a href="tag/five-oceanfalls/">Five</a><span class="tooltip thing-name-tooltip"><span class="tooltip-content">Five (Oceanfalls)</span></span></span>
 `
 
 exports[`test/snapshot/linkThing.js > TAP > linkThing (snapshot) > tags in name escaped 1`] = `
@@ -34,5 +34,11 @@ exports[`test/snapshot/linkThing.js > TAP > linkThing (snapshot) > tooltip & con
 <a href="album/beyond-canon/">Beyond Canon</a>
 <a title="Beyond Canon" href="album/beyond-canon/">Beyond Canon</a>
 <a title="Beyond Canon" href="album/beyond-canon/">Next</a>
+<a href="album/beyond-canon/">Beyond Canon</a>
+<span class="text-with-tooltip"><a href="album/beyond-canon/">BC</a><span class="tooltip thing-name-tooltip"><span class="tooltip-content">Beyond Canon</span></span></span>
+<span class="text-with-tooltip"><a href="album/beyond-canon/">Next</a><span class="tooltip thing-name-tooltip"><span class="tooltip-content">Beyond Canon</span></span></span>
+<a href="album/beyond-canon/">Next</a>
+<span class="text-with-tooltip"><a href="album/beyond-canon/">Beyond Canon</a><span class="tooltip thing-name-tooltip"><span class="tooltip-content">Beyond Canon</span></span></span>
+<span class="text-with-tooltip"><a href="album/beyond-canon/">Next</a><span class="tooltip thing-name-tooltip"><span class="tooltip-content">Beyond Canon</span></span></span>
 <a href="album/beyond-canon/">Banana</a>
 `

--- a/test/snapshot/generateTrackCoverArtwork.js
+++ b/test/snapshot/generateTrackCoverArtwork.js
@@ -1,5 +1,6 @@
 import t from 'tap';
 import {testContentFunctions} from '#test-lib';
+import {showAggregate} from '#sugar';
 
 testContentFunctions(t, 'generateTrackCoverArtwork (snapshot)', async (t, evaluate) => {
   await evaluate.load({
@@ -35,11 +36,15 @@ testContentFunctions(t, 'generateTrackCoverArtwork (snapshot)', async (t, evalua
     album,
   };
 
-  evaluate.snapshot('display: primary - unique art', {
-    name: 'generateTrackCoverArtwork',
-    args: [track1],
-    slots: {mode: 'primary'},
-  });
+  try {
+    evaluate.snapshot('display: primary - unique art', {
+      name: 'generateTrackCoverArtwork',
+      args: [track1],
+      slots: {mode: 'primary'},
+    });
+  } catch (error) {
+    showAggregate(error);
+  }
 
   evaluate.snapshot('display: thumbnail - unique art', {
     name: 'generateTrackCoverArtwork',

--- a/test/snapshot/linkThing.js
+++ b/test/snapshot/linkThing.js
@@ -58,6 +58,7 @@ testContentFunctions(t, 'linkThing (snapshot)', async (t, evaluate) => {
       {slots: {color: false}},
       {slots: {color: true}},
       {slots: {color: '#aaccff'}},
+      {slots: {color: '#aaccff', tooltipStyle: 'wiki'}},
     ],
   });
 

--- a/test/snapshot/linkThing.js
+++ b/test/snapshot/linkThing.js
@@ -34,10 +34,9 @@ testContentFunctions(t, 'linkThing (snapshot)', async (t, evaluate) => {
       name: 'Beyond Canon',
     }],
     multiple: [
-      {slots: {tooltip: false}},
-      {slots: {tooltip: true}},
-      {slots: {tooltip: true, content: 'Next'}},
-      {slots: {tooltip: 'Apple', content: 'Banana'}},
+      {slots: {tooltipStyle: 'none'}},
+      {slots: {tooltipStyle: 'browser'}},
+      {slots: {tooltipStyle: 'browser', content: 'Next'}},
       {slots: {content: 'Banana'}},
     ],
   });

--- a/test/snapshot/linkThing.js
+++ b/test/snapshot/linkThing.js
@@ -32,11 +32,18 @@ testContentFunctions(t, 'linkThing (snapshot)', async (t, evaluate) => {
     args: ['localized.album', {
       directory: 'beyond-canon',
       name: 'Beyond Canon',
+      nameShort: 'BC',
     }],
     multiple: [
       {slots: {tooltipStyle: 'none'}},
       {slots: {tooltipStyle: 'browser'}},
       {slots: {tooltipStyle: 'browser', content: 'Next'}},
+      {slots: {tooltipStyle: 'auto'}},
+      {slots: {tooltipStyle: 'auto', preferShortName: true}},
+      {slots: {tooltipStyle: 'auto', preferShortName: true, content: 'Next'}},
+      {slots: {tooltipStyle: 'auto', content: 'Next'}},
+      {slots: {tooltipStyle: 'wiki'}},
+      {slots: {tooltipStyle: 'wiki', content: 'Next'}},
       {slots: {content: 'Banana'}},
     ],
   });


### PR DESCRIPTION
This PR changes the presentation of art tags in cover artworks in some pretty neat ways:

* Duplicate short names are now replaced with full names. So for example, before, `tag:john` and `tag:john-heinoustuck` would read "John, John", and now it's "John, John (Heinoustuck)". Non-duplicates are left in short form, of course!
* When a short name is used (i.e. it isn't a duplicate), there's now a small tooltip including the full name. (Since this descends from `#cover-art-container`, there were some minor CSS tweaks to keep that element from being `overflow: hidden`.)

Internally, there are now four options for `linkThing`'s slot `tooltipMode`:

* `auto` (default): Show a wiki tooltip with the full name if the short name was used. Don't show it in any other circumstances (including if you specified custom content yourself).
* `none`: Never show a tooltip.
* `browser`: Show a tooltip with the full name, and display it as a browser/system tooltip - it won't be visible on mobile, but is much less prevalent than wiki tooltips.
* `wiki`: Show a tooltip with the full name, and display it as with wiki styling - that's using the same tooltip system as has been integrated like basically everywhere. ([We're so tired of working on tooltips today LMAO](https://github.com/hsmusic/hsmusic-wiki/pull/373))

The old `tooltip` slot, which was a binary that could be provided HTML content, was removed, since nowhere was slotting custom tooltip content. That means tooltips always display only the full name of the track, if present.

And relevant snapshot tests are all updated!
