### PR TITLE
Make group album navigation match sorting of group pages

### DIFF
--- a/src/util/sugar.js
+++ b/src/util/sugar.js
@@ -60,6 +60,34 @@ export function repeat(times, array) {
   return out;
 }
 
+// Gets the item at an index relative to another index.
+export function atOffset(array, index, offset, {
+  wrap = false,
+  valuePastEdge = null,
+} = {}) {
+  if (index === -1) {
+    return valuePastEdge;
+  }
+
+  if (offset === 0) {
+    return array[index];
+  }
+
+  if (wrap) {
+    return array[(index + offset) % array.length];
+  }
+
+  if (offset > 0 && index + offset > array.length - 1) {
+    return valuePastEdge;
+  }
+
+  if (offset < 0 && index + offset < 0) {
+    return valuePastEdge;
+  }
+
+  return array[index + offset];
+}
+
 // Sums the values in an array, optionally taking a function which maps each
 // item to a number (handy for accessing a certain property on an array of like
 // objects). This also coalesces null values to zero, so if the mapping function


### PR DESCRIPTION
Updates `generateAlbumSidebarGroupBox` and `generateAlbumSecondaryNav` to match the sorting order used on group gallery and info pages, for better group navigation.

* The sorts were previously left arbitrary, i.e. dependent on `wikiData`, which was a bug; it was deterministic only by inheriting from `#yaml` the results of `sortChronologically`, non-`latestFirst`.
* This PR makes sorting explicit rather than inherited, and changes the sorting to use `latestFirst: true` (flipping the offsets used for "previous" and "next") so that the order matches what is used on group gallery and group info pages.
* There's also a new `atOffset` utility in `#sugar`, which isn't yet implemented across the codebase but should come in handy.
