### PR TITLE
Fast reverse references!

### DIFF
--- a/src/data/composite/wiki-data/index.js
+++ b/src/data/composite/wiki-data/index.js
@@ -11,5 +11,6 @@ export {default as withParsedCommentaryEntries} from './withParsedCommentaryEntr
 export {default as withResolvedContribs} from './withResolvedContribs.js';
 export {default as withResolvedReference} from './withResolvedReference.js';
 export {default as withResolvedReferenceList} from './withResolvedReferenceList.js';
+export {default as withReverseContributionList} from './withReverseContributionList.js';
 export {default as withReverseReferenceList} from './withReverseReferenceList.js';
 export {default as withThingsSortedAlphabetically} from './withThingsSortedAlphabetically.js';

--- a/src/data/composite/wiki-data/withReverseContributionList.js
+++ b/src/data/composite/wiki-data/withReverseContributionList.js
@@ -1,9 +1,9 @@
-// Analogous implementation for withReverseReferenceList, but contributions.
+// Analogous implementation for withReverseReferenceList, for contributions.
+// This is all duplicate code and both should be ported to the same underlying
+// data form later on.
 //
 // This implementation uses a global cache (via WeakMap) to attempt to speed
-// up subsequent similar accesses. Reverse contribution lists are the most
-// costly in live-dev-server, but we intend to expand the impelemntation here
-// to reverse reference lists in general later on.
+// up subsequent similar accesses.
 //
 // This has absolutely not been rigorously tested with altering properties of
 // data objects in a wiki data array which is reused. If a new wiki data array
@@ -57,6 +57,10 @@ export default templateCompositeFrom({
 
           for (const referencingThing of data) {
             const referenceList = referencingThing[list];
+
+            // Destructuring {who} is the only unique part of the
+            // withReverseContributionList implementation, compared to
+            // withReverseReferneceList.
             for (const {who: referencedThing} of referenceList) {
               if (cacheRecord.has(referencedThing)) {
                 cacheRecord.get(referencedThing).push(referencingThing);

--- a/src/data/composite/wiki-data/withReverseContributionList.js
+++ b/src/data/composite/wiki-data/withReverseContributionList.js
@@ -1,0 +1,45 @@
+// Analogous implementation for withReverseReferenceList, but contributions.
+//
+// This implementation uses a global cache (via WeakMap) to attempt to speed
+// up subsequent similar accesses. Reverse contribution lists are the most
+// costly in live-dev-server, but we intend to expand the impelemntation here
+// to reverse reference lists in general later on.
+
+import {input, templateCompositeFrom} from '#composite';
+
+import {exitWithoutDependency} from '#composite/control-flow';
+
+import inputWikiData from './inputWikiData.js';
+
+export default templateCompositeFrom({
+  annotation: `withReverseContributionList`,
+
+  inputs: {
+    data: inputWikiData({allowMixedTypes: false}),
+    list: input({type: 'string'}),
+  },
+
+  outputs: ['#reverseContributionList'],
+
+  steps: () => [
+    exitWithoutDependency({
+      dependency: input('data'),
+      value: input.value([]),
+      mode: input.value('empty'),
+    }),
+
+    {
+      dependencies: [input.myself(), input('data'), input('list')],
+
+      compute: (continuation, {
+        [input.myself()]: myself,
+        [input('data')]: data,
+        [input('list')]: list,
+      }) =>
+        continuation({
+          ['#reverseContributionList']:
+            data.filter(thing => thing[list].some(({who}) => who === myself)),
+        }),
+    },
+  ],
+});

--- a/src/data/composite/wiki-data/withReverseReferenceList.js
+++ b/src/data/composite/wiki-data/withReverseReferenceList.js
@@ -1,11 +1,27 @@
 // Check out the info on reverseReferenceList!
 // This is its composable form.
+//
+// This implementation uses a global cache (via WeakMap) to attempt to speed
+// up subsequent similar accesses.
+//
+// This has absolutely not been rigorously tested with altering properties of
+// data objects in a wiki data array which is reused. If a new wiki data array
+// is used, a fresh cache will always be created.
+//
+// Note that this implementation is mirrored in withReverseContributionList,
+// so any changes should be reflected there (until these are combined).
 
 import {input, templateCompositeFrom} from '#composite';
 
 import {exitWithoutDependency} from '#composite/control-flow';
 
 import inputWikiData from './inputWikiData.js';
+
+// Mapping of reference list property to WeakMap.
+// Each WeakMap maps a wiki data array to another weak map,
+// which in turn maps each referenced thing to an array of
+// things referencing it.
+const caches = new Map();
 
 export default templateCompositeFrom({
   annotation: `withReverseReferenceList`,
@@ -28,14 +44,38 @@ export default templateCompositeFrom({
       dependencies: [input.myself(), input('data'), input('list')],
 
       compute: (continuation, {
-        [input.myself()]: thisThing,
+        [input.myself()]: myself,
         [input('data')]: data,
-        [input('list')]: refListProperty,
-      }) =>
-        continuation({
+        [input('list')]: list,
+      }) => {
+        if (!caches.has(list)) {
+          caches.set(list, new WeakMap());
+        }
+
+        const cache = caches.get(list);
+
+        if (!cache.has(data)) {
+          const cacheRecord = new WeakMap();
+
+          for (const referencingThing of data) {
+            const referenceList = referencingThing[list];
+            for (const referencedThing of referenceList) {
+              if (cacheRecord.has(referencedThing)) {
+                cacheRecord.get(referencedThing).push(referencingThing);
+              } else {
+                cacheRecord.set(referencedThing, [referencingThing]);
+              }
+            }
+          }
+
+          cache.set(data, cacheRecord);
+        }
+
+        return continuation({
           ['#reverseReferenceList']:
-            data.filter(thing => thing[refListProperty].includes(thisThing)),
-        }),
+            cache.get(data).get(myself) ?? [],
+        });
+      },
     },
   ],
 });

--- a/src/data/composite/wiki-properties/index.js
+++ b/src/data/composite/wiki-properties/index.js
@@ -19,6 +19,7 @@ export {default as fileExtension} from './fileExtension.js';
 export {default as flag} from './flag.js';
 export {default as name} from './name.js';
 export {default as referenceList} from './referenceList.js';
+export {default as reverseContributionList} from './reverseContributionList.js';
 export {default as reverseReferenceList} from './reverseReferenceList.js';
 export {default as simpleDate} from './simpleDate.js';
 export {default as simpleString} from './simpleString.js';

--- a/src/data/composite/wiki-properties/reverseContributionList.js
+++ b/src/data/composite/wiki-properties/reverseContributionList.js
@@ -1,0 +1,24 @@
+import {input, templateCompositeFrom} from '#composite';
+
+import {exposeDependency} from '#composite/control-flow';
+import {inputWikiData, withReverseContributionList} from '#composite/wiki-data';
+
+export default templateCompositeFrom({
+  annotation: `reverseContributionList`,
+
+  compose: false,
+
+  inputs: {
+    data: inputWikiData({allowMixedTypes: false}),
+    list: input({type: 'string'}),
+  },
+
+  steps: () => [
+    withReverseContributionList({
+      data: input('data'),
+      list: input('list'),
+    }),
+
+    exposeDependency({dependency: '#reverseContributionList'}),
+  ],
+});

--- a/src/data/things/artist.js
+++ b/src/data/things/artist.js
@@ -8,10 +8,15 @@ import {
   fileExtension,
   flag,
   name,
+  reverseContributionList,
   singleReference,
   urls,
   wikiData,
 } from '#composite/wiki-properties';
+
+import {
+  withReverseContributionList,
+} from '#composite/wiki-data';
 
 import Thing from './thing.js';
 
@@ -64,28 +69,62 @@ export class Artist extends Thing {
 
     // Expose only
 
-    tracksAsArtist:
-      Artist.filterByContrib('trackData', 'artistContribs'),
-    tracksAsContributor:
-      Artist.filterByContrib('trackData', 'contributorContribs'),
-    tracksAsCoverArtist:
-      Artist.filterByContrib('trackData', 'coverArtistContribs'),
+    tracksAsArtist: reverseContributionList({
+      data: 'trackData',
+      list: input.value('artistContribs'),
+    }),
 
-    tracksAsAny: {
-      flags: {expose: true},
+    tracksAsContributor: reverseContributionList({
+      data: 'trackData',
+      list: input.value('contributorContribs'),
+    }),
 
-      expose: {
-        dependencies: ['this', 'trackData'],
+    tracksAsCoverArtist: reverseContributionList({
+      data: 'trackData',
+      list: input.value('coverArtistContribs'),
+    }),
 
-        compute: ({this: artist, trackData}) =>
-          trackData?.filter((track) =>
-            [
-              ...track.artistContribs ?? [],
-              ...track.contributorContribs ?? [],
-              ...track.coverArtistContribs ?? [],
-            ].some(({who}) => who === artist)) ?? [],
+    tracksAsAny: [
+      withReverseContributionList({
+        data: 'trackData',
+        list: input.value('artistContribs'),
+      }).outputs({
+        '#reverseContributionList': '#tracksAsArtist',
+      }),
+
+      withReverseContributionList({
+        data: 'trackData',
+        list: input.value('contributorContribs'),
+      }).outputs({
+        '#reverseContributionList': '#tracksAsContributor',
+      }),
+
+      withReverseContributionList({
+        data: 'trackData',
+        list: input.value('coverArtistContribs'),
+      }).outputs({
+        '#reverseContributionList': '#tracksAsCoverArtist',
+      }),
+
+      {
+        dependencies: [
+          '#tracksAsArtist',
+          '#tracksAsContributor',
+          '#tracksAsCoverArtist',
+        ],
+
+        compute: ({
+          ['#tracksAsArtist']: tracksAsArtist,
+          ['#tracksAsContributor']: tracksAsContributor,
+          ['#tracksAsCoverArtist']: tracksAsCoverArtist,
+        }) =>
+          unique([
+            ...tracksAsArtist,
+            ...tracksAsContributor,
+            ...tracksAsCoverArtist,
+          ]),
       },
-    },
+    ],
 
     tracksAsCommentator: {
       flags: {expose: true},
@@ -99,31 +138,77 @@ export class Artist extends Thing {
       },
     },
 
-    albumsAsAlbumArtist:
-      Artist.filterByContrib('albumData', 'artistContribs'),
-    albumsAsCoverArtist:
-      Artist.filterByContrib('albumData', 'coverArtistContribs'),
-    albumsAsWallpaperArtist:
-      Artist.filterByContrib('albumData', 'wallpaperArtistContribs'),
-    albumsAsBannerArtist:
-      Artist.filterByContrib('albumData', 'bannerArtistContribs'),
+    albumsAsAlbumArtist: reverseContributionList({
+      data: 'albumData',
+      list: input.value('artistContribs'),
+    }),
 
-    albumsAsAny: {
-      flags: {expose: true},
+    albumsAsCoverArtist: reverseContributionList({
+      data: 'albumData',
+      list: input.value('coverArtistContribs'),
+    }),
 
-      expose: {
-        dependencies: ['albumData'],
+    albumsAsWallpaperArtist: reverseContributionList({
+      data: 'albumData',
+      list: input.value('wallpaperArtistContribs'),
+    }),
 
-        compute: ({albumData, [Artist.instance]: artist}) =>
-          albumData?.filter((album) =>
-            [
-              ...album.artistContribs,
-              ...album.coverArtistContribs,
-              ...album.wallpaperArtistContribs,
-              ...album.bannerArtistContribs,
-            ].some(({who}) => who === artist)) ?? [],
+    albumsAsBannerArtist: reverseContributionList({
+      data: 'albumData',
+      list: input.value('bannerArtistContribs'),
+    }),
+
+    albumsAsAny: [
+      withReverseContributionList({
+        data: 'albumData',
+        list: input.value('artistContribs'),
+      }).outputs({
+        '#reverseContributionList': '#albumsAsArtist',
+      }),
+
+      withReverseContributionList({
+        data: 'albumData',
+        list: input.value('coverArtistContribs'),
+      }).outputs({
+        '#reverseContributionList': '#albumsAsCoverArtist',
+      }),
+
+      withReverseContributionList({
+        data: 'albumData',
+        list: input.value('wallpaperArtistContribs'),
+      }).outputs({
+        '#reverseContributionList': '#albumsAsWallpaperArtist',
+      }),
+
+      withReverseContributionList({
+        data: 'albumData',
+        list: input.value('bannerArtistContribs'),
+      }).outputs({
+        '#reverseContributionList': '#albumsAsBannerArtist',
+      }),
+
+      {
+        dependencies: [
+          '#albumsAsArtist',
+          '#albumsAsCoverArtist',
+          '#albumsAsWallpaperArtist',
+          '#albumsAsBannerArtist',
+        ],
+
+        compute: ({
+          ['#albumsAsArtist']: albumsAsArtist,
+          ['#albumsAsCoverArtist']: albumsAsCoverArtist,
+          ['#albumsAsWallpaperArtist']: albumsAsWallpaperArtist,
+          ['#albumsAsBannerArtist']: albumsAsBannerArtist,
+        }) =>
+          unique([
+            ...albumsAsArtist,
+            ...albumsAsCoverArtist,
+            ...albumsAsWallpaperArtist,
+            ...albumsAsBannerArtist,
+          ]),
       },
-    },
+    ],
 
     albumsAsCommentator: {
       flags: {expose: true},
@@ -137,8 +222,10 @@ export class Artist extends Thing {
       },
     },
 
-    flashesAsContributor:
-      Artist.filterByContrib('flashData', 'contributorContribs'),
+    flashesAsContributor: reverseContributionList({
+      data: 'flashData',
+      list: input.value('contributorContribs'),
+    }),
   });
 
   static [Thing.getSerializeDescriptors] = ({
@@ -166,21 +253,5 @@ export class Artist extends Thing {
     albumsAsCommentator: S.toRefs,
 
     flashesAsContributor: S.toRefs,
-  });
-
-  static filterByContrib = (thingDataProperty, contribsProperty) => ({
-    flags: {expose: true},
-
-    expose: {
-      dependencies: ['this', thingDataProperty],
-
-      compute: ({
-        this: artist,
-        [thingDataProperty]: thingData,
-      }) =>
-        thingData?.filter(thing =>
-          thing[contribsProperty]
-            ?.some(contrib => contrib.who === artist)) ?? [],
-    },
   });
 }

--- a/src/data/things/artist.js
+++ b/src/data/things/artist.js
@@ -9,6 +9,7 @@ import {
   flag,
   name,
   reverseContributionList,
+  reverseReferenceList,
   singleReference,
   urls,
   wikiData,
@@ -126,17 +127,10 @@ export class Artist extends Thing {
       },
     ],
 
-    tracksAsCommentator: {
-      flags: {expose: true},
-
-      expose: {
-        dependencies: ['this', 'trackData'],
-
-        compute: ({this: artist, trackData}) =>
-          trackData?.filter(({commentatorArtists}) =>
-            commentatorArtists.includes(artist)) ?? [],
-      },
-    },
+    tracksAsCommentator: reverseReferenceList({
+      data: 'trackData',
+      list: input.value('commentatorArtists'),
+    }),
 
     albumsAsAlbumArtist: reverseContributionList({
       data: 'albumData',
@@ -210,17 +204,10 @@ export class Artist extends Thing {
       },
     ],
 
-    albumsAsCommentator: {
-      flags: {expose: true},
-
-      expose: {
-        dependencies: ['this', 'albumData'],
-
-        compute: ({this: artist, albumData}) =>
-          albumData?.filter(({commentatorArtists}) =>
-            commentatorArtists.includes(artist)) ?? [],
-      },
-    },
+    albumsAsCommentator: reverseReferenceList({
+      data: 'albumData',
+      list: input.value('commentatorArtists'),
+    }),
 
     flashesAsContributor: reverseContributionList({
       data: 'flashData',

--- a/src/data/yaml.js
+++ b/src/data/yaml.js
@@ -1514,18 +1514,7 @@ export async function loadAndProcessDataDocuments({dataPath}) {
 // Data linking! Basically, provide (portions of) wikiData to the Things which
 // require it - they'll expose dynamically computed properties as a result (many
 // of which are required for page HTML generation and other expected behavior).
-//
-// The XXX_decacheWikiData option should be used specifically to mark
-// points where you *aren't* replacing any of the arrays under wikiData with
-// new values, and are using linkWikiDataArrays to instead "decache" data
-// properties which depend on any of them. It's currently not possible for
-// a CacheableObject to depend directly on the value of a property exposed
-// on some other CacheableObject, so when those values change, you have to
-// manually decache before the object will realize its cache isn't valid
-// anymore.
-export function linkWikiDataArrays(wikiData, {
-  XXX_decacheWikiData = false,
-} = {}) {
+export function linkWikiDataArrays(wikiData) {
   const linkWikiDataSpec = new Map([
     [wikiData.albumData, [
       'artTagData',
@@ -1588,7 +1577,6 @@ export function linkWikiDataArrays(wikiData, {
       if (thing === undefined) continue;
       for (const key of keys) {
         if (!(key in wikiData)) continue;
-        if (XXX_decacheWikiData) thing[key] = [];
         thing[key] = wikiData[key];
       }
     }

--- a/src/page/artist.js
+++ b/src/page/artist.js
@@ -1,5 +1,7 @@
 import {empty} from '#sugar';
 
+import CacheableObject from '#cacheable-object';
+
 export const description = `per-artist info & artwork gallery pages`;
 
 // NB: See artist-alias.js for artist alias redirect pages.

--- a/src/upd8.js
+++ b/src/upd8.js
@@ -1051,7 +1051,7 @@ async function main() {
         // Needed for sorting
         'date', 'tracks',
         // Needed for computing page paths
-        'commentary',
+        'commentary', 'coverArtistContribs',
       ]),
 
       artTagData: new Set([
@@ -1088,7 +1088,7 @@ async function main() {
         // Needed for sorting
         'album', 'date',
         // Needed for computing page paths
-        'commentary',
+        'commentary', 'coverArtistContribs',
       ]),
     };
 

--- a/test/lib/wiki-data.js
+++ b/test/lib/wiki-data.js
@@ -1,12 +1,17 @@
 import CacheableObject from '#cacheable-object';
 import find from '#find';
+import {withEntries} from '#sugar';
 import {linkWikiDataArrays} from '#yaml';
 
 export function linkAndBindWikiData(wikiData, {
   inferAlbumsOwnTrackData = true,
 } = {}) {
-  function customLinkWikiDataArrays(...args) {
-    linkWikiDataArrays(...args);
+  function customLinkWikiDataArrays(wikiData, options = {}) {
+    linkWikiDataArrays(
+      (options.XXX_decacheWikiData
+        ? withEntries(wikiData, entries => entries
+            .map(([key, value]) => [key, value.slice()]))
+        : wikiData));
 
     // If albumData is present, automatically set albums' ownTrackData values
     // by resolving track sections' references against the full array. This is
@@ -43,7 +48,23 @@ export function linkAndBindWikiData(wikiData, {
 
     // Use this if you HAVEN'T mutated wikiData and just need to decache
     // indirect dependencies on exposed properties of other data objects.
-    // See documentation on linkWikiDataArarys (in yaml.js) for more info.
+    //
+    // XXX_decacheWikiData option should be used specifically to mark points
+    // where you *aren't* replacing any of the arrays under wikiData with
+    // new values, and are using linkWikiDataArrays to instead "decache" data
+    // properties which depend on any of them. It's currently not possible for
+    // a CacheableObject to depend directly on the value of a property exposed
+    // on some other CacheableObject, so when those values change, you have to
+    // manually decache before the object will realize its cache isn't valid
+    // anymore.
+    //
+    // The previous implementation for this involved overwriting the relevant
+    // wikiData properties with null, then replacing it with the original
+    // array, which effectively cleared a CacheableObject cache. But it isn't
+    // enough to clear other caches that depend on the identity of wikiData
+    // arrays, such as withReverseReferenceList, so now it replaces with fresh
+    // copies of the data arrays instead; the original identities don't get
+    // reused.
     XXX_decacheWikiData:
       customLinkWikiDataArrays
         .bind(null, wikiData, {XXX_decacheWikiData: true}),


### PR DESCRIPTION
This PR does several things:

* Add a new `reverseContributionList` (and `withReverseContributionList`) function based on `reverseReferenceList`, and port existing uses of `Artist.filterByContrib` over to that instead.
* Also port custom behavior for `tracksAsCommentator`/`albumsAsCommentator` to `reverseReferenceList`, since that accomplishes the same behavior.
* Implement new caching behavior, for now manually duplicated between reverse reference/contribution lists, which caches all the results pertaining to a particular list property (e.g. `artistContribs` or `sampledTracks`) for each wiki data list containing the referencing objects (e.g. `trackData`). This uses weak maps quite similarly to `#find`. Processing is only performed once for a given wiki data array + list property combo.
  * We'd like to generalize contributions and references into a more general format, supporting references with and without annotations (and possibly other data) in the same format/shape. At the moment these are shaped slightly differently in a manner that hits internal code (`ref` vs `ref.who`), so get separate, mostly duplicate functions.
* Update the test framework's `XXX_decacheWikiData` utility to replace wiki data arrays with completely new identities, rather than just tricking `CacheableObject` into thinking its old cache should be dropped. This was necessary to ensure new references would be computed in `withReveseReferenceList` (etc). This changes the semantic meaning of `XXX_decacheWikiData` in a fairly significant way, though it's to the same effect as existing uses, and squirrels testing-specific code out of `#yaml` and into `#test-lib`.
* Compute `coverArtistContribs` as part of the `precacheCommonData` upd8 step, as it's used for computing page paths (see below).

Reverse reference lists, needed for identifying if artists should have gallery pages, are by far the most expensive part of computing page paths. That's a necessary step in any build, but has a big impact on live-dev-server, where a step that previously took around 5–6 seconds now takes around 1–1.5 seconds. Computing page paths has to happen every time the live-dev-server restarts, so this is a pretty big speed-up!
