### PR TITLE
data: fix missing unique import

### DIFF
--- a/src/data/things/artist.js
+++ b/src/data/things/artist.js
@@ -1,5 +1,6 @@
 import {input} from '#composite';
 import find from '#find';
+import {unique} from '#sugar';
 import {isName, validateArrayItems} from '#validators';
 
 import {


### PR DESCRIPTION
https://github.com/hsmusic/hsmusic-wiki/commit/301ed2a12f4716a85359b6cb50462e415539553f added a call to `unique` in artist.js, but didn't actually import it from `#sugar`.