### PR TITLE
Group info page: "Other group" logic improvements

### DIFF
--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -1098,7 +1098,7 @@ groupInfoPage:
         {YEAR_ACCENT} {ALBUM} {OTHER_GROUP_ACCENT}
 
       yearAccent: "({YEAR})"
-      otherGroupAccent:  "(from {GROUP})"
+      otherGroupAccent:  "(from {GROUPS})"
 
 #
 # groupGalleryPage:


### PR DESCRIPTION
This PR tweaks the "from (some other group)" element on group info pages, mostly to improve support albums belonging to two or more groups of the same category (e.g. "Solo musicians"). Details:

* We no longer display groups from the same category as the current group belongs to. (We select the first non-same group, top-down, same direction as before.)
* We'll now display more than one group from the same category, if applicable. (That is, if the album belongs to multiple groups under the category selected above.)

Examples:

<img width="471" alt="Albums from the Official Discography, such as Hiveswap Act 1 OST (from James Roach and Toby Fox)" src="https://github.com/hsmusic/hsmusic-wiki/assets/9948030/5fcfe9dd-20fc-42a4-9136-95fce7ec5739">

<img width="483" alt="Albums from James Roach, such as Hiveswap Act 1 OST (from Official Discography)" src="https://github.com/hsmusic/hsmusic-wiki/assets/9948030/ed2fb47d-3815-468a-a0ae-593a415ad02b">
