### PR TITLE
Tweak sticky sidebar heading material & give it a shadow

### DIFF
--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -1930,8 +1930,12 @@ main.long-content .content-sticky-heading-container .content-sticky-subheading-r
   padding: 10px 5px;
 
   background: var(--bg-black-color);
-  -webkit-backdrop-filter: blur(3px);
-  backdrop-filter: blur(3px);
+  -webkit-backdrop-filter: blur(4px);
+  backdrop-filter: blur(4px);
+
+  box-shadow:
+    0 2px 3px -1px #0006,
+    0 4px 8px -2px #0009;
 }
 
 /* Image overlay */


### PR DESCRIPTION
As described! This is a raised element that we missed previously, so was missing a shadow. This shadow is mostly pulled from the sticky subheading, just a little less pronounced, and we've also increased the material blur from 3px to 4px to match the sticky subheading.