### PR TITLE
Configure "find" behavior on Thing classes

### DIFF
--- a/src/content/dependencies/listArtistsByCommentaryEntries.js
+++ b/src/content/dependencies/listArtistsByCommentaryEntries.js
@@ -10,7 +10,10 @@ export default {
   },
 
   query({artistData}, spec) {
-    const artists = sortAlphabetically(artistData.slice());
+    const artists =
+      sortAlphabetically(
+        artistData.filter(artist => !artist.isAlias));
+
     const counts =
       artists.map(artist =>
         artist.tracksAsCommentator.length +

--- a/src/content/dependencies/listArtistsByContributions.js
+++ b/src/content/dependencies/listArtistsByContributions.js
@@ -25,8 +25,12 @@ export default {
     };
 
     const queryContributionInfo = (artistsKey, countsKey, fn) => {
-      const artists = sortAlphabetically(sprawl.artistData.slice());
-      const counts = artists.map(artist => fn(artist));
+      const artists =
+        sortAlphabetically(
+          sprawl.artistData.filter(artist => !artist.isAlias));
+
+      const counts =
+        artists.map(artist => fn(artist));
 
       filterByCount(artists, counts);
       sortByCount(artists, counts, {greatestFirst: true});

--- a/src/content/dependencies/listArtistsByDuration.js
+++ b/src/content/dependencies/listArtistsByDuration.js
@@ -10,12 +10,16 @@ export default {
   },
 
   query({artistData}, spec) {
-    const artists = sortAlphabetically(artistData.slice());
-    const durations = artists.map(artist =>
-      getTotalDuration([
-        ...(artist.tracksAsArtist ?? []),
-        ...(artist.tracksAsContributor ?? []),
-      ], {originalReleasesOnly: true}));
+    const artists =
+      sortAlphabetically(
+        artistData.filter(artist => !artist.isAlias));
+
+    const durations =
+      artists.map(artist =>
+        getTotalDuration([
+          ...(artist.tracksAsArtist ?? []),
+          ...(artist.tracksAsContributor ?? []),
+        ], {originalReleasesOnly: true}));
 
     filterByCount(artists, durations);
     sortByCount(artists, durations, {greatestFirst: true});

--- a/src/content/dependencies/listArtistsByGroup.js
+++ b/src/content/dependencies/listArtistsByGroup.js
@@ -15,8 +15,12 @@ export default {
   },
 
   query(sprawl, spec) {
-    const artists = sortAlphabetically(sprawl.artistData.slice());
-    const groups = sprawl.wikiInfo.divideTrackListsByGroups;
+    const artists =
+      sortAlphabetically(
+        sprawl.artistData.filter(artist => !artist.isAlias));
+
+    const groups =
+      sprawl.wikiInfo.divideTrackListsByGroups;
 
     if (empty(groups)) {
       return {spec, artists};

--- a/src/content/dependencies/listArtistsByLatestContribution.js
+++ b/src/content/dependencies/listArtistsByLatestContribution.js
@@ -145,7 +145,8 @@ export default {
     //
 
     const artistsAlphabetically =
-      sortAlphabetically(sprawl.artistData.slice());
+      sortAlphabetically(
+        sprawl.artistData.filter(artist => !artist.isAlias));
 
     const artists =
       Array.from(artistLatestContribMap.keys());

--- a/src/content/dependencies/listArtistsByName.js
+++ b/src/content/dependencies/listArtistsByName.js
@@ -12,7 +12,8 @@ export default {
     spec,
 
     artists:
-      sortAlphabetically(sprawl.artistData.slice()),
+      sortAlphabetically(
+        sprawl.artistData.filter(artist => !artist.isAlias)),
   }),
 
   relations: (relation, query) => ({

--- a/src/data/thing.js
+++ b/src/data/thing.js
@@ -13,6 +13,7 @@ export default class Thing extends CacheableObject {
   static getPropertyDescriptors = Symbol.for('Thing.getPropertyDescriptors');
   static getSerializeDescriptors = Symbol.for('Thing.getSerializeDescriptors');
 
+  static findSpecs = Symbol.for('Thing.findSpecs');
   static yamlDocumentSpec = Symbol.for('Thing.yamlDocumentSpec');
   static getYamlLoadingSpec = Symbol.for('Thing.getYamlLoadingSpec');
 

--- a/src/data/things/album.js
+++ b/src/data/things/album.js
@@ -207,6 +207,13 @@ export class Album extends Thing {
     commentatorArtists: S.toRefs,
   });
 
+  static [Thing.findSpecs] = {
+    album: {
+      referenceTypes: ['album', 'album-commentary', 'album-gallery'],
+      bindTo: 'albumData',
+    },
+  };
+
   static [Thing.yamlDocumentSpec] = {
     fields: {
       'Album': {property: 'name'},

--- a/src/data/things/art-tag.js
+++ b/src/data/things/art-tag.js
@@ -65,6 +65,18 @@ export class ArtTag extends Thing {
     },
   });
 
+  static [Thing.findSpecs] = {
+    artTag: {
+      referenceTypes: ['tag'],
+      bindTo: 'artTagData',
+
+      getMatchableNames: tag =>
+        (tag.isContentWarning
+          ? [`cw: ${tag.name}`]
+          : [tag.name]),
+    },
+  };
+
   static [Thing.yamlDocumentSpec] = {
     fields: {
       'Tag': {property: 'name'},

--- a/src/data/things/artist.js
+++ b/src/data/things/artist.js
@@ -1,5 +1,9 @@
 export const ARTIST_DATA_FILE = 'artists.yaml';
 
+import {inspect} from 'node:util';
+
+import CacheableObject from '#cacheable-object';
+import {colors} from '#cli';
 import {input} from '#composite';
 import find from '#find';
 import {unique} from '#sugar';
@@ -294,4 +298,25 @@ export class Artist extends Thing {
       sortAlphabetically(artistAliasData);
     },
   });
+
+  [inspect.custom]() {
+    const parts = [];
+
+    parts.push(Thing.prototype[inspect.custom].apply(this));
+
+    if (CacheableObject.getUpdateValue(this, 'isAlias')) {
+      parts.unshift(`${colors.yellow('[alias]')} `);
+
+      let aliasedArtist;
+      try {
+        aliasedArtist = this.aliasedArtist.name;
+      } catch (_error) {
+        aliasedArtist = CacheableObject.getUpdateValue(this, 'aliasedArtist');
+      }
+
+      parts.push(` ${colors.yellow(`[of ${aliasedArtist}]`)}`);
+    }
+
+    return parts.join('');
+  }
 }

--- a/src/data/things/flash.js
+++ b/src/data/things/flash.js
@@ -130,6 +130,13 @@ export class Flash extends Thing {
     color: S.id,
   });
 
+  static [Thing.findSpecs] = {
+    flash: {
+      referenceTypes: ['flash'],
+      bindTo: 'flashData',
+    },
+  };
+
   static [Thing.yamlDocumentSpec] = {
     fields: {
       'Flash': {property: 'name'},
@@ -192,6 +199,13 @@ export class FlashAct extends Thing {
       class: input.value(Flash),
     }),
   });
+
+  static [Thing.findSpecs] = {
+    flashAct: {
+      referenceTypes: ['flash-act'],
+      bindTo: 'flashActData',
+    },
+  };
 
   static [Thing.yamlDocumentSpec] = {
     fields: {

--- a/src/data/things/group.js
+++ b/src/data/things/group.js
@@ -87,6 +87,13 @@ export class Group extends Thing {
     },
   });
 
+  static [Thing.findSpecs] = {
+    group: {
+      referenceTypes: ['group', 'group-gallery'],
+      bindTo: 'groupData',
+    },
+  };
+
   static [Thing.yamlDocumentSpec] = {
     fields: {
       'Group': {property: 'name'},

--- a/src/data/things/news-entry.js
+++ b/src/data/things/news-entry.js
@@ -33,6 +33,13 @@ export class NewsEntry extends Thing {
     },
   });
 
+  static [Thing.findSpecs] = {
+    newsEntry: {
+      referenceTypes: ['news-entry'],
+      bindTo: 'newsData',
+    },
+  };
+
   static [Thing.yamlDocumentSpec] = {
     fields: {
       'Name': {property: 'name'},

--- a/src/data/things/static-page.js
+++ b/src/data/things/static-page.js
@@ -35,6 +35,13 @@ export class StaticPage extends Thing {
     script: simpleString(),
   });
 
+  static [Thing.findSpecs] = {
+    staticPage: {
+      referenceTypes: ['static'],
+      bindTo: 'staticPageData',
+    },
+  };
+
   static [Thing.yamlDocumentSpec] = {
     fields: {
       'Name': {property: 'name'},

--- a/src/data/things/track.js
+++ b/src/data/things/track.js
@@ -451,6 +451,35 @@ export class Track extends Thing {
     ],
   };
 
+  static [Thing.findSpecs] = {
+    track: {
+      referenceTypes: ['track'],
+      bindTo: 'trackData',
+
+      getMatchableNames: track =>
+        (track.alwaysReferenceByDirectory
+          ? []
+          : [track.name]),
+    },
+
+    trackOriginalReleasesOnly: {
+      referenceTypes: ['track'],
+      bindTo: 'trackData',
+
+      include: track =>
+        !CacheableObject.getUpdateValue(track, 'originalReleaseTrack'),
+
+      // It's still necessary to check alwaysReferenceByDirectory here, since
+      // it may be set manually (with `Always Reference By Directory: true`),
+      // and these shouldn't be matched by name (as per usual).
+      // See the definition for that property for more information.
+      getMatchableNames: track =>
+        (track.alwaysReferenceByDirectory
+          ? []
+          : [track.name]),
+    },
+  };
+
   // Track YAML loading is handled in album.js.
   static [Thing.getYamlLoadingSpec] = null;
 

--- a/src/data/yaml.js
+++ b/src/data/yaml.js
@@ -1023,7 +1023,7 @@ export function reportDuplicateDirectories(wikiData) {
   const aggregate = openAggregate({message: `Duplicate directories found`});
   for (const thingDataProp of deduplicateSpec) {
     const thingData = wikiData[thingDataProp];
-    aggregate.nest({message: `Duplicate directories found in ${colors.green('wikiData.' + thingDataProp)}`}, ({call}) => {
+    aggregate.nest({message: `Duplicate directories found in ${colors.green('wikiData.' + thingDataProp)}`}, ({push}) => {
       const directoryPlaces = Object.create(null);
       const duplicateDirectories = new Set();
 
@@ -1049,11 +1049,9 @@ export function reportDuplicateDirectories(wikiData) {
 
       for (const directory of sortedDuplicateDirectories) {
         const places = directoryPlaces[directory];
-        call(() => {
-          throw new Error(
-            `Duplicate directory ${colors.green(directory)}:\n` +
-            places.map(thing => ` - ` + inspect(thing)).join('\n'));
-        });
+        push(new Error(
+          `Duplicate directory ${colors.green(directory)}:\n` +
+          places.map(thing => ` - ` + inspect(thing)).join('\n')));
       }
     });
   }

--- a/src/data/yaml.js
+++ b/src/data/yaml.js
@@ -1028,13 +1028,13 @@ export function filterDuplicateDirectories(wikiData) {
     const thingData = wikiData[thingDataProp];
     aggregate.nest({message: `Duplicate directories found in ${colors.green('wikiData.' + thingDataProp)}`}, ({call}) => {
       const directoryPlaces = Object.create(null);
-      const duplicateDirectories = [];
+      const duplicateDirectories = new Set();
 
       for (const thing of thingData) {
         const {directory} = thing;
         if (directory in directoryPlaces) {
           directoryPlaces[directory].push(thing);
-          duplicateDirectories.push(directory);
+          duplicateDirectories.add(directory);
         } else {
           directoryPlaces[directory] = [thing];
         }
@@ -1042,13 +1042,15 @@ export function filterDuplicateDirectories(wikiData) {
 
       if (empty(duplicateDirectories)) return;
 
-      duplicateDirectories.sort((a, b) => {
-        const aL = a.toLowerCase();
-        const bL = b.toLowerCase();
-        return aL < bL ? -1 : aL > bL ? 1 : 0;
-      });
+      const sortedDuplicateDirectories =
+        Array.from(duplicateDirectories)
+          .sort((a, b) => {
+            const aL = a.toLowerCase();
+            const bL = b.toLowerCase();
+            return aL < bL ? -1 : aL > bL ? 1 : 0;
+          });
 
-      for (const directory of duplicateDirectories) {
+      for (const directory of sortedDuplicateDirectories) {
         const places = directoryPlaces[directory];
         call(() => {
           throw new Error(

--- a/src/find.js
+++ b/src/find.js
@@ -23,6 +23,11 @@ export function processAllAvailableMatches(data, {
     (Object.hasOwn(thing, 'name')
       ? [thing.name]
       : []),
+
+  getMatchableDirectories = thing =>
+    (Object.hasOwn(thing, 'directory')
+      ? [thing.directory]
+      : [null]),
 } = {}) {
   const byName = Object.create(null);
   const byDirectory = Object.create(null);
@@ -31,7 +36,14 @@ export function processAllAvailableMatches(data, {
   for (const thing of data) {
     if (!include(thing)) continue;
 
-    byDirectory[thing.directory] = thing;
+    for (const directory of getMatchableDirectories(thing)) {
+      if (typeof directory !== 'string') {
+        logWarn`Unexpected ${typeAppearance(directory)} returned in directories for ${inspect(thing)}`;
+        continue;
+      }
+
+      byDirectory[directory] = thing;
+    }
 
     for (const name of getMatchableNames(thing)) {
       if (typeof name !== 'string') {

--- a/src/find.js
+++ b/src/find.js
@@ -3,6 +3,7 @@ import {inspect} from 'node:util';
 import CacheableObject from '#cacheable-object';
 import {colors, logWarn} from '#cli';
 import {typeAppearance} from '#sugar';
+import {getKebabCase} from '#wiki-data';
 
 function warnOrThrow(mode, message) {
   if (mode === 'error') {
@@ -161,6 +162,50 @@ const find = {
 
   artistIncludingAliases: findHelper({
     referenceTypes: ['artist', 'artist-gallery'],
+
+    getMatchableDirectories(artist) {
+      // Regular artists are always matchable by their directory.
+      if (!artist.isAlias) {
+        return [artist.directory];
+      }
+
+      const originalArtist = artist.aliasedArtist;
+
+      // Aliases never match by the same directory as the original.
+      if (artist.directory === originalArtist.directory) {
+        return [];
+      }
+
+      // Aliases never match by the same directory as some *previous* alias
+      // in the original's alias list. This is honestly a bit awkward, but it
+      // avoids artist aliases conflicting with each other when checking for
+      // duplicate directories.
+      for (const aliasName of originalArtist.aliasNames) {
+        // These are trouble. We should be accessing aliases' directories
+        // directly, but artists currently don't expose a reverse reference
+        // list for aliases. (This is pending a cleanup of "reverse reference"
+        // behavior in general.) It doesn't actually cause problems *here*
+        // because alias directories are computed from their names 100% of the
+        // time, but that *is* an assumption this code makes.
+        if (aliasName === artist.name) continue;
+        if (artist.directory === getKebabCase(aliasName)) {
+          return [];
+        }
+      }
+
+      // And, aliases never return just a blank string. This part is pretty
+      // spooky because it doesn't handle two differently named aliases, on
+      // different artists, who have names that are similar *apart* from a
+      // character that's shortened. But that's also so fundamentally scary
+      // that we can't support it properly with existing code, anyway - we
+      // would need to be able to specifically set a directory *on an alias,*
+      // which currently can't be done in YAML data files.
+      if (artist.directory === '') {
+        return [];
+      }
+
+      return [artist.directory];
+    },
   }),
 
   artTag: findHelper({

--- a/src/find.js
+++ b/src/find.js
@@ -155,6 +155,12 @@ const find = {
 
   artist: findHelper({
     referenceTypes: ['artist', 'artist-gallery'],
+
+    include: artist => !artist.isAlias,
+  }),
+
+  artistIncludingAliases: findHelper({
+    referenceTypes: ['artist', 'artist-gallery'],
   }),
 
   artTag: findHelper({

--- a/src/page/artist-alias.js
+++ b/src/page/artist-alias.js
@@ -1,7 +1,7 @@
 export const description = `redirects for aliased artist names`;
 
 export function targets({wikiData}) {
-  return wikiData.artistAliasData;
+  return wikiData.artistData.filter(artist => artist.isAlias);
 }
 
 export function pathsForTarget(aliasArtist) {

--- a/src/page/artist.js
+++ b/src/page/artist.js
@@ -6,7 +6,7 @@ export const description = `per-artist info & artwork gallery pages`;
 
 // NB: See artist-alias.js for artist alias redirect pages.
 export function targets({wikiData}) {
-  return wikiData.artistData;
+  return wikiData.artistData.filter(artist => !artist.isAlias);
 }
 
 export function pathsForTarget(artist) {

--- a/src/upd8.js
+++ b/src/upd8.js
@@ -952,13 +952,20 @@ async function main() {
   Object.assign(wikiData, wikiDataResult);
 
   {
-    const logThings = (thingDataProp, label) =>
-      logInfo` - ${wikiData[thingDataProp]?.length ?? colors.red('(Missing!)')} ${colors.normal(colors.dim(label))}`;
+    const logThings = (prop, label) => {
+      const array =
+        (Array.isArray(prop)
+          ? prop
+          : wikiData[prop]);
+
+      logInfo` - ${array?.length ?? colors.red('(Missing!)')} ${colors.normal(colors.dim(label))}`;
+    }
+
     try {
       logInfo`Loaded data and processed objects:`;
       logThings('albumData', 'albums');
       logThings('trackData', 'tracks');
-      logThings('artistData', 'artists');
+      logThings(wikiData.artistData.filter(artist => !artist.isAlias), 'artists');
       if (wikiData.flashData) {
         logThings('flashData', 'flashes');
         logThings('flashActData', 'flash acts');
@@ -1050,17 +1057,12 @@ async function main() {
         // Needed for sorting
         'date', 'tracks',
         // Needed for computing page paths
-        'commentary', 'coverArtistContribs',
+        'aliasedArtist', 'commentary', 'coverArtistContribs',
       ]),
 
       artTagData: new Set([
         // Needed for computing page paths
         'isContentWarning',
-      ]),
-
-      artistAliasData: new Set([
-        // Needed for computing page paths
-        'aliasedArtist',
       ]),
 
       flashData: new Set([

--- a/src/upd8.js
+++ b/src/upd8.js
@@ -68,10 +68,10 @@ import genThumbs, {
 } from '#thumbs';
 
 import {
-  filterDuplicateDirectories,
   filterReferenceErrors,
   linkWikiDataArrays,
   loadAndProcessDataDocuments,
+  reportDuplicateDirectories,
   sortWikiDataArrays,
 } from '#yaml';
 
@@ -131,7 +131,7 @@ async function main() {
     precacheCommonData:
       {...defaultStepStatus, name: `precache common data`},
 
-    filterDuplicateDirectories:
+    reportDuplicateDirectories:
       {...defaultStepStatus, name: `filter duplicate directories`},
 
     filterReferenceErrors:
@@ -1110,19 +1110,16 @@ async function main() {
   // Filter out any things with duplicate directories throughout the data,
   // warning about them too.
 
-  Object.assign(stepStatusSummary.filterDuplicateDirectories, {
+  Object.assign(stepStatusSummary.reportDuplicateDirectories, {
     status: STATUS_STARTED_NOT_DONE,
     timeStart: Date.now(),
   });
 
-  const filterDuplicateDirectoriesAggregate =
-    filterDuplicateDirectories(wikiData);
-
   try {
-    filterDuplicateDirectoriesAggregate.close();
+    reportDuplicateDirectories(wikiData);
     logInfo`No duplicate directories found - nice!`;
 
-    Object.assign(stepStatusSummary.filterDuplicateDirectories, {
+    Object.assign(stepStatusSummary.reportDuplicateDirectories, {
       status: STATUS_DONE_CLEAN,
       timeEnd: Date.now(),
     });
@@ -1134,7 +1131,7 @@ async function main() {
     logWarn`correct, the build can't continue. Specify unique 'Directory' fields in`;
     logWarn`some or all of these data entries to resolve the errors.`;
 
-    Object.assign(stepStatusSummary.filterDuplicateDirectories, {
+    Object.assign(stepStatusSummary.reportDuplicateDirectories, {
       status: STATUS_FATAL_ERROR,
       annotation: `duplicate directories found`,
       timeEnd: Date.now(),

--- a/src/write/common-templates.js
+++ b/src/write/common-templates.js
@@ -46,10 +46,12 @@ export function generateRandomLinkDataJSON({wikiData}) {
 
     artistDirectories:
       artistData
+        .filter(artist => !artist.isAlias)
         .map(artist => artist.directory),
 
     artistNumContributions:
       artistData
+        .filter(artist => !artist.isAlias)
         .map(artist => getArtistNumContributions(artist)),
   });
 }


### PR DESCRIPTION
Yay! This is a follow-up to #386, and unlike that PR, it includes a few significant behavior changes.

- Resolves #389.
- Resolves #392.
- Resolves #393.

There are a lot of changes in this PR; it'd be split into separate ones if possible, but all the core changes work together and can't meaningfully be separated from each other.

* Remove hard-coded descriptions saved on `find` from `#find`, with one exception that doesn't actually correspond to any Thing subclass (`find.listing`).
* Remove hard-coded mapping of find function to data array in the `bindFind` utility function.
* Move the above information into a new property on Thing constructors, `[Thing.findSpecs]`, which may define multiple "find" functions. These definitions are in the same format as before, except with one new property: `bindTo` controls the wiki data array bound in `bindFind`.
  * `bindTo` is a string, not, say, a function of `wikiData`, because no complex filtering or logic should be performed here; it's purely for controlling `bindFind`. Filtering remains available through the `include` function on a find spec.
* Re-define `find` and `bindFind` in terms of `[Thing.findSpecs]`, working with new utility functions `getAllFindSpecs` and `findFindSpec`.
  * `find` is now a Freakin' Proxy, and actually the first (non-debug) use of proxies in HSMusic, despite us knowing about 'em for years! It's done this way so that references like `find.artist` still have meaning *before* the `Artist` class even exists. We *thought* this was crucial because `find` functions are very often referenced as part of a Thing constructor's `getPropertyDescriptors` phase... but, well, you know, the class constructors (including their static `[Thing.findSpecs]` value) *are* extant by that point... but it's kept this way anyway for reference and ready availability.
  * The only function of the `find` proxy is to facilitate getting a unique, reliable identity for functions like `find.album` before Thing constructors are actually ready. This function will error *when called* if Thing constructors still aren't ready, but its identity is available for static storage right away. We try to reduce general overhead as much as possible; the identity itself is just `(...args) => behavior(...args)`, where `behavior` replaces its own identifier with the usual output of `findHelper(spec)`, once that spec is actually available.
* Combine `artistData` and `artistAliasData` into one. This is analogous to how `artTagData` contains both normal art tags and content warnings; for consistency and simplicity, we're going with that. The usual `find.artist` function is adapted and will never match aliases, so stuff consuming that doesn't need to adapt at all, but listings and other data or content code that directly access `artistData` (or `artistAliasData`) now filter as appropriate, like uses of `artTagData`.
  * The main reason for this change, rather than *separating* `artTagData` into two arrays, is that artists and artist aliases share the same directory namespace — that's largely the point of aliases (at the moment), so that old URLs will redirect you to the right artist. It's trouble if an artist and an unrelated alias, or two unrelated aliases, share directories!
  * Aliases have some slightly funky logic for determining if their directory is matchable or not. See `artist.js` for details; the point is to avoid having conflicting directories where we already know the common directory belongs to the obviously correct original artist. (Two aliases sharing a computed directory is also OK and ignored, since both would end up redirecting to the original artist.) This is all a bit clunky and kind of counter to how directories are supposed to work anywhere else on the website, so there's absolutely room to revisit it later on, but this enables directory deduplication between artists and aliases while essentially preserving previous behavior.
* General minor cleanups.
  * `filterDuplicateDirectories` is renamed to `reportDuplicateDirectories` and has all of its filtering code removed, because as of 940b2cbf8b68eb0b446cca0feeb507840c486394 (no PR, sorry!?) we just cancel the build if any duplicate directories were found — filtering behavior isn't needed anymore. This also cleans up the way the internal aggregate error is handled — it's just closed and thrown like any normal aggregate-throwing function, and this is caught and displayed by `upd8.js`, instead of having upd8.js access and close the internal aggregate itself.
  * Artists now show if they're an alias (and if so, of whom) when inspected, which helps actually resolve duplicate artist/alias directories.