### PR TITLE
Fix Artists by Contributions when flashes are disabled

### DIFF
--- a/src/content/dependencies/listArtistsByContributions.js
+++ b/src/content/dependencies/listArtistsByContributions.js
@@ -107,21 +107,27 @@ export default {
   },
 
   generate(data, relations, {language}) {
-    const listChunkIDs = ['tracks', 'artworks', 'flashes'];
-    const listTitleStringsKeys = ['trackContributors', 'artContributors', 'flashContributors'];
-    const listCountFunctions = ['countTracks', 'countArtworks', 'countFlashes'];
+    const listChunkIDs = ['tracks', 'artworks'];
+    const listTitleStringsKeys = ['trackContributors', 'artContributors'];
+    const listCountFunctions = ['countTracks', 'countArtworks'];
 
     const listArtistLinks = [
       relations.artistLinksByTrackContributions,
       relations.artistLinksByArtworkContributions,
-      relations.artistLinksByFlashContributions,
     ];
 
     const listArtistCounts = [
       data.countsByTrackContributions,
       data.countsByArtworkContributions,
-      data.countsByFlashContributions,
     ];
+
+    if (data.enableFlashesAndGames) {
+      listChunkIDs.push('flashes');
+      listTitleStringsKeys.push('flashContributors');
+      listCountFunctions.push('countFlashes');
+      listArtistLinks.push(relations.artistLinksByFlashContributions);
+      listArtistCounts.push(data.countsByFlashContributions);
+    }
 
     filterMultipleArrays(
       listChunkIDs,


### PR DESCRIPTION
Previously on a wiki with no flashes:
```
2/5/2024, 04:46:01 PM [500] /list/artists/by-contribs/
Error in relation("listArtistsByContributions") called with args: [
  {
    directory: 'artists/by-contribs',
    stringsKey: 'listArtists.byContribs',
    contentFunction: 'listArtistsByContributions',
    seeAlso: [ [Object], [Object] ],
    target: { stringsKey: 'artist', listings: [Array] }
  }
] (no stack trace)
 ↪ Error generating content for listArtistsByContributions - listArtistsByContributions.js:126:5
    ↪ Expected array, set, or null
```