### PR TITLE
Provide fallback values when inheriting from original release

### DIFF
--- a/src/data/composite/things/track/inheritFromOriginalRelease.js
+++ b/src/data/composite/things/track/inheritFromOriginalRelease.js
@@ -3,6 +3,10 @@
 // dependencies provided. If allowOverride is true, then the continuation
 // will also be called if the original release exposed the requested
 // property as null.
+//
+// Like withOriginalRelease, this will early exit (with notFoundValue) if the
+// original release is specified by reference and that reference doesn't
+// resolve to anything.
 
 import {input, templateCompositeFrom} from '#composite';
 
@@ -14,10 +18,13 @@ export default templateCompositeFrom({
   inputs: {
     property: input({type: 'string'}),
     allowOverride: input({type: 'boolean', defaultValue: false}),
+    notFoundValue: input({defaultValue: null}),
   },
 
   steps: () => [
-    withOriginalRelease(),
+    withOriginalRelease({
+      notFoundValue: input('notFoundValue'),
+    }),
 
     {
       dependencies: [

--- a/src/data/composite/things/track/withOriginalRelease.js
+++ b/src/data/composite/things/track/withOriginalRelease.js
@@ -1,9 +1,8 @@
 // Just includes the original release of this track as a dependency.
 // If this track isn't a rerelease, then it'll provide null, unless the
 // {selfIfOriginal} option is set, in which case it'll provide this track
-// itself. Note that this will early exit if the original release is
-// specified by reference and that reference doesn't resolve to anything.
-// Outputs to '#originalRelease' by default.
+// itself. This will early exit (with notFoundValue) if the original release
+// is specified by reference and that reference doesn't resolve to anything.
 
 import {input, templateCompositeFrom} from '#composite';
 import find from '#find';
@@ -23,6 +22,8 @@ export default templateCompositeFrom({
       validate: validateWikiData({referenceType: 'track'}),
       defaultDependency: 'trackData',
     }),
+
+    notFoundValue: input({defaultValue: null}),
   },
 
   outputs: ['#originalRelease'],
@@ -60,6 +61,7 @@ export default templateCompositeFrom({
 
     exitWithoutDependency({
       dependency: '#resolvedReference',
+      value: input('notFoundValue'),
     }),
 
     {

--- a/src/data/composite/things/track/withOtherReleases.js
+++ b/src/data/composite/things/track/withOtherReleases.js
@@ -17,6 +17,7 @@ export default templateCompositeFrom({
 
     withOriginalRelease({
       selfIfOriginal: input.value(true),
+      notFoundValue: input.value([]),
     }),
 
     {

--- a/src/data/composite/wiki-data/withResolvedReference.js
+++ b/src/data/composite/wiki-data/withResolvedReference.js
@@ -1,12 +1,10 @@
 // Resolves a reference by using the provided find function to match it
 // within the provided thingData dependency. This will early exit if the
-// data dependency is null, or, if notFoundMode is set to 'exit', if the find
-// function doesn't match anything for the reference. Otherwise, the data
-// object is provided on the output dependency; or null, if the reference
-// doesn't match anything or itself was null to begin with.
+// data dependency is null. Otherwise, the data object is provided on the
+// output dependency, or null, if the reference doesn't match anything or
+// itself was null to begin with.
 
 import {input, templateCompositeFrom} from '#composite';
-import {is} from '#validators';
 
 import {
   exitWithoutDependency,
@@ -23,11 +21,6 @@ export default templateCompositeFrom({
 
     data: inputWikiData({allowMixedTypes: false}),
     find: input({type: 'function'}),
-
-    notFoundMode: input({
-      validate: is('null', 'exit'),
-      defaultValue: 'null',
-    }),
   },
 
   outputs: ['#resolvedReference'],
@@ -49,25 +42,16 @@ export default templateCompositeFrom({
         input('ref'),
         input('data'),
         input('find'),
-        input('notFoundMode'),
       ],
 
-      compute(continuation, {
+      compute: (continuation, {
         [input('ref')]: ref,
         [input('data')]: data,
         [input('find')]: findFunction,
-        [input('notFoundMode')]: notFoundMode,
-      }) {
-        const match = findFunction(ref, data, {mode: 'quiet'});
-
-        if (match === null && notFoundMode === 'exit') {
-          return continuation.exit(null);
-        }
-
-        return continuation.raiseOutput({
-          ['#resolvedReference']: match ?? null,
-        });
-      },
+      }) => continuation({
+        ['#resolvedReference']:
+          findFunction(ref, data, {mode: 'quiet'}) ?? null,
+      }),
     },
   ],
 });

--- a/src/data/things/track.js
+++ b/src/data/things/track.js
@@ -179,6 +179,7 @@ export class Track extends Thing {
     artistContribs: [
       inheritFromOriginalRelease({
         property: input.value('artistContribs'),
+        notFoundValue: input.value([]),
       }),
 
       withResolvedContribs({
@@ -202,6 +203,7 @@ export class Track extends Thing {
     contributorContribs: [
       inheritFromOriginalRelease({
         property: input.value('contributorContribs'),
+        notFoundValue: input.value([]),
       }),
 
       contributionList(),
@@ -236,6 +238,7 @@ export class Track extends Thing {
     referencedTracks: [
       inheritFromOriginalRelease({
         property: input.value('referencedTracks'),
+        notFoundValue: input.value([]),
       }),
 
       referenceList({
@@ -248,6 +251,7 @@ export class Track extends Thing {
     sampledTracks: [
       inheritFromOriginalRelease({
         property: input.value('sampledTracks'),
+        notFoundValue: input.value([]),
       }),
 
       referenceList({


### PR DESCRIPTION
Development:

- Fixes #401.
- We're meeting the intended behavior now. If `Original Release Track` is specified but fails to match anything, properties inheriting from the original are empty. It's still impossible to e.g. combine an unmatching `Original Release Track` and `Referenced Tracks`. The track is otherwise not treated as a rerelease by content or data code (which usually check the computed value of `originalReleaseTrack`, not the presence of an update value).

This pull request makes a few internal changes to original release logic so that a fallback value can be specified for if a track *has* an original release specified, but this reference doesn't match anything.

Since this was the only use of `notFoundMode: 'exit'` in `resolveReference` across the codebase, that input was removed; callers should take control of the reference resolving null. The reduced logic makes `withResolvedReference` slightly lower level (less abstracting), which may bubble up and force callers to use more composable logic. It only affects `withOriginalRelease` for now, which is lightly restructured to handle its `selfIfOriginal` input sooner.

`withOriginalRelease` and `inheritFromOriginalRelease` get new `notFoundValue` inputs, which set an early-exit value if original release is specified but doesn't match anything. This defaults to `null`, like before, but (incidentally) every place these functions are used should really be exiting with an array, so it's always set to `[]` at the moment.

There's room to evaluate other usage of `notFoundMode` and early exits in general. During early compositional work, we were treating `null` as an acceptable exit value for any property at any time. In principle, functions like `empty` adapt to this, but thanks to other properties (like `artistContribs`) returning an empty array instead, we rarely assume that the property value *might* be `null`. There may be other instances where a reference failing to match — or other functions perform early exits — where null is returned instead of an empty array, and errors or unexpected behavior come up.