### PR TITLE
Show annotations on artist info page's Commentary section!

### DIFF
--- a/src/content/dependencies/generateArtistInfoPageArtworksChunkedList.js
+++ b/src/content/dependencies/generateArtistInfoPageArtworksChunkedList.js
@@ -179,7 +179,7 @@ export default {
                   }) =>
                     item.slots({
                       otherArtistLinks,
-                      contribution,
+                      annotation: contribution,
 
                       content:
                         (type === 'trackCover'

--- a/src/content/dependencies/generateArtistInfoPageArtworksChunkedList.js
+++ b/src/content/dependencies/generateArtistInfoPageArtworksChunkedList.js
@@ -24,47 +24,58 @@ export default {
     // shape (#70) and get their own sorting function. Read for more info:
     // https://github.com/hsmusic/hsmusic-wiki/issues/90#issuecomment-1607422961
 
-    const entries = [
-      ...artist.albumsAsCoverArtist.map(album => ({
-        thing: album,
-        entry: {
+    const processEntries = (things, details) =>
+      things.map(thing => ({
+        thing,
+        entry: details(thing),
+      }));
+
+    const albumCoverEntries =
+      processEntries(
+        artist.albumsAsCoverArtist,
+        album => ({
           type: 'albumCover',
           album: album,
           date: album.coverArtDate ?? album.date,
           contribs: album.coverArtistContribs,
-        },
-      })),
+        }));
 
-      ...artist.albumsAsWallpaperArtist.map(album => ({
-        thing: album,
-        entry: {
+    const albumWallpaperEntries =
+      processEntries(
+        artist.albumsAsWallpaperArtist,
+        album => ({
           type: 'albumWallpaper',
           album: album,
           date: album.coverArtDate ?? album.date,
           contribs: album.wallpaperArtistContribs,
-        },
-      })),
+        }));
 
-      ...artist.albumsAsBannerArtist.map(album => ({
-        thing: album,
-        entry: {
+    const albumBannerEntries =
+      processEntries(
+        artist.albumsAsBannerArtist,
+        album => ({
           type: 'albumBanner',
           album: album,
           date: album.coverArtDate ?? album.date,
           contribs: album.bannerArtistContribs,
-        },
-      })),
+        }));
 
-      ...artist.tracksAsCoverArtist.map(track => ({
-        thing: track,
-        entry: {
+    const trackCoverEntries =
+      processEntries(
+        artist.tracksAsCoverArtist,
+        track => ({
           type: 'trackCover',
           album: track.album,
           date: track.coverArtDate ?? track.date,
           track: track,
           contribs: track.coverArtistContribs,
-        },
-      })),
+        }));
+
+    const entries = [
+      ...albumCoverEntries,
+      ...albumWallpaperEntries,
+      ...albumBannerEntries,
+      ...trackCoverEntries,
     ];
 
     sortEntryThingPairs(entries,

--- a/src/content/dependencies/generateArtistInfoPageArtworksChunkedList.js
+++ b/src/content/dependencies/generateArtistInfoPageArtworksChunkedList.js
@@ -24,58 +24,105 @@ export default {
     // shape (#70) and get their own sorting function. Read for more info:
     // https://github.com/hsmusic/hsmusic-wiki/issues/90#issuecomment-1607422961
 
-    const processEntries = (things, details) =>
-      things.map(thing => ({
-        thing,
-        entry: details(thing),
-      }));
+    const processEntry = ({thing, type, track, album, contribs}) => ({
+      thing: thing,
+      entry: {
+        type: type,
+        track: track,
+        album: album,
+        contribs: contribs,
+        date: thing.coverArtDate ?? thing.date,
+      },
+    });
 
-    const albumCoverEntries =
-      processEntries(
-        artist.albumsAsCoverArtist,
-        album => ({
-          type: 'albumCover',
-          album: album,
-          date: album.coverArtDate ?? album.date,
-          contribs: album.coverArtistContribs,
-        }));
+    const processAlbumEntry = ({type, album, contribs}) =>
+      processEntry({
+        thing: album,
+        type: type,
+        track: null,
+        album: album,
+        contribs: contribs,
+      });
 
-    const albumWallpaperEntries =
-      processEntries(
-        artist.albumsAsWallpaperArtist,
-        album => ({
-          type: 'albumWallpaper',
-          album: album,
-          date: album.coverArtDate ?? album.date,
-          contribs: album.wallpaperArtistContribs,
-        }));
+    const processTrackEntry = ({type, track, contribs}) =>
+      processEntry({
+        thing: track,
+        type: type,
+        track: track,
+        album: track.album,
+        contribs: contribs,
+      });
 
-    const albumBannerEntries =
-      processEntries(
-        artist.albumsAsBannerArtist,
-        album => ({
-          type: 'albumBanner',
-          album: album,
-          date: album.coverArtDate ?? album.date,
-          contribs: album.bannerArtistContribs,
-        }));
+    const processAlbumEntries = ({type, albums, contribs}) =>
+      stitchArrays({
+        album: albums,
+        contribs: contribs,
+      }).map(entry =>
+          processAlbumEntry({type, ...entry}));
 
-    const trackCoverEntries =
-      processEntries(
-        artist.tracksAsCoverArtist,
-        track => ({
-          type: 'trackCover',
-          album: track.album,
-          date: track.coverArtDate ?? track.date,
-          track: track,
-          contribs: track.coverArtistContribs,
-        }));
+    const processTrackEntries = ({type, tracks, contribs}) =>
+      stitchArrays({
+        track: tracks,
+        contribs: contribs,
+      }).map(entry =>
+          processTrackEntry({type, ...entry}));
+
+    const {
+      albumsAsCoverArtist,
+      albumsAsWallpaperArtist,
+      albumsAsBannerArtist,
+      tracksAsCoverArtist,
+    } = artist;
+
+    const albumsAsCoverArtistContribs =
+      albumsAsCoverArtist
+        .map(album => album.coverArtistContribs);
+
+    const albumsAsWallpaperArtistContribs =
+      albumsAsWallpaperArtist
+        .map(album => album.wallpaperArtistContribs);
+
+    const albumsAsBannerArtistContribs =
+      albumsAsBannerArtist
+        .map(album => album.bannerArtistContribs);
+
+    const tracksAsCoverArtistContribs =
+      tracksAsCoverArtist
+        .map(track => track.coverArtistContribs);
+
+    const albumsAsCoverArtistEntries =
+      processAlbumEntries({
+        type: 'albumCover',
+        albums: albumsAsCoverArtist,
+        contribs: albumsAsCoverArtistContribs,
+      });
+
+    const albumsAsWallpaperArtistEntries =
+      processAlbumEntries({
+        type: 'albumWallpaper',
+        albums: albumsAsWallpaperArtist,
+        contribs: albumsAsWallpaperArtistContribs,
+      });
+
+    const albumsAsBannerArtistEntries =
+      processAlbumEntries({
+        type: 'albumBanner',
+        albums: albumsAsBannerArtist,
+        contribs: albumsAsBannerArtistContribs,
+      });
+
+    const tracksAsCoverArtistEntries =
+      processTrackEntries({
+        type: 'trackCover',
+        tracks: tracksAsCoverArtist,
+        contribs: tracksAsCoverArtistContribs,
+      });
 
     const entries = [
-      ...albumCoverEntries,
-      ...albumWallpaperEntries,
-      ...albumBannerEntries,
-      ...trackCoverEntries,
+      ...albumsAsCoverArtistEntries,
+      ...albumsAsWallpaperArtistEntries,
+      ...albumsAsBannerArtistEntries,
+      ...tracksAsCoverArtistEntries,
     ];
 
     sortEntryThingPairs(entries,

--- a/src/content/dependencies/generateArtistInfoPageChunkItem.js
+++ b/src/content/dependencies/generateArtistInfoPageChunkItem.js
@@ -7,7 +7,7 @@ export default {
       mutable: false,
     },
 
-    contribution: {
+    annotation: {
       type: 'html',
       mutable: false,
     },
@@ -40,9 +40,9 @@ export default {
         options.artists = language.formatConjunctionList(slots.otherArtistLinks);
       }
 
-      if (!html.isBlank(slots.contribution)) {
-        parts.push('withContribution');
-        options.contribution = slots.contribution;
+      if (!html.isBlank(slots.annotation)) {
+        parts.push('withAnnotation');
+        options.annotation = slots.annotation;
       }
 
       if (parts.length === 1) {

--- a/src/content/dependencies/generateArtistInfoPageCommentaryChunkedList.js
+++ b/src/content/dependencies/generateArtistInfoPageCommentaryChunkedList.js
@@ -19,10 +19,13 @@ export default {
 
   query(artist) {
     const processEntries = (things, details) =>
-      things.map(thing => ({
-        thing,
-        entry: details(thing),
-      }));
+      things.flatMap(thing =>
+        thing.commentary
+          .filter(entry => entry.artists.includes(artist))
+          .map(entry => ({
+            thing,
+            entry: details(thing, entry),
+          })));
 
     const albumEntries =
       processEntries(

--- a/src/content/dependencies/generateArtistInfoPageCommentaryChunkedList.js
+++ b/src/content/dependencies/generateArtistInfoPageCommentaryChunkedList.js
@@ -18,11 +18,6 @@ export default {
   extraDependencies: ['html', 'language'],
 
   query(artist) {
-    // TODO: Add and integrate wallpaper and banner date fields (#90)
-    // This will probably only happen once all artworks follow a standard
-    // shape (#70) and get their own sorting function. Read for more info:
-    // https://github.com/hsmusic/hsmusic-wiki/issues/90#issuecomment-1607422961
-
     const entries = [
       ...artist.albumsAsCommentator.map(album => ({
         thing: album,

--- a/src/content/dependencies/generateArtistInfoPageCommentaryChunkedList.js
+++ b/src/content/dependencies/generateArtistInfoPageCommentaryChunkedList.js
@@ -18,23 +18,32 @@ export default {
   extraDependencies: ['html', 'language'],
 
   query(artist) {
-    const entries = [
-      ...artist.albumsAsCommentator.map(album => ({
-        thing: album,
-        entry: {
+    const processEntries = (things, details) =>
+      things.map(thing => ({
+        thing,
+        entry: details(thing),
+      }));
+
+    const albumEntries =
+      processEntries(
+        artist.albumsAsCommentator,
+        album => ({
           type: 'album',
           album,
-        },
-      })),
+        }));
 
-      ...artist.tracksAsCommentator.map(track => ({
-        thing: track,
-        entry: {
+    const trackEntries =
+      processEntries(
+        artist.tracksAsCommentator,
+        track => ({
           type: 'track',
           album: track.album,
           track,
-        },
-      })),
+        }));
+
+    const entries = [
+      ...albumEntries,
+      ...trackEntries,
     ];
 
     sortEntryThingPairs(entries, sortAlbumsTracksChronologically);

--- a/src/content/dependencies/generateArtistInfoPageFlashesChunkedList.js
+++ b/src/content/dependencies/generateArtistInfoPageFlashesChunkedList.js
@@ -16,15 +16,23 @@ export default {
   extraDependencies: ['html', 'language'],
 
   query(artist) {
-    const entries = [
-      ...artist.flashesAsContributor.map(flash => ({
-        thing: flash,
-        entry: {
+    const processEntries = (things, details) =>
+      things.map(thing => ({
+        thing,
+        entry: details(thing),
+      }));
+
+    const contributorEntries =
+      processEntries(
+        artist.flashesAsContributor,
+        flash => ({
           flash,
           act: flash.act,
           contribs: flash.contributorContribs,
-        },
-      })),
+        }));
+
+    const entries = [
+      ...contributorEntries,
     ];
 
     sortEntryThingPairs(entries, sortFlashesChronologically);

--- a/src/content/dependencies/generateArtistInfoPageFlashesChunkedList.js
+++ b/src/content/dependencies/generateArtistInfoPageFlashesChunkedList.js
@@ -130,7 +130,7 @@ export default {
                   contribution,
                 }) =>
                   item.slots({
-                    contribution,
+                    annotation: contribution,
 
                     content:
                       language.$('artistPage.creditList.entry.flash', {

--- a/src/content/dependencies/generateArtistInfoPageFlashesChunkedList.js
+++ b/src/content/dependencies/generateArtistInfoPageFlashesChunkedList.js
@@ -16,23 +16,35 @@ export default {
   extraDependencies: ['html', 'language'],
 
   query(artist) {
-    const processEntries = (things, details) =>
-      things.map(thing => ({
-        thing,
-        entry: details(thing),
-      }));
+    const processFlashEntry = ({flash, contribs}) => ({
+      thing: flash,
+      entry: {
+        flash: flash,
+        act: flash.act,
+        contribs: contribs,
+      },
+    });
 
-    const contributorEntries =
-      processEntries(
-        artist.flashesAsContributor,
-        flash => ({
-          flash,
-          act: flash.act,
-          contribs: flash.contributorContribs,
-        }));
+    const processFlashEntries = ({flashes, contribs}) =>
+      stitchArrays({
+        flash: flashes,
+        contribs: contribs,
+      }).map(processFlashEntry);
+
+    const {flashesAsContributor} = artist;
+
+    const flashesAsContributorContribs =
+      flashesAsContributor
+        .map(flash => flash.contributorContribs);
+
+    const flashesAsContributorEntries =
+      processFlashEntries({
+        flashes: flashesAsContributor,
+        contribs: flashesAsContributorContribs,
+      });
 
     const entries = [
-      ...contributorEntries,
+      ...flashesAsContributorEntries,
     ];
 
     sortEntryThingPairs(entries, sortFlashesChronologically);

--- a/src/content/dependencies/generateArtistInfoPageTracksChunkedList.js
+++ b/src/content/dependencies/generateArtistInfoPageTracksChunkedList.js
@@ -206,7 +206,7 @@ export default {
                       otherArtistLinks,
                       rerelease,
 
-                      contribution:
+                      annotation:
                         (contribution
                           ? language.formatUnitList(contribution)
                           : html.blank()),

--- a/src/content/dependencies/generateArtistInfoPageTracksChunkedList.js
+++ b/src/content/dependencies/generateArtistInfoPageTracksChunkedList.js
@@ -19,58 +19,73 @@ export default {
   extraDependencies: ['html', 'language'],
 
   query(artist) {
-    const processEntries = (things, details) =>
-      things.map(thing => ({
-        thing,
-        entry: details(thing),
-      }));
+    const processTrackEntry = ({track, contribs}) => ({
+      thing: track,
+      entry: {
+        track: track,
+        album: track.album,
+        date: track.date,
+        contribs: contribs,
+      },
+    });
+
+    const processTrackEntries = ({tracks, contribs}) =>
+      stitchArrays({
+        track: tracks,
+        contribs: contribs,
+      }).map(processTrackEntry);
+
+    const {tracksAsArtist, tracksAsContributor} = artist;
 
     const tracksAsArtistAndContributor =
-      artist.tracksAsArtist
-        .filter(track => artist.tracksAsContributor.includes(track));
+      tracksAsArtist
+        .filter(track => tracksAsContributor.includes(track));
 
     const tracksAsArtistOnly =
-      artist.tracksAsArtist
-        .filter(track => !artist.tracksAsContributor.includes(track));
+      tracksAsArtist
+        .filter(track => !tracksAsContributor.includes(track));
 
     const tracksAsContributorOnly =
-      artist.tracksAsContributor
-        .filter(track => !artist.tracksAsArtist.includes(track));
+      tracksAsContributor
+        .filter(track => !tracksAsArtist.includes(track));
 
-    const entriesAsArtistAndContributor =
-      processEntries(
-        tracksAsArtistAndContributor,
-        track => ({
-          track,
-          album: track.album,
-          date: track.date,
-          contribs: [...track.artistContribs, ...track.contributorContribs],
-        }));
+    const tracksAsArtistAndContributorContribs =
+      tracksAsArtistAndContributor
+        .map(track => [
+          ...track.artistContribs,
+          ...track.contributorContribs,
+        ]);
 
-    const entriesAsArtistOnly =
-      processEntries(
-        tracksAsArtistOnly,
-        track => ({
-          track,
-          album: track.album,
-          date: track.date,
-          contribs: track.artistContribs,
-        }));
+    const tracksAsArtistOnlyContribs =
+      tracksAsArtistOnly
+        .map(track => track.artistContribs);
 
-    const entriesAsContributorOnly =
-      processEntries(
-        tracksAsContributorOnly,
-        track => ({
-          track,
-          date: track.date,
-          album: track.album,
-          contribs: track.contributorContribs,
-        }));
+    const tracksAsContributorOnlyContribs =
+      tracksAsContributorOnly
+        .map(track => track.contributorContribs);
+
+    const tracksAsArtistAndContributorEntries =
+      processTrackEntries({
+        tracks: tracksAsArtistAndContributor,
+        contribs: tracksAsArtistAndContributorContribs,
+      });
+
+    const tracksAsArtistOnlyEntries =
+      processTrackEntries({
+        tracks: tracksAsArtistOnly,
+        contribs: tracksAsArtistOnlyContribs,
+      });
+
+    const tracksAsContributorOnlyEntries =
+      processTrackEntries({
+        tracks: tracksAsContributorOnly,
+        contribs: tracksAsContributorOnlyContribs,
+      });
 
     const entries = [
-      ...entriesAsArtistAndContributor,
-      ...entriesAsArtistOnly,
-      ...entriesAsContributorOnly,
+      ...tracksAsArtistAndContributorEntries,
+      ...tracksAsArtistOnlyEntries,
+      ...tracksAsContributorOnlyEntries,
     ];
 
     sortEntryThingPairs(entries, sortAlbumsTracksChronologically);

--- a/src/content/dependencies/generateArtistInfoPageTracksChunkedList.js
+++ b/src/content/dependencies/generateArtistInfoPageTracksChunkedList.js
@@ -19,6 +19,12 @@ export default {
   extraDependencies: ['html', 'language'],
 
   query(artist) {
+    const processEntries = (things, details) =>
+      things.map(thing => ({
+        thing,
+        entry: details(thing),
+      }));
+
     const tracksAsArtistAndContributor =
       artist.tracksAsArtist
         .filter(track => artist.tracksAsContributor.includes(track));
@@ -31,36 +37,40 @@ export default {
       artist.tracksAsContributor
         .filter(track => !artist.tracksAsArtist.includes(track));
 
-    const entries = [
-      ...tracksAsArtistAndContributor.map(track => ({
-        thing: track,
-        entry: {
+    const entriesAsArtistAndContributor =
+      processEntries(
+        tracksAsArtistAndContributor,
+        track => ({
           track,
           album: track.album,
           date: track.date,
           contribs: [...track.artistContribs, ...track.contributorContribs],
-        },
-      })),
+        }));
 
-      ...tracksAsArtistOnly.map(track => ({
-        thing: track,
-        entry: {
+    const entriesAsArtistOnly =
+      processEntries(
+        tracksAsArtistOnly,
+        track => ({
           track,
           album: track.album,
           date: track.date,
           contribs: track.artistContribs,
-        },
-      })),
+        }));
 
-      ...tracksAsContributorOnly.map(track => ({
-        thing: track,
-        entry: {
+    const entriesAsContributorOnly =
+      processEntries(
+        tracksAsContributorOnly,
+        track => ({
           track,
           date: track.date,
           album: track.album,
           contribs: track.contributorContribs,
-        },
-      })),
+        }));
+
+    const entries = [
+      ...entriesAsArtistAndContributor,
+      ...entriesAsArtistOnly,
+      ...entriesAsContributorOnly,
     ];
 
     sortEntryThingPairs(entries, sortAlbumsTracksChronologically);

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -879,12 +879,12 @@ artistPage:
 
     entry:
 
-      # withContribution:
+      # withAnnotation:
       #   The specific contribution that an artist made to a given
       #   thing may be described with a word or two, and that's shown
       #   in the list.
 
-      withContribution: "{ENTRY} ({CONTRIBUTION})"
+      withAnnotation: "{ENTRY} ({ANNOTATION})"
 
       # withArtists:
       #   This lists co-artists or co-contributors, depending on how
@@ -892,7 +892,7 @@ artistPage:
 
       withArtists: "{ENTRY} (with {ARTISTS})"
 
-      withArtists.withContribution: "{ENTRY} ({CONTRIBUTION}; with {ARTISTS})"
+      withArtists.withAnnotation: "{ENTRY} ({ANNOTATION}; with {ARTISTS})"
 
       # rerelease:
       #   Tracks which aren't the original release don't display co-


### PR DESCRIPTION
This PR adds commentary entry annotations to the Commentary section on an artist info page, so you can easily see what stuff is "wiki editor" vs original commentary, sources and summaries, and so on, all at a glance! Thanks to Jebb for suggesting this!

It also does a bunch of refactoring for all the related components (`generateArtistInfoPageCommentaryChunkedList`, etc). Code style is cleaned up and much more compositional and structured; this is all intended to be groundworks for handling stuff like contribution and artwork objects more directly than we would've before.