### PR TITLE
Improve missing/zero-duration presentation!

### DIFF
--- a/src/content/dependencies/generateAlbumTrackList.js
+++ b/src/content/dependencies/generateAlbumTrackList.js
@@ -108,8 +108,24 @@ export default {
     return data;
   },
 
-  generate(data, relations, {html, language}) {
+  slots: {
+    collapseDurationScope: {
+      validate: v =>
+        v.is('never', 'track', 'section', 'album'),
+
+      default: 'album',
+    },
+  },
+
+  generate(data, relations, slots, {html, language}) {
     const listTag = (data.hasTrackNumbers ? 'ol' : 'ul');
+
+    const slotItems = items =>
+      items.map(item =>
+        item.slots({
+          collapseDurationScope:
+            slots.collapseDurationScope,
+        }));
 
     switch (data.displayMode) {
       case 'trackSections':
@@ -152,11 +168,11 @@ export default {
                   data.hasTrackNumbers &&
                     {start: startIndex + 1},
 
-                  items)),
+                  slotItems(items))),
             ]));
 
       case 'tracks':
-        return html.tag(listTag, relations.items);
+        return html.tag(listTag, slotItems(relations.items));
 
       default:
         return html.blank();

--- a/src/content/dependencies/generateAlbumTrackList.js
+++ b/src/content/dependencies/generateAlbumTrackList.js
@@ -134,13 +134,17 @@ export default {
               heading.slots({
                 tag: 'dt',
                 title:
-                  language.$('trackList.section.withDuration', {
-                    section: name,
-                    duration:
-                      language.formatDuration(duration, {
-                        approximate: durationApproximate,
-                      }),
-                  }),
+                  (duration === 0
+                    ? language.$('trackList.section', {
+                        section: name,
+                      })
+                    : language.$('trackList.section.withDuration', {
+                        section: name,
+                        duration:
+                          language.formatDuration(duration, {
+                            approximate: durationApproximate,
+                          }),
+                      })),
               }),
 
               html.tag('dd',

--- a/src/content/dependencies/generateAlbumTrackListMissingDuration.js
+++ b/src/content/dependencies/generateAlbumTrackListMissingDuration.js
@@ -13,14 +13,14 @@ export default {
   generate: (relations, {html, language}) =>
     relations.textWithTooltip.slots({
       attributes: {class: 'missing-duration'},
+      customInteractionCue: true,
 
       text:
-        html.tag('span',
-          language.$('trackList.item.withDuration.duration', {
-            duration:
-              html.tag('span', {class: 'duration-text'},
-                language.$('trackList.item.withDuration.duration.missing')),
-          })),
+        language.$('trackList.item.withDuration.duration', {
+          duration:
+            html.tag('span', {class: 'text-with-tooltip-interaction-cue'},
+              language.$('trackList.item.withDuration.duration.missing')),
+        }),
 
       tooltip:
         relations.tooltip.slots({

--- a/src/content/dependencies/generateAlbumTrackListMissingDuration.js
+++ b/src/content/dependencies/generateAlbumTrackListMissingDuration.js
@@ -1,0 +1,33 @@
+export default {
+  contentDependencies: ['generateTextWithTooltip', 'generateTooltip'],
+  extraDependencies: ['html', 'language'],
+
+  relations: (relation) => ({
+    textWithTooltip:
+      relation('generateTextWithTooltip'),
+
+    tooltip:
+      relation('generateTooltip'),
+  }),
+
+  generate: (relations, {html, language}) =>
+    relations.textWithTooltip.slots({
+      attributes: {class: 'missing-duration'},
+
+      text:
+        html.tag('span',
+          language.$('trackList.item.withDuration.duration', {
+            duration:
+              html.tag('span', {class: 'duration-text'},
+                language.$('trackList.item.withDuration.duration.missing')),
+          })),
+
+      tooltip:
+        relations.tooltip.slots({
+          attributes: {class: 'missing-duration-tooltip'},
+
+          content:
+            language.$('trackList.item.withDuration.duration.missing.info'),
+        }),
+    }),
+};

--- a/src/content/dependencies/generateTextWithTooltip.js
+++ b/src/content/dependencies/generateTextWithTooltip.js
@@ -7,6 +7,11 @@ export default {
       mutable: false,
     },
 
+    customInteractionCue: {
+      type: 'boolean',
+      default: false,
+    },
+
     text: {
       type: 'html',
       mutable: false,
@@ -37,10 +42,20 @@ export default {
       });
     }
 
+    const textPart =
+      (hasTooltip && slots.customInteractionCue
+        ? html.tag('span', {class: 'hoverable'},
+            slots.text)
+     : hasTooltip
+        ? html.tag('span', {class: 'hoverable'},
+            html.tag('span', {class: 'text-with-tooltip-interaction-cue'},
+              slots.text))
+        : slots.text);
+
     const content =
       (hasTooltip
-        ? [slots.text, slots.tooltip]
-        : slots.text);
+        ? [textPart, slots.tooltip]
+        : textPart);
 
     return html.tag('span', attributes, content);
   },

--- a/src/content/dependencies/linkContribution.js
+++ b/src/content/dependencies/linkContribution.js
@@ -58,7 +58,13 @@ export default {
     options.artist =
       (hasExternalIcons && slots.iconMode === 'tooltip'
         ? relations.textWithTooltip.slots({
-            text: relations.artistLink,
+            customInteractionCue: true,
+
+            text:
+              relations.artistLink.slots({
+                attributes: {class: 'text-with-tooltip-interaction-cue'},
+              }),
+
             tooltip:
               relations.tooltip.slots({
                 attributes:

--- a/src/content/dependencies/linkThing.js
+++ b/src/content/dependencies/linkThing.js
@@ -108,6 +108,10 @@ export default {
       linkAttributes.add('title', data.name);
     }
 
+    if (showWikiTooltip) {
+      linkAttributes.add('class', 'text-with-tooltip-interaction-cue');
+    }
+
     const content =
       (html.isBlank(slots.content)
         ? language.sanitize(name)
@@ -131,6 +135,7 @@ export default {
 
     return relations.textWithTooltip.slots({
       attributes: wrapperAttributes,
+      customInteractionCue: true,
 
       text:
         relations.linkTemplate.slots({

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -507,35 +507,28 @@ a:not([href]):hover {
   position: relative;
 }
 
-.text-with-tooltip > :first-child {
+.text-with-tooltip .text-with-tooltip-interaction-cue {
   text-decoration: underline;
   text-decoration-style: dotted;
 }
 
-.text-with-tooltip > :first-child:hover,
-.text-with-tooltip > :first-child.has-visible-tooltip {
+.text-with-tooltip > .hoverable:hover .text-with-tooltip-interaction-cue,
+.text-with-tooltip > .hoverable.has-visible-tooltip .text-with-tooltip-interaction-cue {
   text-decoration-style: wavy !important;
 }
 
-.text-with-tooltip.datetimestamp > :first-child,
-.text-with-tooltip.missing-duration > :first-child {
+.text-with-tooltip.datetimestamp .text-with-tooltip-interaction-cue,
+.text-with-tooltip.missing-duration .text-with-tooltip-interaction-cue {
   cursor: default;
 }
 
-.text-with-tooltip.missing-duration > :first-child {
+.text-with-tooltip.missing-duration > .hoverable {
   opacity: 0.5;
 }
 
-.text-with-tooltip.missing-duration > :first-child:hover,
-.text-with-tooltip.missing-duration > :first-child.has-visible-tooltip {
-  text-decoration: none !important;
+.text-with-tooltip.missing-duration > .hoverable:hover,
+.text-with-tooltip.missing-duration > .hoverable.has-visible-tooltip {
   opacity: 1;
-}
-
-.text-with-tooltip.missing-duration > :first-child:hover .duration-text,
-.text-with-tooltip.missing-duration > :first-child.has-visible-tooltip .duration-text {
-  text-decoration: underline;
-  text-decoration-style: wavy;
 }
 
 .tooltip {

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -531,6 +531,10 @@ a:not([href]):hover {
   opacity: 1;
 }
 
+.text-with-tooltip.missing-duration .text-with-tooltip-interaction-cue {
+  text-decoration: none !important;
+}
+
 .tooltip {
   position: absolute;
   z-index: 3;

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -517,8 +517,25 @@ a:not([href]):hover {
   text-decoration-style: wavy !important;
 }
 
-.text-with-tooltip.datetimestamp > :first-child {
+.text-with-tooltip.datetimestamp > :first-child,
+.text-with-tooltip.missing-duration > :first-child {
   cursor: default;
+}
+
+.text-with-tooltip.missing-duration > :first-child {
+  opacity: 0.5;
+}
+
+.text-with-tooltip.missing-duration > :first-child:hover,
+.text-with-tooltip.missing-duration > :first-child.has-visible-tooltip {
+  text-decoration: none !important;
+  opacity: 1;
+}
+
+.text-with-tooltip.missing-duration > :first-child:hover .duration-text,
+.text-with-tooltip.missing-duration > :first-child.has-visible-tooltip .duration-text {
+  text-decoration: underline;
+  text-decoration-style: wavy;
 }
 
 .tooltip {
@@ -557,7 +574,8 @@ li:not(:first-child:last-child) .tooltip,
   left: -34px;
 }
 
-.datetimestamp-tooltip {
+.datetimestamp-tooltip,
+.missing-duration-tooltip {
   padding: 3px 4px 2px 2px;
   left: -10px;
 }
@@ -581,7 +599,8 @@ li:not(:first-child:last-child) .tooltip,
   cursor: default;
 }
 
-.datetimestamp-tooltip .tooltip-content {
+.datetimestamp-tooltip .tooltip-content,
+.missing-duration-tooltip .tooltip-content {
   padding: 5px 6px;
   white-space: nowrap;
   font-size: 0.9em;

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -360,6 +360,7 @@ releaseInfo:
 #
 trackList:
   section:
+    _: "{SECTION}:"
     withDuration: "{SECTION}: ({DURATION})"
 
   group:

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -360,7 +360,7 @@ releaseInfo:
 #
 trackList:
   section:
-    withDuration: "{SECTION} ({DURATION}):"
+    withDuration: "{SECTION}: ({DURATION})"
 
   group:
     _: "From {GROUP}:"

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -375,8 +375,8 @@ trackList:
 
     withDuration.duration:
       _: "({DURATION})"
-      missing: "0:00"
-      missing.info: "no duration provided"
+      missing: "_:__"
+      missing.info: "no duration provided; treated as zero seconds long"
 
     withArtists.by: "by {ARTISTS}"
 

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -368,6 +368,7 @@ trackList:
     fromOther: "From somewhere else:"
 
   item:
+    _: "{TRACK}"
     withDuration: "{DURATION} {TRACK}"
     withArtists: "{TRACK} {BY}"
     withDuration.withArtists: "{DURATION} {TRACK} {BY}"

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -367,10 +367,17 @@ trackList:
     fromOther: "From somewhere else:"
 
   item:
-    withDuration: "({DURATION}) {TRACK}"
-    withDuration.withArtists: "({DURATION}) {TRACK} {BY}"
+    withDuration: "{DURATION} {TRACK}"
     withArtists: "{TRACK} {BY}"
+    withDuration.withArtists: "{DURATION} {TRACK} {BY}"
+
+    withDuration.duration:
+      _: "({DURATION})"
+      missing: "0:00"
+      missing.info: "no duration provided"
+
     withArtists.by: "by {ARTISTS}"
+
     rerelease: "{TRACK} (re-release)"
 
 #

--- a/tap-snapshots/test/snapshot/generateAlbumReleaseInfo.js.test.cjs
+++ b/tap-snapshots/test/snapshot/generateAlbumReleaseInfo.js.test.cjs
@@ -7,7 +7,7 @@
 'use strict'
 exports[`test/snapshot/generateAlbumReleaseInfo.js > TAP > generateAlbumReleaseInfo (snapshot) > basic behavior 1`] = `
 <p>
-    By <span class="contribution nowrap"><a href="artist/toby-fox/">Toby Fox</a> (music probably)</span> and <span class="contribution nowrap"><span class="text-with-tooltip"><a href="artist/tensei/">Tensei</a><span class="tooltip icons icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://tenseimusic.bandcamp.com/">
+    By <span class="contribution nowrap"><a href="artist/toby-fox/">Toby Fox</a> (music probably)</span> and <span class="contribution nowrap"><span class="text-with-tooltip"><span class="hoverable"><a class="text-with-tooltip-interaction-cue" href="artist/tensei/">Tensei</a></span><span class="tooltip icons icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://tenseimusic.bandcamp.com/">
                         <svg><use href="static/icons.svg#icon-bandcamp"></use></svg>
                         <span class="icon-text">tenseimusic</span>
                     </a></span></span></span> (hot jams)</span>.

--- a/tap-snapshots/test/snapshot/generateAlbumTrackList.js.test.cjs
+++ b/tap-snapshots/test/snapshot/generateAlbumTrackList.js.test.cjs
@@ -8,23 +8,123 @@
 exports[`test/snapshot/generateAlbumTrackList.js > TAP > generateAlbumTrackList (snapshot) > basic behavior, default track section 1`] = `
 <ul>
     <li>(0:20) <a href="track/t1/">Track 1</a></li>
-    <li>(0:30) <a href="track/t2/">Track 2</a></li>
+    <li>[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t2/">Track 2</a></li>
     <li>(0:40) <a href="track/t3/">Track 3</a></li>
-    <li style="--primary-color: #ea2e83">(0:05) <a href="track/t4/">Track 4</a> <span class="by">by <a href="artist/apricot/">Apricot</a> and <a href="artist/peach/">Peach</a></span></li>
+    <li style="--primary-color: #ea2e83">[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t4/">Track 4</a> <span class="by">by <a href="artist/apricot/">Apricot</a> and <a href="artist/peach/">Peach</a></span></li>
 </ul>
 `
 
 exports[`test/snapshot/generateAlbumTrackList.js > TAP > generateAlbumTrackList (snapshot) > basic behavior, with track sections 1`] = `
 <dl class="album-group-list">
-    <dt class="content-heading" tabindex="0"><span class="content-heading-main-title">First section: (~1:30)</span></dt>
+    <dt class="content-heading" tabindex="0"><span class="content-heading-main-title">First section: (~1:00)</span></dt>
     <dd>
         <ul>
             <li>(0:20) <a href="track/t1/">Track 1</a></li>
-            <li>(0:30) <a href="track/t2/">Track 2</a></li>
+            <li>[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t2/">Track 2</a></li>
             <li>(0:40) <a href="track/t3/">Track 3</a></li>
         </ul>
     </dd>
-    <dt class="content-heading" tabindex="0"><span class="content-heading-main-title">Second section: (0:05)</span></dt>
-    <dd><ul><li style="--primary-color: #ea2e83">(0:05) <a href="track/t4/">Track 4</a> <span class="by">by <a href="artist/apricot/">Apricot</a> and <a href="artist/peach/">Peach</a></span></li></ul></dd>
+    <dt class="content-heading" tabindex="0"><span class="content-heading-main-title">Second section:</span></dt>
+    <dd><ul><li style="--primary-color: #ea2e83">[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t4/">Track 4</a> <span class="by">by <a href="artist/apricot/">Apricot</a> and <a href="artist/peach/">Peach</a></span></li></ul></dd>
 </dl>
+`
+
+exports[`test/snapshot/generateAlbumTrackList.js > TAP > generateAlbumTrackList (snapshot) > collapseDurationScope: album 1`] = `
+<dl class="album-group-list">
+    <dt class="content-heading" tabindex="0"><span class="content-heading-main-title">First section: (~1:00)</span></dt>
+    <dd>
+        <ul>
+            <li>(0:20) <a href="track/t1/">Track 1</a></li>
+            <li>[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t2/">Track 2</a></li>
+            <li>(0:40) <a href="track/t3/">Track 3</a></li>
+        </ul>
+    </dd>
+    <dt class="content-heading" tabindex="0"><span class="content-heading-main-title">Second section:</span></dt>
+    <dd><ul><li style="--primary-color: #ea2e83">[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t4/">Track 4</a> <span class="by">by <a href="artist/apricot/">Apricot</a> and <a href="artist/peach/">Peach</a></span></li></ul></dd>
+</dl>
+<ul>
+    <li>(0:20) <a href="track/t1/">Track 1</a></li>
+    <li>[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t2/">Track 2</a></li>
+    <li>(0:40) <a href="track/t3/">Track 3</a></li>
+    <li style="--primary-color: #ea2e83">[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t4/">Track 4</a> <span class="by">by <a href="artist/apricot/">Apricot</a> and <a href="artist/peach/">Peach</a></span></li>
+</ul>
+<ul>
+    <li><a href="track/t2/">Track 2</a></li>
+    <li style="--primary-color: #ea2e83"><a href="track/t4/">Track 4</a> <span class="by">by <a href="artist/apricot/">Apricot</a> and <a href="artist/peach/">Peach</a></span></li>
+</ul>
+`
+
+exports[`test/snapshot/generateAlbumTrackList.js > TAP > generateAlbumTrackList (snapshot) > collapseDurationScope: never 1`] = `
+<dl class="album-group-list">
+    <dt class="content-heading" tabindex="0"><span class="content-heading-main-title">First section: (~1:00)</span></dt>
+    <dd>
+        <ul>
+            <li>(0:20) <a href="track/t1/">Track 1</a></li>
+            <li>[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t2/">Track 2</a></li>
+            <li>(0:40) <a href="track/t3/">Track 3</a></li>
+        </ul>
+    </dd>
+    <dt class="content-heading" tabindex="0"><span class="content-heading-main-title">Second section:</span></dt>
+    <dd><ul><li style="--primary-color: #ea2e83">[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t4/">Track 4</a> <span class="by">by <a href="artist/apricot/">Apricot</a> and <a href="artist/peach/">Peach</a></span></li></ul></dd>
+</dl>
+<ul>
+    <li>(0:20) <a href="track/t1/">Track 1</a></li>
+    <li>[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t2/">Track 2</a></li>
+    <li>(0:40) <a href="track/t3/">Track 3</a></li>
+    <li style="--primary-color: #ea2e83">[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t4/">Track 4</a> <span class="by">by <a href="artist/apricot/">Apricot</a> and <a href="artist/peach/">Peach</a></span></li>
+</ul>
+<ul>
+    <li>[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t2/">Track 2</a></li>
+    <li style="--primary-color: #ea2e83">[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t4/">Track 4</a> <span class="by">by <a href="artist/apricot/">Apricot</a> and <a href="artist/peach/">Peach</a></span></li>
+</ul>
+`
+
+exports[`test/snapshot/generateAlbumTrackList.js > TAP > generateAlbumTrackList (snapshot) > collapseDurationScope: section 1`] = `
+<dl class="album-group-list">
+    <dt class="content-heading" tabindex="0"><span class="content-heading-main-title">First section: (~1:00)</span></dt>
+    <dd>
+        <ul>
+            <li>(0:20) <a href="track/t1/">Track 1</a></li>
+            <li>[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t2/">Track 2</a></li>
+            <li>(0:40) <a href="track/t3/">Track 3</a></li>
+        </ul>
+    </dd>
+    <dt class="content-heading" tabindex="0"><span class="content-heading-main-title">Second section:</span></dt>
+    <dd><ul><li style="--primary-color: #ea2e83"><a href="track/t4/">Track 4</a> <span class="by">by <a href="artist/apricot/">Apricot</a> and <a href="artist/peach/">Peach</a></span></li></ul></dd>
+</dl>
+<ul>
+    <li>(0:20) <a href="track/t1/">Track 1</a></li>
+    <li>[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t2/">Track 2</a></li>
+    <li>(0:40) <a href="track/t3/">Track 3</a></li>
+    <li style="--primary-color: #ea2e83">[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t4/">Track 4</a> <span class="by">by <a href="artist/apricot/">Apricot</a> and <a href="artist/peach/">Peach</a></span></li>
+</ul>
+<ul>
+    <li><a href="track/t2/">Track 2</a></li>
+    <li style="--primary-color: #ea2e83"><a href="track/t4/">Track 4</a> <span class="by">by <a href="artist/apricot/">Apricot</a> and <a href="artist/peach/">Peach</a></span></li>
+</ul>
+`
+
+exports[`test/snapshot/generateAlbumTrackList.js > TAP > generateAlbumTrackList (snapshot) > collapseDurationScope: track 1`] = `
+<dl class="album-group-list">
+    <dt class="content-heading" tabindex="0"><span class="content-heading-main-title">First section: (~1:00)</span></dt>
+    <dd>
+        <ul>
+            <li>(0:20) <a href="track/t1/">Track 1</a></li>
+            <li><a href="track/t2/">Track 2</a></li>
+            <li>(0:40) <a href="track/t3/">Track 3</a></li>
+        </ul>
+    </dd>
+    <dt class="content-heading" tabindex="0"><span class="content-heading-main-title">Second section:</span></dt>
+    <dd><ul><li style="--primary-color: #ea2e83"><a href="track/t4/">Track 4</a> <span class="by">by <a href="artist/apricot/">Apricot</a> and <a href="artist/peach/">Peach</a></span></li></ul></dd>
+</dl>
+<ul>
+    <li>(0:20) <a href="track/t1/">Track 1</a></li>
+    <li><a href="track/t2/">Track 2</a></li>
+    <li>(0:40) <a href="track/t3/">Track 3</a></li>
+    <li style="--primary-color: #ea2e83"><a href="track/t4/">Track 4</a> <span class="by">by <a href="artist/apricot/">Apricot</a> and <a href="artist/peach/">Peach</a></span></li>
+</ul>
+<ul>
+    <li><a href="track/t2/">Track 2</a></li>
+    <li style="--primary-color: #ea2e83"><a href="track/t4/">Track 4</a> <span class="by">by <a href="artist/apricot/">Apricot</a> and <a href="artist/peach/">Peach</a></span></li>
+</ul>
 `

--- a/tap-snapshots/test/snapshot/generateAlbumTrackList.js.test.cjs
+++ b/tap-snapshots/test/snapshot/generateAlbumTrackList.js.test.cjs
@@ -16,7 +16,7 @@ exports[`test/snapshot/generateAlbumTrackList.js > TAP > generateAlbumTrackList 
 
 exports[`test/snapshot/generateAlbumTrackList.js > TAP > generateAlbumTrackList (snapshot) > basic behavior, with track sections 1`] = `
 <dl class="album-group-list">
-    <dt class="content-heading" tabindex="0"><span class="content-heading-main-title">First section (~1:30):</span></dt>
+    <dt class="content-heading" tabindex="0"><span class="content-heading-main-title">First section: (~1:30)</span></dt>
     <dd>
         <ul>
             <li>(0:20) <a href="track/t1/">Track 1</a></li>
@@ -24,7 +24,7 @@ exports[`test/snapshot/generateAlbumTrackList.js > TAP > generateAlbumTrackList 
             <li>(0:40) <a href="track/t3/">Track 3</a></li>
         </ul>
     </dd>
-    <dt class="content-heading" tabindex="0"><span class="content-heading-main-title">Second section (0:05):</span></dt>
+    <dt class="content-heading" tabindex="0"><span class="content-heading-main-title">Second section: (0:05)</span></dt>
     <dd><ul><li style="--primary-color: #ea2e83">(0:05) <a href="track/t4/">Track 4</a> <span class="by">by <a href="artist/apricot/">Apricot</a> and <a href="artist/peach/">Peach</a></span></li></ul></dd>
 </dl>
 `

--- a/tap-snapshots/test/snapshot/linkArtist.js.test.cjs
+++ b/tap-snapshots/test/snapshot/linkArtist.js.test.cjs
@@ -10,5 +10,5 @@ exports[`test/snapshot/linkArtist.js > TAP > linkArtist (snapshot) > basic behav
 `
 
 exports[`test/snapshot/linkArtist.js > TAP > linkArtist (snapshot) > prefer short name 1`] = `
-<span class="text-with-tooltip"><a href="artist/55gore/">55gore</a><span class="tooltip thing-name-tooltip"><span class="tooltip-content">ICCTTCMDMIROTMCWMWFTPFTDDOTARHPOESWGBTWEATFCWSEBTSSFOFG</span></span></span>
+<span class="text-with-tooltip"><span class="hoverable"><a class="text-with-tooltip-interaction-cue" href="artist/55gore/">55gore</a></span><span class="tooltip thing-name-tooltip"><span class="tooltip-content">ICCTTCMDMIROTMCWMWFTPFTDDOTARHPOESWGBTWEATFCWSEBTSSFOFG</span></span></span>
 `

--- a/tap-snapshots/test/snapshot/linkContribution.js.test.cjs
+++ b/tap-snapshots/test/snapshot/linkContribution.js.test.cjs
@@ -30,7 +30,7 @@ exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) >
 `
 
 exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) > loads of links (tooltip) 1`] = `
-<span class="contribution"><span class="text-with-tooltip"><a href="artist/lorem-ipsum-lover/">Lorem Ipsum Lover</a><span class="tooltip icons icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://loremipsum.io">
+<span class="contribution"><span class="text-with-tooltip"><span class="hoverable"><a class="text-with-tooltip-interaction-cue" href="artist/lorem-ipsum-lover/">Lorem Ipsum Lover</a></span><span class="tooltip icons icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://loremipsum.io">
                     <svg><use href="static/icons.svg#icon-globe"></use></svg>
                     <span class="icon-text">loremipsum.io</span>
                 </a><a class="icon has-text" href="https://loremipsum.io/generator/">
@@ -112,12 +112,12 @@ exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) >
 `
 
 exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) > only showIcons (tooltip) 1`] = `
-<span class="contribution"><span class="text-with-tooltip"><a href="artist/clark-powell/">Clark Powell</a><span class="tooltip icons icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://soundcloud.com/plazmataz">
+<span class="contribution"><span class="text-with-tooltip"><span class="hoverable"><a class="text-with-tooltip-interaction-cue" href="artist/clark-powell/">Clark Powell</a></span><span class="tooltip icons icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://soundcloud.com/plazmataz">
                     <svg><use href="static/icons.svg#icon-soundcloud"></use></svg>
                     <span class="icon-text">plazmataz</span>
                 </a></span></span></span></span>
 <span class="contribution nowrap"><a href="artist/the-big-baddies/">Grounder &amp; Scratch</a> (Snooping)</span>
-<span class="contribution nowrap"><span class="text-with-tooltip"><a href="artist/toby-fox/">Toby Fox</a><span class="tooltip icons icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://tobyfox.bandcamp.com/">
+<span class="contribution nowrap"><span class="text-with-tooltip"><span class="hoverable"><a class="text-with-tooltip-interaction-cue" href="artist/toby-fox/">Toby Fox</a></span><span class="tooltip icons icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://tobyfox.bandcamp.com/">
                     <svg><use href="static/icons.svg#icon-bandcamp"></use></svg>
                     <span class="icon-text">tobyfox</span>
                 </a><a class="icon has-text" href="https://toby.fox/">
@@ -148,12 +148,12 @@ exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) >
 `
 
 exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) > showContribution & showIcons (tooltip) 1`] = `
-<span class="contribution"><span class="text-with-tooltip"><a href="artist/clark-powell/">Clark Powell</a><span class="tooltip icons icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://soundcloud.com/plazmataz">
+<span class="contribution"><span class="text-with-tooltip"><span class="hoverable"><a class="text-with-tooltip-interaction-cue" href="artist/clark-powell/">Clark Powell</a></span><span class="tooltip icons icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://soundcloud.com/plazmataz">
                     <svg><use href="static/icons.svg#icon-soundcloud"></use></svg>
                     <span class="icon-text">plazmataz</span>
                 </a></span></span></span></span>
 <span class="contribution nowrap"><a href="artist/the-big-baddies/">Grounder &amp; Scratch</a> (Snooping)</span>
-<span class="contribution nowrap"><span class="text-with-tooltip"><a href="artist/toby-fox/">Toby Fox</a><span class="tooltip icons icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://tobyfox.bandcamp.com/">
+<span class="contribution nowrap"><span class="text-with-tooltip"><span class="hoverable"><a class="text-with-tooltip-interaction-cue" href="artist/toby-fox/">Toby Fox</a></span><span class="tooltip icons icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://tobyfox.bandcamp.com/">
                     <svg><use href="static/icons.svg#icon-bandcamp"></use></svg>
                     <span class="icon-text">tobyfox</span>
                 </a><a class="icon has-text" href="https://toby.fox/">

--- a/tap-snapshots/test/snapshot/linkThing.js.test.cjs
+++ b/tap-snapshots/test/snapshot/linkThing.js.test.cjs
@@ -13,7 +13,7 @@ exports[`test/snapshot/linkThing.js > TAP > linkThing (snapshot) > color 1`] = `
 <a href="track/showtime-piano-refrain/">Showtime (Piano Refrain)</a>
 <a style="--primary-color: #38f43d" href="track/showtime-piano-refrain/">Showtime (Piano Refrain)</a>
 <a style="--primary-color: #aaccff" href="track/showtime-piano-refrain/">Showtime (Piano Refrain)</a>
-<span style="--primary-color: #aaccff" class="text-with-tooltip"><a href="track/showtime-piano-refrain/">Showtime (Piano Refrain)</a><span class="tooltip thing-name-tooltip"><span class="tooltip-content">Showtime (Piano Refrain)</span></span></span>
+<span style="--primary-color: #aaccff" class="text-with-tooltip"><span class="hoverable"><a class="text-with-tooltip-interaction-cue" href="track/showtime-piano-refrain/">Showtime (Piano Refrain)</a></span><span class="tooltip thing-name-tooltip"><span class="tooltip-content">Showtime (Piano Refrain)</span></span></span>
 `
 
 exports[`test/snapshot/linkThing.js > TAP > linkThing (snapshot) > nested links in content stripped 1`] = `
@@ -21,7 +21,7 @@ exports[`test/snapshot/linkThing.js > TAP > linkThing (snapshot) > nested links 
 `
 
 exports[`test/snapshot/linkThing.js > TAP > linkThing (snapshot) > preferShortName 1`] = `
-<span class="text-with-tooltip"><a href="tag/five-oceanfalls/">Five</a><span class="tooltip thing-name-tooltip"><span class="tooltip-content">Five (Oceanfalls)</span></span></span>
+<span class="text-with-tooltip"><span class="hoverable"><a class="text-with-tooltip-interaction-cue" href="tag/five-oceanfalls/">Five</a></span><span class="tooltip thing-name-tooltip"><span class="tooltip-content">Five (Oceanfalls)</span></span></span>
 `
 
 exports[`test/snapshot/linkThing.js > TAP > linkThing (snapshot) > tags in name escaped 1`] = `
@@ -36,10 +36,10 @@ exports[`test/snapshot/linkThing.js > TAP > linkThing (snapshot) > tooltip & con
 <a title="Beyond Canon" href="album/beyond-canon/">Beyond Canon</a>
 <a title="Beyond Canon" href="album/beyond-canon/">Next</a>
 <a href="album/beyond-canon/">Beyond Canon</a>
-<span class="text-with-tooltip"><a href="album/beyond-canon/">BC</a><span class="tooltip thing-name-tooltip"><span class="tooltip-content">Beyond Canon</span></span></span>
-<span class="text-with-tooltip"><a href="album/beyond-canon/">Next</a><span class="tooltip thing-name-tooltip"><span class="tooltip-content">Beyond Canon</span></span></span>
+<span class="text-with-tooltip"><span class="hoverable"><a class="text-with-tooltip-interaction-cue" href="album/beyond-canon/">BC</a></span><span class="tooltip thing-name-tooltip"><span class="tooltip-content">Beyond Canon</span></span></span>
+<span class="text-with-tooltip"><span class="hoverable"><a class="text-with-tooltip-interaction-cue" href="album/beyond-canon/">Next</a></span><span class="tooltip thing-name-tooltip"><span class="tooltip-content">Beyond Canon</span></span></span>
 <a href="album/beyond-canon/">Next</a>
-<span class="text-with-tooltip"><a href="album/beyond-canon/">Beyond Canon</a><span class="tooltip thing-name-tooltip"><span class="tooltip-content">Beyond Canon</span></span></span>
-<span class="text-with-tooltip"><a href="album/beyond-canon/">Next</a><span class="tooltip thing-name-tooltip"><span class="tooltip-content">Beyond Canon</span></span></span>
+<span class="text-with-tooltip"><span class="hoverable"><a class="text-with-tooltip-interaction-cue" href="album/beyond-canon/">Beyond Canon</a></span><span class="tooltip thing-name-tooltip"><span class="tooltip-content">Beyond Canon</span></span></span>
+<span class="text-with-tooltip"><span class="hoverable"><a class="text-with-tooltip-interaction-cue" href="album/beyond-canon/">Next</a></span><span class="tooltip thing-name-tooltip"><span class="tooltip-content">Beyond Canon</span></span></span>
 <a href="album/beyond-canon/">Banana</a>
 `

--- a/test/snapshot/generateAlbumTrackList.js
+++ b/test/snapshot/generateAlbumTrackList.js
@@ -2,7 +2,12 @@ import t from 'tap';
 import {testContentFunctions} from '#test-lib';
 
 testContentFunctions(t, 'generateAlbumTrackList (snapshot)', async (t, evaluate) => {
-  await evaluate.load();
+  await evaluate.load({
+    mock: {
+      generateAlbumTrackListMissingDuration:
+        evaluate.stubContentFunction('generateAlbumTrackListMissingDuration'),
+    },
+  });
 
   const contribs1 = [
     {who: {name: 'Apricot', directory: 'apricot', urls: null}},
@@ -18,31 +23,82 @@ testContentFunctions(t, 'generateAlbumTrackList (snapshot)', async (t, evaluate)
 
   const tracks = [
     {name: 'Track 1', directory: 't1', duration: 20, artistContribs: contribs1, color: color1},
-    {name: 'Track 2', directory: 't2', duration: 30, artistContribs: contribs1, color: color1},
+    {name: 'Track 2', directory: 't2', duration: 0, artistContribs: contribs1, color: color1},
     {name: 'Track 3', directory: 't3', duration: 40, artistContribs: contribs1, color: color1},
-    {name: 'Track 4', directory: 't4', duration: 5, artistContribs: contribs2, color: color2},
+    {name: 'Track 4', directory: 't4', duration: 0, artistContribs: contribs2, color: color2},
   ];
 
-  evaluate.snapshot('basic behavior, with track sections', {
+  const albumWithTrackSections = {
+    color: color1,
+    artistContribs: contribs1,
+    trackSections: [
+      {name: 'First section', tracks: tracks.slice(0, 3)},
+      {name: 'Second section', tracks: tracks.slice(3)},
+    ],
+    tracks,
+  };
+
+  const albumWithoutTrackSections = {
+    color: color1,
+    artistContribs: contribs1,
+    trackSections: [{isDefaultTrackSection: true, tracks}],
+    tracks,
+  };
+
+  const albumWithNoDuration = {
+    color: color1,
+    artistContribs: contribs1,
+    trackSections: [{isDefaultTrackSection: true, tracks: [tracks[1], tracks[3]]}],
+    tracks: [tracks[1], tracks[3]],
+  };
+
+  evaluate.snapshot(`basic behavior, with track sections`, {
     name: 'generateAlbumTrackList',
-    args: [{
-      color: color1,
-      artistContribs: contribs1,
-      trackSections: [
-        {name: 'First section', tracks: tracks.slice(0, 3)},
-        {name: 'Second section', tracks: tracks.slice(3)},
-      ],
-      tracks,
-    }],
+    args: [albumWithTrackSections],
   });
 
-  evaluate.snapshot('basic behavior, default track section', {
+  evaluate.snapshot(`basic behavior, default track section`, {
     name: 'generateAlbumTrackList',
-    args: [{
-      color: color1,
-      artistContribs: contribs1,
-      trackSections: [{isDefaultTrackSection: true, tracks}],
-      tracks,
-    }],
+    args: [albumWithoutTrackSections],
+  });
+
+  evaluate.snapshot(`collapseDurationScope: never`, {
+    name: 'generateAlbumTrackList',
+    slots: {collapseDurationScope: 'never'},
+    multiple: [
+      {args: [albumWithTrackSections]},
+      {args: [albumWithoutTrackSections]},
+      {args: [albumWithNoDuration]},
+    ],
+  });
+
+  evaluate.snapshot(`collapseDurationScope: track`, {
+    name: 'generateAlbumTrackList',
+    slots: {collapseDurationScope: 'track'},
+    multiple: [
+      {args: [albumWithTrackSections]},
+      {args: [albumWithoutTrackSections]},
+      {args: [albumWithNoDuration]},
+    ],
+  });
+
+  evaluate.snapshot(`collapseDurationScope: section`, {
+    name: 'generateAlbumTrackList',
+    slots: {collapseDurationScope: 'section'},
+    multiple: [
+      {args: [albumWithTrackSections]},
+      {args: [albumWithoutTrackSections]},
+      {args: [albumWithNoDuration]},
+    ],
+  });
+
+  evaluate.snapshot(`collapseDurationScope: album`, {
+    name: 'generateAlbumTrackList',
+    slots: {collapseDurationScope: 'album'},
+    multiple: [
+      {args: [albumWithTrackSections]},
+      {args: [albumWithoutTrackSections]},
+      {args: [albumWithNoDuration]},
+    ],
   });
 });


### PR DESCRIPTION
Development:

- Resolves #398.

This PR touches up the way tracks without durations are handled and presented on album info pages! After discussion in the server with vriska ([#hsmusic-chat](https://discord.com/channels/749042497610842152/779895315750715422/1204598405427368026)) we decided to go with slightly more reserved changes than originally planned — missing durations are still written as "(_:__)". But otherwise everything's here: dim until hovered, tooltip with updated content: "no duration provided; treated as zero seconds long", and relatively smart compacting dynamics!

* We had to make some changes to the way text-with-tooltip works! There was initially some hierarchy trouble, where we wanted the "cue" to be just the `0:00` text and not the wrapping parentheses, meaning the `0:00` would get dotted- and wavy-underlined, while the parentheses wouldn't... while still keeping the whole `(0:00)` as the *hoverable,* including the dim effect. In order to support this...
  * We tweaked how CSS selects text-with-tooltip stuff! It now generally targets class names instead of `:first-child` and direct descendants and such.
  * This allows better content control, since we can nest the cue further down, and it'll still be selected with its new class name: `.text-with-tooltip-interaction-cue`.
  * The cue is always nested *inside* the hoverable; the hoverable itself can't be the cue. This is mostly just for CSS niceness, but also somewhat more reliable layout consistency. This means the "text" slot is *always* wrapped in a plain `<span class="hoverable">`.
  * `generateTextWithTooltip` automatically *also* nests the "text" slot in `<span class="text-with-tooltip-interaction-cue">`, so that all the text is treated as the cue... *unless* you've provided the slot `customInteractionCue`, indicating you're going to take responsibility for putting that class where it goes!
  * We use this to target specifically the `0:00` (or now the `_:__`) with CSS.
  * We *also* use this to make the artist link of `linkContribution` into that text-with-tooltip's cue — otherwise the underline would be applied to the (auto-inserted) containing span, which is sort of fine, but 1) wouldn't get the custom color set on the link, and 2) wouldn't *replace* the link's own underline when hovered!
  * Other, simpler use cases (just datetimestamps, at the moment) can get by without custom cues no problem.
* We also had to be careful with how the dim opacity gets applied; we don't want to accidentally dim the *tooltip!* The new `.hoverable` class helped with this (we were targeting `:first-child` before and that was kind of awkward).
* Duration collapsing has some fun dynamics!
  * Track sections with zero total duration will *always* display the nice compact form, skipping out on the duration accent altogether (for that chunk's title).
  * Tracks with missing duration are context-sensitive! Just how sensitive is controlled by a `collapseDurationScope` slot (passed in through `generateAlbumTrackList`), which takes one of four values.
  * `never`: A track's missing duration will *always* be displayed.
  * `track`: A track's missing duration will *never* be displayed.
  * `section`: A track's missing duration will be displayed *only if* there are any other tracks in the section which *have* a duration.
  * `album`: A track's missing duration will be displayed *only if* there are any other tracks in the whole album which *have* a duration. (This is the default!)
* At the moment, "missing duration" just means "a track whose duration is unset or zero". We definitely want to support tracks that are actually zero seconds long; in the future these would just be displayed as "(0:00)", and completely excluded from any of this "missing duration" nonsense! We don't have that feature yet, but the new code here is basically ready for it: all "does this have any duration?" logic is neatly isolated in the `query` step for `generateAlbumTrackListItem`.

New snapshot tests are also included for `generateAlbumTrackList`'s different `collapseDurationScope` modes, and existing snapshot tests are updated where relevant, of course! (That's mostly because `linkThing`-with-tooltips gets the touched up text-with-tooltip layout.)