### PR TITLE
Chronology link fix-ups

### DIFF
--- a/src/content/dependencies/generateAlbumInfoPage.js
+++ b/src/content/dependencies/generateAlbumInfoPage.js
@@ -54,13 +54,16 @@ export default {
             ? relation('linkTrack', trackOrAlbum)
             : relation('linkAlbum', trackOrAlbum)),
 
-        getThings: artist =>
-          sortAlbumsTracksChronologically([
+        getThings(artist) {
+          const getDate = thing => thing.coverArtDate ?? thing.date;
+
+          const things = [
             ...artist.albumsAsCoverArtist,
             ...artist.tracksAsCoverArtist,
-          ], {
-            getDate: thing => thing.coverArtDate ?? thing.date,
-          }),
+          ].filter(getDate);
+
+          return sortAlbumsTracksChronologically(things, {getDate});
+        },
       });
 
     relations.albumNavAccent =

--- a/src/content/dependencies/generateAlbumInfoPage.js
+++ b/src/content/dependencies/generateAlbumInfoPage.js
@@ -58,7 +58,9 @@ export default {
           sortAlbumsTracksChronologically([
             ...artist.albumsAsCoverArtist,
             ...artist.tracksAsCoverArtist,
-          ]),
+          ], {
+            getDate: thing => thing.coverArtDate ?? thing.date,
+          }),
       });
 
     relations.albumNavAccent =

--- a/src/content/dependencies/generateTrackInfoPage.js
+++ b/src/content/dependencies/generateTrackInfoPage.js
@@ -64,11 +64,16 @@ export default {
         linkArtist: artist => relation('linkArtist', artist),
         linkThing: track => relation('linkTrack', track),
 
-        getThings: artist =>
-          sortAlbumsTracksChronologically([
+        getThings(artist) {
+          const getDate = thing => thing.date;
+
+          const things = [
             ...artist.tracksAsArtist,
             ...artist.tracksAsContributor,
-          ]),
+          ].filter(getDate);
+
+          return sortAlbumsTracksChronologically(things, {getDate});
+        },
       });
 
     relations.coverArtistChronologyContributions =
@@ -82,13 +87,16 @@ export default {
             ? relation('linkTrack', trackOrAlbum)
             : relation('linkAlbum', trackOrAlbum)),
 
-        getThings: artist =>
-          sortAlbumsTracksChronologically([
+        getThings(artist) {
+          const getDate = thing => thing.coverArtDate ?? thing.date;
+
+          const things = [
             ...artist.albumsAsCoverArtist,
             ...artist.tracksAsCoverArtist,
-          ], {
-            getDate: thing => thing.coverArtDate ?? thing.date,
-          }),
+          ].filter(getDate);
+
+          return sortAlbumsTracksChronologically(things, {getDate});
+        },
       }),
 
     relations.albumLink =

--- a/src/content/util/getChronologyRelations.js
+++ b/src/content/util/getChronologyRelations.js
@@ -29,13 +29,22 @@ export default function getChronologyRelations(thing, {
 
   return contributions.map(({who}) => {
     const things = Array.from(new Set(getThings(who)));
-    if (things.length === 1) {
+
+    // Don't show a line if this contribution isn't part of the artist's
+    // chronology at all (usually because this thing isn't dated).
+    const index = things.indexOf(thing);
+    if (index === -1) {
       return;
     }
 
-    const index = things.indexOf(thing);
+    // Don't show a line if this contribution is the *only* item in the
+    // artist's chronology (since there's nothing to navigate there).
     const previous = things[index - 1];
     const next = things[index + 1];
+    if (!previous && !next) {
+      return;
+    }
+
     return {
       index: index + 1,
       artistLink: linkArtist(who),


### PR DESCRIPTION
This PR bundles two fixes for chronology links:

* `generateAlbumInfoPage` artwork chronology links were processing based on each thing's `date`, instead of its `coverArtDate`, resulting in some misalignments.
* *All* chronology links were allowing dateless things to pass through; the underlying `sortByDate` would just move these to the end of the list. So Toby's "latest" track wasn't [Soul Tether](https://hsmusic.wiki/preview-en/track/soul-tether/), it was [Charun's Cave](https://hsmusic.wiki/preview-en/track/charuns-cave/), for example.

Relevant code is refactored to be a bit nicer, too. Notably, in `getChronologyRelations`, we're now checking for presence of `next` or `previous`, rather than if the length of an artist's whole chronology (`things`) is greater than one; these accomplish the exact same effect, but it more directly phrases *why* we're doing what we are.