### PR TITLE
Detect & report miscapitalization in commentary heading

### DIFF
--- a/src/data/composite/wiki-data/withParsedCommentaryEntries.js
+++ b/src/data/composite/wiki-data/withParsedCommentaryEntries.js
@@ -2,7 +2,7 @@ import {input, templateCompositeFrom} from '#composite';
 import find from '#find';
 import {stitchArrays} from '#sugar';
 import {isCommentary} from '#validators';
-import {commentaryRegex} from '#wiki-data';
+import {commentaryRegexCaseSensitive} from '#wiki-data';
 
 import {
   fillMissingListItems,
@@ -30,7 +30,7 @@ export default templateCompositeFrom({
         [input('from')]: commentaryText,
       }) => continuation({
         ['#rawMatches']:
-          Array.from(commentaryText.matchAll(commentaryRegex)),
+          Array.from(commentaryText.matchAll(commentaryRegexCaseSensitive)),
       }),
     },
 

--- a/src/data/validators.js
+++ b/src/data/validators.js
@@ -5,7 +5,8 @@ import printable_characters from 'printable-characters';
 const {strlen} = printable_characters;
 
 import {colors, ENABLE_COLOR} from '#cli';
-import {commentaryRegex} from '#wiki-data';
+import {commentaryRegexCaseInsensitive, commentaryRegexCaseSensitive}
+  from '#wiki-data';
 
 import {
   cut,
@@ -302,7 +303,7 @@ export function isCommentary(commentaryText) {
   isContentString(commentaryText);
 
   const rawMatches =
-    Array.from(commentaryText.matchAll(commentaryRegex));
+    Array.from(commentaryText.matchAll(commentaryRegexCaseInsensitive));
 
   if (empty(rawMatches)) {
     throw new TypeError(`Expected at least one commentary heading`);
@@ -330,6 +331,14 @@ export function isCommentary(commentaryText) {
         `${colors.green(`"${cut(ownInput, 40)}"`)} (<- heading)\n` +
         `(extra on same line ->) ${colors.red(`"${cut(upToNextLineBreak, 30)}"`)}\n` +
         `(Check for missing "|-" in YAML, or a misshapen annotation)`);
+    }
+
+    commentaryRegexCaseSensitive.lastIndex = 0;
+    if (!commentaryRegexCaseSensitive.test(ownInput)) {
+      throw new TypeError(
+        `Miscapitalization in commentary heading:\n` +
+        `${colors.red(`"${cut(ownInput, 60)}"`)}\n` +
+        `(Check for ${colors.red(`"<I>"`)} instead of ${colors.green(`"<i>"`)})`);
     }
 
     const nextHeading =

--- a/src/data/yaml.js
+++ b/src/data/yaml.js
@@ -12,7 +12,7 @@ import {colors, ENABLE_COLOR, logInfo, logWarn} from '#cli';
 import find, {bindFind, getAllFindSpecs} from '#find';
 import Thing from '#thing';
 import thingConstructors from '#things';
-import {commentaryRegex, sortByName} from '#wiki-data';
+import {commentaryRegexCaseSensitive, sortByName} from '#wiki-data';
 
 import {
   annotateErrorWithFile,
@@ -1189,7 +1189,7 @@ export function filterReferenceErrors(wikiData) {
               case '_commentary':
                 if (value) {
                   value =
-                    Array.from(value.matchAll(commentaryRegex))
+                    Array.from(value.matchAll(commentaryRegexCaseSensitive))
                       .map(({groups}) => groups.artistReferences)
                       .map(text => text.split(',').map(text => text.trim()));
                 }

--- a/src/util/wiki-data.js
+++ b/src/util/wiki-data.js
@@ -665,8 +665,12 @@ export function sortFlashesChronologically(data, {
 // This regular expression *doesn't* match bodies, which will need to be parsed
 // out of the original string based on the indices matched using this.
 //
-export const commentaryRegex =
-  /^<i>(?<artistReferences>.+?)(?:\|(?<artistDisplayText>.+))?:<\/i>(?: \((?<annotation>(?:.*?(?=,|\)[^)]*$))*?)(?:,? ?(?<date>[a-zA-Z]+ [0-9]{1,2}, [0-9]{4,4}|[0-9]{1,2} [^,]*[0-9]{4,4}|[0-9]{1,4}[-/][0-9]{1,4}[-/][0-9]{1,4}))?\))?/gm;
+const commentaryRegexRaw =
+  String.raw`^<i>(?<artistReferences>.+?)(?:\|(?<artistDisplayText>.+))?:<\/i>(?: \((?<annotation>(?:.*?(?=,|\)[^)]*$))*?)(?:,? ?(?<date>[a-zA-Z]+ [0-9]{1,2}, [0-9]{4,4}|[0-9]{1,2} [^,]*[0-9]{4,4}|[0-9]{1,4}[-/][0-9]{1,4}[-/][0-9]{1,4}))?\))?`;
+export const commentaryRegexCaseInsensitive =
+  new RegExp(commentaryRegexRaw, 'gmi');
+export const commentaryRegexCaseSensitive =
+  new RegExp(commentaryRegexRaw, 'gm');
 
 export function filterAlbumsByCommentary(albums) {
   return albums


### PR DESCRIPTION
This is specifically regarding the only part of commentary headings that are actually case-sensitive, the artist-wrapping `<i>` and `</i>`. Miscapitalized artist references are handled by `filterReferenceErrors` like usual.

Two problems, now detected and reported every time hsmusic runs, [got caught](https://github.com/hsmusic/hsmusic-data/commit/49c62f593ec49659436674b2cae71b8892d93c82) by this:

* `<I>Toby Fox:</i>`, on [Horschestra STRONG Version](https://hsmusic.wiki/preview-en/track/horschestra-STRONG-version/), wasn't getting treated as a commentary heading at all(!). This broke apparent formatting in [the new layout](https://github.com/hsmusic/hsmusic-wiki/pull/328), and kept the entry from displaying on Toby Fox's "Commentary" section (in both old and new).
* `<i>0syTezy:</I>`, on [Premortem](https://hsmusic.wiki/preview-en/track/premortem/), wasn't getting styled either. But worse, it actually included a reference error — the correct spelling is `OysTezy`! We only catch one of these at a time, i.e. it'll warn you, "hey, this isn't a commentary heading, plz check capitalization" and *then* (once you fix that), it'll display the reference error (as usual).

Internally, we now require specifying which of `commentaryRegexCaseSensitive` or `commentaryRegexCaseInsensitive` you want to use; for actually processing data, it's always the former, but data validation uses the latter and then checks each heading against the former, reporting mismatches.
