### PR TITLE
Be smarter about "YouTube (full album)" links; support providing multiple contexts

### DIFF
--- a/src/content/dependencies/generateAlbumReleaseInfo.js
+++ b/src/content/dependencies/generateAlbumReleaseInfo.js
@@ -46,6 +46,8 @@ export default {
     data.duration = accumulateSum(album.tracks, track => track.duration);
     data.durationApproximate = album.tracks.length > 1;
 
+    data.numTracks = album.tracks.length;
+
     return data;
   },
 
@@ -95,7 +97,14 @@ export default {
                 relations.externalLinks
                   .map(link =>
                     link.slots({
-                      context: 'album',
+                      context: [
+                        'album',
+                        (data.numTracks === 0
+                          ? 'albumNoTracks'
+                       : data.numTracks === 1
+                          ? 'albumOneTrack'
+                          : 'albumMultipleTracks'),
+                      ],
                       style: 'normal',
                     }))),
           })),

--- a/src/util/external-links.js
+++ b/src/util/external-links.js
@@ -24,6 +24,9 @@ export const isExternalLinkStyle = is(...externalLinkStyles);
 
 export const externalLinkContexts = [
   'album',
+  'albumOneTrack',
+  'albumMultipleTracks',
+  'albumNoTracks',
   'artist',
   'flash',
   'generic',
@@ -125,7 +128,7 @@ export const externalLinkSpec = [
 
   {
     match: {
-      context: 'album',
+      context: 'albumMultipleTracks',
       domain: 'youtube.com',
       pathname: /^watch/,
     },
@@ -138,7 +141,7 @@ export const externalLinkSpec = [
 
   {
     match: {
-      context: 'album',
+      context: 'albumMultipleTracks',
       domain: 'youtu.be',
     },
 

--- a/tap-snapshots/test/snapshot/linkExternal.js.test.cjs
+++ b/tap-snapshots/test/snapshot/linkExternal.js.test.cjs
@@ -12,12 +12,66 @@ exports[`test/snapshot/linkExternal.js > TAP > linkExternal (snapshot) > context
 `
 
 exports[`test/snapshot/linkExternal.js > TAP > linkExternal (snapshot) > context: album, style: normal 1`] = `
+<a href="https://youtu.be/abc" class="nowrap">YouTube</a>
+<a href="https://youtube.com/watch?v=abc" class="nowrap">YouTube</a>
+<a href="https://youtube.com/Playlist?list=kweh" class="nowrap">YouTube</a>
+`
+
+exports[`test/snapshot/linkExternal.js > TAP > linkExternal (snapshot) > context: album, style: platform 1`] = `
+<a href="https://youtu.be/abc" class="nowrap">YouTube</a>
+<a href="https://youtube.com/watch?v=abc" class="nowrap">YouTube</a>
+<a href="https://youtube.com/Playlist?list=kweh" class="nowrap">YouTube</a>
+`
+
+exports[`test/snapshot/linkExternal.js > TAP > linkExternal (snapshot) > context: albumMultipleTracks, style: compact 1`] = `
+<a href="https://youtu.be/abc" class="nowrap">youtu.be</a>
+<a href="https://youtube.com/watch?v=abc" class="nowrap">youtube.com</a>
+<a href="https://youtube.com/Playlist?list=kweh" class="nowrap">youtube.com</a>
+`
+
+exports[`test/snapshot/linkExternal.js > TAP > linkExternal (snapshot) > context: albumMultipleTracks, style: normal 1`] = `
 <a href="https://youtu.be/abc" class="nowrap">YouTube (full album)</a>
 <a href="https://youtube.com/watch?v=abc" class="nowrap">YouTube (full album)</a>
 <a href="https://youtube.com/Playlist?list=kweh" class="nowrap">YouTube</a>
 `
 
-exports[`test/snapshot/linkExternal.js > TAP > linkExternal (snapshot) > context: album, style: platform 1`] = `
+exports[`test/snapshot/linkExternal.js > TAP > linkExternal (snapshot) > context: albumMultipleTracks, style: platform 1`] = `
+<a href="https://youtu.be/abc" class="nowrap">YouTube</a>
+<a href="https://youtube.com/watch?v=abc" class="nowrap">YouTube</a>
+<a href="https://youtube.com/Playlist?list=kweh" class="nowrap">YouTube</a>
+`
+
+exports[`test/snapshot/linkExternal.js > TAP > linkExternal (snapshot) > context: albumNoTracks, style: compact 1`] = `
+<a href="https://youtu.be/abc" class="nowrap">youtu.be</a>
+<a href="https://youtube.com/watch?v=abc" class="nowrap">youtube.com</a>
+<a href="https://youtube.com/Playlist?list=kweh" class="nowrap">youtube.com</a>
+`
+
+exports[`test/snapshot/linkExternal.js > TAP > linkExternal (snapshot) > context: albumNoTracks, style: normal 1`] = `
+<a href="https://youtu.be/abc" class="nowrap">YouTube</a>
+<a href="https://youtube.com/watch?v=abc" class="nowrap">YouTube</a>
+<a href="https://youtube.com/Playlist?list=kweh" class="nowrap">YouTube</a>
+`
+
+exports[`test/snapshot/linkExternal.js > TAP > linkExternal (snapshot) > context: albumNoTracks, style: platform 1`] = `
+<a href="https://youtu.be/abc" class="nowrap">YouTube</a>
+<a href="https://youtube.com/watch?v=abc" class="nowrap">YouTube</a>
+<a href="https://youtube.com/Playlist?list=kweh" class="nowrap">YouTube</a>
+`
+
+exports[`test/snapshot/linkExternal.js > TAP > linkExternal (snapshot) > context: albumOneTrack, style: compact 1`] = `
+<a href="https://youtu.be/abc" class="nowrap">youtu.be</a>
+<a href="https://youtube.com/watch?v=abc" class="nowrap">youtube.com</a>
+<a href="https://youtube.com/Playlist?list=kweh" class="nowrap">youtube.com</a>
+`
+
+exports[`test/snapshot/linkExternal.js > TAP > linkExternal (snapshot) > context: albumOneTrack, style: normal 1`] = `
+<a href="https://youtu.be/abc" class="nowrap">YouTube</a>
+<a href="https://youtube.com/watch?v=abc" class="nowrap">YouTube</a>
+<a href="https://youtube.com/Playlist?list=kweh" class="nowrap">YouTube</a>
+`
+
+exports[`test/snapshot/linkExternal.js > TAP > linkExternal (snapshot) > context: albumOneTrack, style: platform 1`] = `
 <a href="https://youtu.be/abc" class="nowrap">YouTube</a>
 <a href="https://youtube.com/watch?v=abc" class="nowrap">YouTube</a>
 <a href="https://youtube.com/Playlist?list=kweh" class="nowrap">YouTube</a>

--- a/test/snapshot/linkExternal.js
+++ b/test/snapshot/linkExternal.js
@@ -57,6 +57,24 @@ testContentFunctions(t, 'linkExternal (snapshot)', async (t, evaluate) => {
     'https://youtube.com/Playlist?list=kweh',
   ]);
 
+  quickSnapshotAllStyles('albumNoTracks', [
+    'https://youtu.be/abc',
+    'https://youtube.com/watch?v=abc',
+    'https://youtube.com/Playlist?list=kweh',
+  ]);
+
+  quickSnapshotAllStyles('albumOneTrack', [
+    'https://youtu.be/abc',
+    'https://youtube.com/watch?v=abc',
+    'https://youtube.com/Playlist?list=kweh',
+  ]);
+
+  quickSnapshotAllStyles('albumMultipleTracks', [
+    'https://youtu.be/abc',
+    'https://youtube.com/watch?v=abc',
+    'https://youtube.com/Playlist?list=kweh',
+  ]);
+
   quickSnapshotAllStyles('flash', [
     'https://www.bgreco.net/hsflash/002238.html',
     'https://homestuck.com/story/1234',


### PR DESCRIPTION
Previously, album links to YouTube videos would *always* display "YouTube (full album)" — even if the album only included one track! This fixes that by allowing calls to `linkExternal` to slot in multiple applicable contexts, instead of just one.

Contexts are still binary, i.e. "this context is provided or isn't provided". So to accommodate track count, one of three new contexts is provided alongside `album`: `albumNoTracks`, `albumOneTrack`, `albumMultipleTracks`. The existing `fullAlbum` specs are made conditional on the last of those, and snapshot tests are accordingly updated.