### PR TITLE
Validate commentary capitalization w/ non-global regex

### DIFF
--- a/src/data/validators.js
+++ b/src/data/validators.js
@@ -5,7 +5,7 @@ import printable_characters from 'printable-characters';
 const {strlen} = printable_characters;
 
 import {colors, ENABLE_COLOR} from '#cli';
-import {commentaryRegexCaseInsensitive, commentaryRegexCaseSensitive}
+import {commentaryRegexCaseInsensitive, commentaryRegexCaseSensitiveOneShot}
   from '#wiki-data';
 
 import {
@@ -333,8 +333,7 @@ export function isCommentary(commentaryText) {
         `(Check for missing "|-" in YAML, or a misshapen annotation)`);
     }
 
-    commentaryRegexCaseSensitive.lastIndex = 0;
-    if (!commentaryRegexCaseSensitive.test(ownInput)) {
+    if (!commentaryRegexCaseSensitiveOneShot.test(ownInput)) {
       throw new TypeError(
         `Miscapitalization in commentary heading:\n` +
         `${colors.red(`"${cut(ownInput, 60)}"`)}\n` +

--- a/src/util/wiki-data.js
+++ b/src/util/wiki-data.js
@@ -671,6 +671,8 @@ export const commentaryRegexCaseInsensitive =
   new RegExp(commentaryRegexRaw, 'gmi');
 export const commentaryRegexCaseSensitive =
   new RegExp(commentaryRegexRaw, 'gm');
+export const commentaryRegexCaseSensitiveOneShot =
+  new RegExp(commentaryRegexRaw);
 
 export function filterAlbumsByCommentary(albums) {
   return albums


### PR DESCRIPTION
Follow-up to #410.

The built-in `[@@matchAll]` behavior on a regular expression clones the regex and specifically preserves its `lastIndex`, such that the iterator yields matches continuing from whatever position the regex last left off. Because we were using the same regular expression for validating as iterating matches, and validating left its `lastIndex` past the start, the first entry in various commentary properties tended to get skipped.

This PR validates commentary headings with a different regular expression. This one is non-global, so doesn't require the preceding `lastIndex = 0` behavior we previously put in place, and avoids any hijinks to do with `lastIndex`.