### PR TITLE
Minor find/boundFind code cleanup!

### DIFF
--- a/src/data/things/artist.js
+++ b/src/data/things/artist.js
@@ -256,16 +256,13 @@ export class Artist extends Thing {
       include: artist => !artist.isAlias,
     },
 
-    artistIncludingAliases: {
+    artistAlias: {
       referenceTypes: ['artist', 'artist-gallery'],
       bindTo: 'artistData',
 
-      getMatchableDirectories(artist) {
-        // Regular artists are always matchable by their directory.
-        if (!artist.isAlias) {
-          return [artist.directory];
-        }
+      include: artist => artist.isAlias,
 
+      getMatchableDirectories(artist) {
         const originalArtist = artist.aliasedArtist;
 
         // Aliases never match by the same directory as the original.

--- a/src/data/yaml.js
+++ b/src/data/yaml.js
@@ -1157,9 +1157,8 @@ export function filterReferenceErrors(wikiData) {
 
   const boundFind = bindFind(wikiData, {mode: 'error'});
 
-  const artistAliasData = wikiData.artistData.filter(artist => artist.isAlias);
   const findArtistOrAlias = artistRef => {
-    const alias = find.artistIncludingAliases(artistRef, artistAliasData, {mode: 'quiet'});
+    const alias = boundFind.artistAlias(artistRef, {mode: 'quiet'});
     if (alias) {
       // No need to check if the original exists here. Aliases are automatically
       // created from a field on the original, so the original certainly exists.

--- a/src/data/yaml.js
+++ b/src/data/yaml.js
@@ -1094,8 +1094,6 @@ export function reportDuplicateDirectories(wikiData) {
         places.map(thing => ` - ` + inspect(thing)).join('\n')));
     }
   });
-
-  aggregate.close();
 }
 
 // Warn about references across data which don't match anything.  This involves

--- a/src/data/yaml.js
+++ b/src/data/yaml.js
@@ -9,7 +9,7 @@ import yaml from 'js-yaml';
 
 import CacheableObject from '#cacheable-object';
 import {colors, ENABLE_COLOR, logInfo, logWarn} from '#cli';
-import find, {bindFind, getAllFindSpecs} from '#find';
+import {bindFind, getAllFindSpecs} from '#find';
 import Thing from '#thing';
 import thingConstructors from '#things';
 import {commentaryRegexCaseSensitive, sortByName} from '#wiki-data';
@@ -1240,19 +1240,19 @@ export function filterReferenceErrors(wikiData) {
 
               case '_trackNotRerelease':
                 findFn = trackRef => {
-                  const track = find.track(trackRef, wikiData.trackData, {mode: 'error'});
+                  const track = boundFind.track(trackRef);
                   const originalRef = track && CacheableObject.getUpdateValue(track, 'originalReleaseTrack');
 
                   if (originalRef) {
                     // It's possible for the original to not actually exist, in this case.
                     // It should still be reported since the 'Originally Released As' field
                     // was present.
-                    const original = find.track(originalRef, wikiData.trackData, {mode: 'quiet'});
+                    const original = boundFind.track(originalRef, {mode: 'quiet'});
 
                     // Prefer references by name, but only if it's unambiguous.
                     const originalByName =
                       (original
-                        ? find.track(original.name, wikiData.trackData, {mode: 'quiet'})
+                        ? boundFind.track(original.name, {mode: 'quiet'})
                         : null);
 
                     const shouldBeMessage =


### PR DESCRIPTION
This PR just tidies up a little cruft to do with `find` and `bindFind` in yaml.js; we're able to avoid accessing the underlying `find` function at all, thanks to these changes!

Of note, since `find.artistIncludingAliases` was only ever used in yaml.js reference validation, and operated only on alias data in particular, we've ratified that into the find spec itself: it's now `find.artistAlias` and can only possibly return an alias, and is appropriately bound to `artistData` filtered by `artist => artist.isAlias`.

This is functionally a follow-up to #394 (specifically 12a8b6d1148c7d616296c8ab4ed86cbc856e3861 and 7fbc5b87ed05bce433ed959ca18119b72835ee41). It also precedes some general cleanup work on imports, specifically extracting `filterReferenceErrors` and `reportDuplicateDirectories` from yaml.js (PR TBD).