### PR TITLE
More general eslint fixes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,6 +10,7 @@
   },
   "rules": {
     "indent": ["off"],
+    "no-unexpected-multiline": ["off"],
     "no-unused-labels": ["off"],
     "no-unused-vars": ["error", {
       "argsIgnorePattern": "^_",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
                 "image-size": "^1.0.2",
                 "js-yaml": "^4.1.0",
                 "marked": "^10.0.0",
-                "printable-characters": "^1.0.42",
                 "striptags": "^4.0.0-alpha.4",
                 "word-wrap": "^1.2.3"
             },
@@ -3764,11 +3763,6 @@
             "engines": {
                 "node": ">= 0.8.0"
             }
-        },
-        "node_modules/printable-characters": {
-            "version": "1.0.42",
-            "resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
-            "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ=="
         },
         "node_modules/prismjs": {
             "version": "1.29.0",
@@ -8040,11 +8034,6 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
-        },
-        "printable-characters": {
-            "version": "1.0.42",
-            "resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
-            "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ=="
         },
         "prismjs": {
             "version": "1.29.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
         "image-size": "^1.0.2",
         "js-yaml": "^4.1.0",
         "marked": "^10.0.0",
-        "printable-characters": "^1.0.42",
         "striptags": "^4.0.0-alpha.4",
         "word-wrap": "^1.2.3"
     },

--- a/src/data/things/track.js
+++ b/src/data/things/track.js
@@ -516,7 +516,11 @@ export class Track extends Thing {
     if (depth >= 0) {
       try {
         album = this.album;
-      } catch (_error) {}
+      } catch (_error) {
+        // Computing album might crash for any reason, which we don't want to
+        // distract from another error we might be trying to work out at the
+        // moment (for which debugging might involve inspecting this track!).
+      }
 
       album ??= this.dataSourceAlbum;
     }

--- a/src/data/validators.js
+++ b/src/data/validators.js
@@ -1,9 +1,5 @@
 import {inspect as nodeInspect} from 'node:util';
 
-// Heresy.
-import printable_characters from 'printable-characters';
-const {strlen} = printable_characters;
-
 import {colors, ENABLE_COLOR} from '#cli';
 import {commentaryRegexCaseInsensitive, commentaryRegexCaseSensitiveOneShot}
   from '#wiki-data';

--- a/src/find.js
+++ b/src/find.js
@@ -1,6 +1,5 @@
 import {inspect} from 'node:util';
 
-import CacheableObject from '#cacheable-object';
 import {colors, logWarn} from '#cli';
 import thingConstructors from '#things';
 import {typeAppearance} from '#sugar';
@@ -18,7 +17,7 @@ function warnOrThrow(mode, message) {
 }
 
 export function processAllAvailableMatches(data, {
-  include = thing => true,
+  include = _thing => true,
 
   getMatchableNames = thing =>
     (Object.hasOwn(thing, 'name')
@@ -158,7 +157,7 @@ const hardcodedFindSpecs = {
   },
 };
 
-export function getAllFindSpecs(key) {
+export function getAllFindSpecs() {
   try {
     thingConstructors;
   } catch (error) {

--- a/src/page/artist.js
+++ b/src/page/artist.js
@@ -1,7 +1,5 @@
 import {empty} from '#sugar';
 
-import CacheableObject from '#cacheable-object';
-
 export const description = `per-artist info & artwork gallery pages`;
 
 // NB: See artist-alias.js for artist alias redirect pages.

--- a/src/static/client3.js
+++ b/src/static/client3.js
@@ -5,7 +5,6 @@
 // that cannot 8e done at static-site compile time, 8y its fundamentally
 // ephemeral nature.
 
-import {getColors} from '../util/colors.js';
 import {empty, stitchArrays} from '../util/sugar.js';
 import {filterMultipleArrays} from '../util/wiki-data.js';
 
@@ -39,6 +38,7 @@ function initInfo(key, description) {
 
 // Localiz8tion nonsense ----------------------------------
 
+/*
 const language = document.documentElement.getAttribute('lang');
 
 let list;
@@ -65,6 +65,7 @@ if (typeof Intl === 'object' && typeof Intl.ListFormat === 'function') {
     unit: arbitraryMock,
   };
 }
+*/
 
 // Miscellaneous helpers ----------------------------------
 
@@ -112,17 +113,24 @@ function pointIsOverAnyOf(elements) {
 
 // TODO: These should pro8a8ly access some shared urlSpec path. We'd need to
 // separ8te the tooling around that into common-shared code too.
+
+/*
 const getLinkHref = (type, directory) => rebase(`${type}/${directory}`);
+*/
+
 const openAlbum = (d) => rebase(`album/${d}`);
 const openTrack = (d) => rebase(`track/${d}`);
 const openArtist = (d) => rebase(`artist/${d}`);
 
 // TODO: This should also use urlSpec.
+
+/*
 function fetchData(type, directory) {
   return fetch(rebase(`${type}/${directory}/data.json`, 'rebaseData')).then(
     (res) => res.json()
   );
 }
+*/
 
 function dispatchInternalEvent(event, eventName, ...args) {
   const [infoName] =
@@ -2248,9 +2256,6 @@ function scrollAlbumCommentarySidebar() {
 
   const linkScrollTop =
     linkTopEdge - stickyPadding - 5;
-
-  const linkDistanceFromSection =
-    linkScrollTop - sectionTopEdge;
 
   const linkVisibleFromTopOfSection =
     linkBottomEdge - sectionTopEdge > sidebarViewportHeight;

--- a/src/static/client3.js
+++ b/src/static/client3.js
@@ -638,7 +638,7 @@ function handleTooltipMouseLeft(tooltip) {
   }
 }
 
-function handleTooltipReceivedFocus(tooltip) {
+function handleTooltipReceivedFocus(_tooltip) {
   const {state} = hoverableTooltipInfo;
 
   // Cancel the tooltip-hiding timeout if it exists. The tooltip will never
@@ -650,9 +650,7 @@ function handleTooltipReceivedFocus(tooltip) {
   }
 }
 
-function handleTooltipLostFocus(tooltip) {
-  const {settings, state} = hoverableTooltipInfo;
-
+function handleTooltipLostFocus(_tooltip) {
   // Hide the current tooltip right away when it loses focus. Specify intent
   // to replace - while we don't strictly know if another tooltip is going to
   // immediately replace it, the mode of navigating with tab focus (once one
@@ -662,7 +660,7 @@ function handleTooltipLostFocus(tooltip) {
 }
 
 function handleTooltipHoverableMouseEntered(hoverable) {
-  const {event, settings, state} = hoverableTooltipInfo;
+  const {settings, state} = hoverableTooltipInfo;
   const {tooltip} = state.registeredHoverables.get(hoverable);
 
   // If this tooltip was transitioning to hidden, hovering should cancel that
@@ -702,7 +700,7 @@ function handleTooltipHoverableMouseEntered(hoverable) {
   }
 }
 
-function handleTooltipHoverableMouseLeft(hoverable) {
+function handleTooltipHoverableMouseLeft(_hoverable) {
   const {settings, state} = hoverableTooltipInfo;
 
   // Don't show a tooltip when not over a hoverable!
@@ -757,7 +755,7 @@ function handleTooltipHoverableReceivedFocus(hoverable) {
 }
 
 function handleTooltipHoverableLostFocus(hoverable, domEvent) {
-  const {settings, state} = hoverableTooltipInfo;
+  const {state} = hoverableTooltipInfo;
 
   // Don't show a tooltip from focusing a hoverable if it isn't focused
   // anymore! If another hoverable is receiving focus, that will be evaluated
@@ -777,7 +775,7 @@ function handleTooltipHoverableLostFocus(hoverable, domEvent) {
 }
 
 function handleTooltipHoverableTouchEnded(hoverable, domEvent) {
-  const {settings, state} = hoverableTooltipInfo;
+  const {state} = hoverableTooltipInfo;
   const {tooltip} = state.registeredHoverables.get(hoverable);
 
   // Don't proceed if this hoverable's tooltip is already visible - in that
@@ -828,9 +826,8 @@ function handleTooltipHoverableTouchEnded(hoverable, domEvent) {
     }, 250);
 }
 
-function handleTooltipHoverableClicked(hoverable, domEvent) {
+function handleTooltipHoverableClicked(hoverable) {
   const {state} = hoverableTooltipInfo;
-  const {tooltip} = state.registeredHoverables.get(hoverable);
 
   // Don't navigate away from the page if the this hoverable was recently
   // touched (and had its tooltip activated). That flag won't be set if its
@@ -928,7 +925,7 @@ function endTransitioningTooltipHidden() {
 }
 
 function hideCurrentlyShownTooltip(intendingToReplace = false) {
-  const {event, settings, state} = hoverableTooltipInfo;
+  const {settings, state} = hoverableTooltipInfo;
   const {currentlyShownTooltip: tooltip} = state;
 
   // If there was no tooltip to begin with, we're functionally in the desired
@@ -972,7 +969,7 @@ function hideCurrentlyShownTooltip(intendingToReplace = false) {
 }
 
 function showTooltipFromHoverable(hoverable) {
-  const {event, state} = hoverableTooltipInfo;
+  const {state} = hoverableTooltipInfo;
   const {tooltip} = state.registeredHoverables.get(hoverable);
 
   if (!hideCurrentlyShownTooltip(true)) return false;
@@ -1029,9 +1026,6 @@ function addHoverableTooltipPageListeners() {
   ];
 
   document.body.addEventListener('touchend', domEvent => {
-    const hoverables = Array.from(state.registeredHoverables.keys());
-    const tooltips = Array.from(state.registeredTooltips.keys());
-
     const touches = Array.from(domEvent.changedTouches);
     const identifiers = touches.map(touch => touch.identifier);
 

--- a/src/util/external-links.js
+++ b/src/util/external-links.js
@@ -3,7 +3,6 @@ import {empty, stitchArrays} from '#sugar';
 import {
   anyOf,
   is,
-  isObject,
   isStringNonEmpty,
   looseArrayOf,
   optional,

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -170,7 +170,7 @@ export function metatag(identifier, ...args) {
       args[0] instanceof Tag ||
       args[0] instanceof Template)
   ) {
-    opts = args[0];
+    opts = args[0];  /* eslint-disable-line no-unused-vars */
     content = args[1];
   } else {
     content = args[0];
@@ -723,7 +723,7 @@ export class Attributes {
 
     throw new Error(
       `Expected Attributes, Template, or object, ` +
-      `got ${typeAppearance(attribute)}`);
+      `got ${typeAppearance(attributes)}`);
   }
 
   #addOneAttribute(attribute, value) {

--- a/src/write/build-modes/live-dev-server.js
+++ b/src/write/build-modes/live-dev-server.js
@@ -101,7 +101,7 @@ export async function go({
   wikiData,
 
   cachebust,
-  developersComment,
+  developersComment: _developersComment,
   getSizeOfAdditionalFile,
   getSizeOfImagePath,
   niceShowAggregate,

--- a/src/write/build-modes/repl.js
+++ b/src/write/build-modes/repl.js
@@ -30,15 +30,9 @@ export function getCLIOptions() {
 import * as os from 'node:os';
 import * as path from 'node:path';
 import * as repl from 'node:repl';
-import {fileURLToPath} from 'node:url';
 
-import {logError, logWarn, parseOptions} from '#cli';
+import {logWarn} from '#cli';
 import {debugComposite} from '#composite';
-import {internalDefaultStringsFile, processLanguageFile} from '#language';
-import {isMain} from '#node-utils';
-import {bindOpts, showAggregate} from '#sugar';
-import {generateURLs, urlSpec} from '#urls';
-import {quickLoadAllFromYAML} from '#yaml';
 
 import _find, {bindFind} from '#find';
 import CacheableObject from '#cacheable-object';
@@ -46,8 +40,6 @@ import thingConstructors from '#things';
 import * as serialize from '#serialize';
 import * as sugar from '#sugar';
 import * as wikiDataUtils from '#wiki-data';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export async function getContextAssignments({
   dataPath,

--- a/src/write/build-modes/repl.js
+++ b/src/write/build-modes/repl.js
@@ -31,14 +31,13 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import * as repl from 'node:repl';
 
-import {logWarn} from '#cli';
-import {debugComposite} from '#composite';
-
 import _find, {bindFind} from '#find';
 import CacheableObject from '#cacheable-object';
-import thingConstructors from '#things';
+import {logWarn} from '#cli';
+import {debugComposite} from '#composite';
 import * as serialize from '#serialize';
 import * as sugar from '#sugar';
+import thingConstructors from '#things';
 import * as wikiDataUtils from '#wiki-data';
 
 export async function getContextAssignments({

--- a/src/write/build-modes/static-build.js
+++ b/src/write/build-modes/static-build.js
@@ -13,7 +13,6 @@ import {quickLoadContentDependencies} from '#content-dependencies';
 import {quickEvaluate} from '#content-function';
 import * as html from '#html';
 import * as pageSpecs from '#page-specs';
-import {serializeThings} from '#serialize';
 import {empty, queue, withEntries} from '#sugar';
 
 import {
@@ -114,7 +113,7 @@ export async function go({
   wikiData,
 
   cachebust,
-  developersComment,
+  developersComment: _developersComment,
   getSizeOfAdditionalFile,
   getSizeOfImagePath,
   niceShowAggregate,


### PR DESCRIPTION
Follow-up to #414. This just makes `npx eslint src` pass cleanly! Nothing of especial note apart from an explanatory comment in an empty "catch" block (https://github.com/hsmusic/hsmusic-wiki/commit/8c904d232eaa39307b0d52605fcef6e87c4f0635) and commenting out some client-side code only used in still-disabled info cards (4204b5d340203428bc97d1b76531c8939bb179bf).