### PR TITLE
Slightly better replacer escaping & style attributes on image nodes

### DIFF
--- a/src/content/dependencies/transformContent.js
+++ b/src/content/dependencies/transformContent.js
@@ -226,7 +226,7 @@ export default {
                 ? to('media.path', node.src.slice('media/'.length))
                 : node.src);
 
-            const {inline, link, width, height, pixelate} = node;
+            const {inline, link, width, height, style, pixelate} = node;
 
             if (inline) {
               return {
@@ -237,6 +237,7 @@ export default {
                     src && {src},
                     width && {width},
                     height && {height},
+                    style && {style},
 
                     pixelate &&
                       {class: 'pixelate'}),

--- a/src/util/replacer.js
+++ b/src/util/replacer.js
@@ -494,6 +494,7 @@ export function postprocessImages(inputNodes) {
         })();
 
         if (attributes.get('link')) imageNode.link = attributes.get('link');
+        if (attributes.get('style')) imageNode.style = attributes.get('style');
         if (attributes.get('width')) imageNode.width = parseInt(attributes.get('width'));
         if (attributes.get('height')) imageNode.height = parseInt(attributes.get('height'));
         if (attributes.get('pixelate')) imageNode.pixelate = true;

--- a/src/util/replacer.js
+++ b/src/util/replacer.js
@@ -201,6 +201,8 @@ function parseNodes(input, i, stopAt, textOnly) {
       string = string.trimEnd();
     }
 
+    string = squashBackslashes(string);
+
     if (string.length) {
       nodes.push({i: iString, iEnd: i, type: 'text', data: string});
       string = '';
@@ -416,6 +418,15 @@ function parseNodes(input, i, stopAt, textOnly) {
   }
 
   return nodes;
+}
+
+export function squashBackslashes(text) {
+  // Squash backslashes which aren't themselves escaped into
+  // the following character, unless that character is one of
+  // a set of characters where the backslash carries meaning
+  // into later formatting (i.e. markdown). Note that we do
+  // NOT compress double backslashes into single backslashes.
+  return text.replace(/([^\\](?:\\{2})*)\\(?![\\*_-])/g, '$1');
 }
 
 export function postprocessImages(inputNodes) {

--- a/tap-snapshots/test/snapshot/transformContent.js.test.cjs
+++ b/tap-snapshots/test/snapshot/transformContent.js.test.cjs
@@ -5,9 +5,26 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`test/snapshot/transformContent.js > TAP > transformContent (snapshot) > basic markdown 1`] = `
+<p>Hello <em>world!</em> This is <strong>SO COOL.</strong></p>
+`
+
 exports[`test/snapshot/transformContent.js > TAP > transformContent (snapshot) > dates 1`] = `
 <p><time datetime="Thu, 13 Apr 2023 00:00:00 GMT">4/12/2023</time> Yep!</p>
 <p>Very nice: <time datetime="Fri, 25 Oct 2413 03:00:00 GMT">10/25/2413</time></p>
+`
+
+exports[`test/snapshot/transformContent.js > TAP > transformContent (snapshot) > escape end of tag 1`] = `
+<p>My favorite album is <a style="--primary-color: #123456" href="to-localized.album/cool-album">[Tactical Omission]</a>.</p>
+<p>Your favorite album is <a style="--primary-color: #123456" href="to-localized.album/cool-album">[Tactical Wha-Huh-Now</a>].</p>
+`
+
+exports[`test/snapshot/transformContent.js > TAP > transformContent (snapshot) > escape entire tag 1`] = `
+<p>[[album:cool-album|spooky]] <a style="--primary-color: #123456" href="to-localized.album/cool-album">scary</a></p>
+`
+
+exports[`test/snapshot/transformContent.js > TAP > transformContent (snapshot) > escape markdown 1`] = `
+<p>What will it be, <em>ye fool?</em> *arr*</p>
 `
 
 exports[`test/snapshot/transformContent.js > TAP > transformContent (snapshot) > hanging indent list 1`] = `

--- a/test/snapshot/transformContent.js
+++ b/test/snapshot/transformContent.js
@@ -109,6 +109,23 @@ testContentFunctions(t, 'transformContent (snapshot)', async (t, evaluate) => {
       `Neat listing: [[string:listingPage.listAlbums.byDate.title]]`);
 
   quickSnapshot(
+    'basic markdown',
+      `Hello *world!* This is **SO COOL.**`);
+
+  quickSnapshot(
+    'escape entire tag',
+      `\\[[album:cool-album|spooky]] [[album:cool-album|scary]]`);
+
+  quickSnapshot(
+    'escape end of tag',
+      `My favorite album is [[album:cool-album|[Tactical Omission\\]]].\n` +
+      `Your favorite album is [[album:cool-album|[Tactical Wha-Huh-Now]]].`);
+
+  quickSnapshot(
+    'escape markdown',
+      `What will it be, *ye fool?* \\*arr*`);
+
+  quickSnapshot(
     'lyrics - basic line breaks',
       `Hey, ho\n` +
       `And away we go\n` +


### PR DESCRIPTION
Bundles two (separate) changes to `#replacer`:

* Drops (last of odd-count) backslashes preceding non-Markdown characters.
  * This is to enable stuff like `[[album:foo|[Redacted\]]]`.
* Adds support for `style` attributes being specified on `<img>` in content.

Also comes with test cases to make sure stuff isn't broken by the escaping changes. There are still some weird cases escaping doesn't treat very nicely right now, but this PR shouldn't make any of those *worse.*