### PR TITLE
Support content warnings in content images

### DIFF
--- a/src/content/dependencies/image.js
+++ b/src/content/dependencies/image.js
@@ -55,6 +55,10 @@ export default {
       validate: v => v.isColor,
     },
 
+    warnings: {
+      validate: v => v.looseArrayOf(v.isString),
+    },
+
     reveal: {type: 'boolean', default: true},
     lazy: {type: 'boolean', default: false},
     square: {type: 'boolean', default: false},
@@ -120,11 +124,15 @@ export default {
       !isMissingImageFile &&
       (typeof slots.link === 'string' || slots.link);
 
+    const contentWarnings =
+      slots.warnings ??
+      data.contentWarnings;
+
     const willReveal =
       slots.reveal &&
       originalSrc &&
       !isMissingImageFile &&
-      !empty(data.contentWarnings);
+      !empty(contentWarnings);
 
     const willSquare = slots.square;
 
@@ -159,7 +167,7 @@ export default {
 
         html.tag('span', {class: 'reveal-warnings'},
           language.$('misc.contentWarnings.warnings', {
-            warnings: language.formatUnitList(data.contentWarnings),
+            warnings: language.formatUnitList(contentWarnings),
           })),
 
         html.tag('br'),

--- a/src/content/dependencies/transformContent.js
+++ b/src/content/dependencies/transformContent.js
@@ -229,7 +229,7 @@ export default {
             const {
               link,
               style,
-              warning,
+              warnings,
               width,
               height,
               pixelate,
@@ -264,12 +264,8 @@ export default {
                     link: link ?? true,
                     width: width ?? null,
                     height: height ?? null,
+                    warnings: warnings ?? null,
                     thumb: slots.thumb,
-
-                    warnings:
-                      (warning
-                        ? warning.split(', ')
-                        : null),
 
                     attributes: [
                       {class: 'content-image'},

--- a/src/content/dependencies/transformContent.js
+++ b/src/content/dependencies/transformContent.js
@@ -226,9 +226,16 @@ export default {
                 ? to('media.path', node.src.slice('media/'.length))
                 : node.src);
 
-            const {inline, link, width, height, style, pixelate} = node;
+            const {
+              link,
+              style,
+              warning,
+              width,
+              height,
+              pixelate,
+            } = node;
 
-            if (inline) {
+            if (node.inline) {
               return {
                 type: 'image',
                 inline: true,
@@ -258,6 +265,11 @@ export default {
                     width: width ?? null,
                     height: height ?? null,
                     thumb: slots.thumb,
+
+                    warnings:
+                      (warning
+                        ? warning.split(', ')
+                        : null),
 
                     attributes: [
                       {class: 'content-image'},

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -1285,17 +1285,30 @@ img.pixelate, .pixelate img {
 }
 
 .reveal:not(.revealed) .image-outer-area > * {
-  box-sizing: border-box;
-  border: 1px dotted var(--primary-color);
-  border-radius: 6px;
+  --reveal-border-radius: 6px;
+  position: relative;
   overflow: hidden;
+  border-radius: var(--reveal-border-radius);
+}
+
+.reveal:not(.revealed) .image-outer-area > *::after {
+  content: "";
+  position: absolute;
+  box-sizing: border-box;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  border: 1px dotted var(--primary-color);
+  border-radius: var(--reveal-border-radius);
+  pointer-events: none;
 }
 
 .reveal:not(.revealed) .image-inner-area {
   background: var(--deep-color);
 }
 
-.reveal:not(.revealed) .image-outer-area > *:hover {
+.reveal:not(.revealed) .image-outer-area > *:hover::after {
   border-style: solid;
 }
 

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -1238,6 +1238,7 @@ img.pixelate, .pixelate img {
   text-align: center;
   font-weight: bold;
   padding-bottom: 0.5em;
+  font-size: 0.8rem;
 }
 
 .reveal-symbol {

--- a/src/util/replacer.js
+++ b/src/util/replacer.js
@@ -495,6 +495,7 @@ export function postprocessImages(inputNodes) {
 
         if (attributes.get('link')) imageNode.link = attributes.get('link');
         if (attributes.get('style')) imageNode.style = attributes.get('style');
+        if (attributes.get('warning')) imageNode.warning = attributes.get('warning');
         if (attributes.get('width')) imageNode.width = parseInt(attributes.get('width'));
         if (attributes.get('height')) imageNode.height = parseInt(attributes.get('height'));
         if (attributes.get('pixelate')) imageNode.pixelate = true;

--- a/src/util/replacer.js
+++ b/src/util/replacer.js
@@ -495,10 +495,14 @@ export function postprocessImages(inputNodes) {
 
         if (attributes.get('link')) imageNode.link = attributes.get('link');
         if (attributes.get('style')) imageNode.style = attributes.get('style');
-        if (attributes.get('warning')) imageNode.warning = attributes.get('warning');
         if (attributes.get('width')) imageNode.width = parseInt(attributes.get('width'));
         if (attributes.get('height')) imageNode.height = parseInt(attributes.get('height'));
         if (attributes.get('pixelate')) imageNode.pixelate = true;
+
+        if (attributes.get('warning')) {
+          imageNode.warnings =
+            attributes.get('warning').split(', ');
+        }
 
         outputNodes.push(imageNode);
 


### PR DESCRIPTION
Adds support for a new `warning` attribute to non-inline image nodes (`<img>`) in content strings, which presents a content warning and reveal interaction just like normal content warnings in art tag data.

```
<img src="media/misc/grimbark-scare.jpg" width="120" warning="body horror">
```

Multiple warnings may be specified, separated by comma and space (`warning="body horror, corpses"`). Warnings don't *need* to correspond to existing CW art tags, at the moment.

Updates the `image` component to accept very basic string-form passing as a slot. The `image` component predates slots in general, so passing an art tag list directly is legacy behavior, and should be ported out later on - for now that behavior is retained, though, and the slot will only be preferred if present.

Includes some CSS tweaks to improve support for content warnings outside of fixed-dimension containers; the interaction outline is now an `::after` overlay rather than a border on the `.image-link` itself, so doesn't make the image container as a whole wider (causing it to shrink once clicked and the border is removed). Also defines reveal interaction text to be sized relative to root, i.e. `0.8rem`, which is the first and only use of `rem` in the CSS so far.