### PR TITLE
Get reveal image-container dimensions from main image

### DIFF
--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -1264,11 +1264,18 @@ img.pixelate, .pixelate img {
 }
 
 .reveal .image.reveal-thumbnail {
+  position: absolute;
+  top: 0;
   image-rendering: pixelated;
 }
 
 .reveal.has-reveal-thumbnail:not(.revealed) .image:not(.reveal-thumbnail) {
-  display: none !important;
+  /* Keep the main image as part of the box model.
+   * It's what actually defines the dimensions of the
+   * image-container, so those dimensions never shift
+   * once the image is actually revealed.
+   */
+  visibility: hidden;
 }
 
 .reveal.revealed.has-reveal-thumbnail .image.reveal-thumbnail {


### PR DESCRIPTION
Resolves #420 by taking the second approach discussed there. There's a slight bit of awkwardness to this as the blur filter pulls in transparency from past the reveal thumb's edge, giving a sort of soft edge to the outline of the image, and the bottom of that now can get chopped off or misaligned with the actual bottom edge of the image container, resulting in a less soft (or early) edge there. But it's a minor issue compared to the container resizing when clicked. (That's already a small issue in the grand scheme of things!)

<img width="633" alt="Screenshot 2024-02-18 at 6 09 58 PM" src="https://github.com/hsmusic/hsmusic-wiki/assets/9948030/6818de6f-8e28-44f7-9a89-da063c3a088b">
