### PR TITLE
Fix up withSortedList to do what it's supposed to

### DIFF
--- a/src/data/composite/data/withSortedList.js
+++ b/src/data/composite/data/withSortedList.js
@@ -59,13 +59,11 @@ export default templateCompositeFrom({
 
         const symbols = [];
         const symbolToIndex = new Map();
-        const indexToSymbol = new Map();
 
         for (const index of originalIndices) {
           const symbol = Symbol();
           symbols.push(symbol);
           symbolToIndex.set(symbol, index);
-          indexToSymbol.set(index, symbol);
         }
 
         const equalSymbols = new Map();
@@ -96,37 +94,22 @@ export default templateCompositeFrom({
         });
 
         const stableSortIndices = [];
+        const unstableSortIndices = [];
         const sortedList = [];
 
-        const symbolToStable = new Map();
-        const stableToUnstable = new Map();
+        let unstableIndex = 0;
 
         for (const [stableIndex, symbol] of symbols.entries()) {
           const sourceIndex = symbolToIndex.get(symbol);
           stableSortIndices.push(sourceIndex);
-          symbolToStable.set(symbol, stableIndex);
           sortedList.push(list[sourceIndex]);
 
-          if (stableIndex === 0) {
-            stableToUnstable.set(stableIndex, 0);
-            continue;
+          if (stableIndex > 0 && !isEqual(symbol, symbols[stableIndex - 1])) {
+            unstableIndex++;
           }
 
-          const previousUnstable = stableToUnstable.get(stableIndex - 1);
-
-          const newUnstable =
-            (isEqual(symbol, symbols[stableIndex - 1])
-              ? previousUnstable
-              : previousUnstable + 1);
-
-          stableToUnstable.set(stableIndex, newUnstable);
+          unstableSortIndices[sourceIndex] = unstableIndex;
         }
-
-        const unstableSortIndices =
-          originalIndices
-            .map(index => indexToSymbol.get(index))
-            .map(symbol => symbolToStable.get(symbol))
-            .map(stable => stableToUnstable.get(stable));
 
         return continuation({
           ['#sortedList']: sortedList,

--- a/src/data/composite/data/withSortedList.js
+++ b/src/data/composite/data/withSortedList.js
@@ -107,20 +107,14 @@ export default templateCompositeFrom({
         };
 
         const stableToUnstable =
-          symbols
-            .map(
-              (current, index) =>
-                (index === 0
-                  ? false
-                  : isEqual(current, symbols[index - 1])))
-            .reduce(
-              (accumulator, equalsPrevious, index) =>
-                (index === 0
-                  ? accumulator
-                  : (equalsPrevious
-                      ? push(accumulator, accumulator.at(-1))
-                      : push(accumulator, accumulator.at(-1) + 1))),
-              [0]);
+          symbols.reduce(
+            (accumulator, current, index) =>
+              (index === 0
+                ? push(accumulator, 0)
+                : (isEqual(current, symbols[index - 1])
+                    ? push(accumulator, accumulator.at(-1))
+                    : push(accumulator, accumulator.at(-1) + 1))),
+            []);
 
         const unstableSortIndices =
           originalIndices

--- a/src/data/composite/data/withSortedList.js
+++ b/src/data/composite/data/withSortedList.js
@@ -92,7 +92,7 @@ export default templateCompositeFrom({
         const sortedList =
           sortIndices.map(index => list[index]);
 
-        const stableToUnstable =
+        const unstableSortIndices =
           symbols
             .map((current, index) => {
               if (index === 0) {
@@ -116,9 +116,6 @@ export default templateCompositeFrom({
 
               return accumulator;
             }, [0]);
-
-        const unstableSortIndices =
-          sortIndices.map(stable => stableToUnstable[stable]);
 
         return continuation({
           ['#sortedList']: sortedList,

--- a/src/data/composite/data/withSortedList.js
+++ b/src/data/composite/data/withSortedList.js
@@ -35,7 +35,6 @@
 //
 
 import {input, templateCompositeFrom} from '#composite';
-import {empty} from '#sugar';
 
 export default templateCompositeFrom({
   annotation: `withSortedList`,

--- a/src/data/composite/data/withSortedList.js
+++ b/src/data/composite/data/withSortedList.js
@@ -122,10 +122,10 @@ export default templateCompositeFrom({
             }, [0]);
 
         const unstableSortIndices =
-          Array.from(
-            {length: list.length},
-            (_, index) =>
-              stableToUnstable[symbols.indexOf(indexToSymbol.get(index))]);
+          Array.from({length: list.length}, (_, index) => index)
+            .map(index => indexToSymbol.get(index))
+            .map(symbol => symbols.indexOf(symbol))
+            .map(stable => stableToUnstable[stable]);
 
         return continuation({
           ['#sortedList']: sortedList,

--- a/src/data/composite/data/withSortedList.js
+++ b/src/data/composite/data/withSortedList.js
@@ -60,9 +60,13 @@ export default templateCompositeFrom({
         const equalSymbols =
           new Map();
 
-        const indexMap =
+        const symbolToIndex =
           new Map(Array.from(symbols,
             (symbol, index) => [symbol, index]));
+
+        const indexToSymbol =
+          new Map(Array.from(symbols,
+            (symbol, index) => [index, symbol]));
 
         const assertEqual = (symbol1, symbol2) => {
           if (equalSymbols.has(symbol1)) {
@@ -75,8 +79,8 @@ export default templateCompositeFrom({
         symbols.sort((symbol1, symbol2) => {
           const comparison =
             sortFn(
-              list[indexMap.get(symbol1)],
-              list[indexMap.get(symbol2)]);
+              list[symbolToIndex.get(symbol1)],
+              list[symbolToIndex.get(symbol2)]);
 
           if (comparison === 0) {
             assertEqual(symbol1, symbol2);
@@ -87,7 +91,7 @@ export default templateCompositeFrom({
         });
 
         const sortIndices =
-          symbols.map(symbol => indexMap.get(symbol));
+          symbols.map(symbol => symbolToIndex.get(symbol));
 
         const sortedList =
           sortIndices.map(index => list[index]);
@@ -118,7 +122,10 @@ export default templateCompositeFrom({
             }, [0]);
 
         const unstableSortIndices =
-          sortIndices.map(stable => stableToUnstable[stable]);
+          Array.from(
+            {length: list.length},
+            (_, index) =>
+              stableToUnstable[symbols.indexOf(indexToSymbol.get(index))]);
 
         return continuation({
           ['#sortedList']: sortedList,

--- a/src/data/composite/data/withSortedList.js
+++ b/src/data/composite/data/withSortedList.js
@@ -95,37 +95,38 @@ export default templateCompositeFrom({
           return comparison;
         });
 
-        const symbolToStable = new Map();
         const stableSortIndices = [];
         const sortedList = [];
+
+        const symbolToStable = new Map();
+        const stableToUnstable = new Map();
 
         for (const [stableIndex, symbol] of symbols.entries()) {
           const sourceIndex = symbolToIndex.get(symbol);
           stableSortIndices.push(sourceIndex);
           symbolToStable.set(symbol, stableIndex);
           sortedList.push(list[sourceIndex]);
+
+          if (stableIndex === 0) {
+            stableToUnstable.set(stableIndex, 0);
+            continue;
+          }
+
+          const previousUnstable = stableToUnstable.get(stableIndex - 1);
+
+          const newUnstable =
+            (isEqual(symbol, symbols[stableIndex - 1])
+              ? previousUnstable
+              : previousUnstable + 1);
+
+          stableToUnstable.set(stableIndex, newUnstable);
         }
-
-        const push = (array, value) => {
-          array.push(value);
-          return array;
-        };
-
-        const stableToUnstable =
-          symbols.reduce(
-            (accumulator, current, index) =>
-              (index === 0
-                ? push(accumulator, 0)
-                : (isEqual(current, symbols[index - 1])
-                    ? push(accumulator, accumulator.at(-1))
-                    : push(accumulator, accumulator.at(-1) + 1))),
-            []);
 
         const unstableSortIndices =
           originalIndices
             .map(index => indexToSymbol.get(index))
             .map(symbol => symbolToStable.get(symbol))
-            .map(stable => stableToUnstable[stable]);
+            .map(stable => stableToUnstable.get(stable));
 
         return continuation({
           ['#sortedList']: sortedList,

--- a/src/data/composite/data/withSortedList.js
+++ b/src/data/composite/data/withSortedList.js
@@ -54,13 +54,10 @@ export default templateCompositeFrom({
         [input('list')]: list,
         [input('sort')]: sortFn,
       }) {
-        const originalIndices =
-          Array.from({length: list.length}, (_, index) => index);
-
         const symbols = [];
         const symbolToIndex = new Map();
 
-        for (const index of originalIndices) {
+        for (const index of list.keys()) {
           const symbol = Symbol();
           symbols.push(symbol);
           symbolToIndex.set(symbol, index);
@@ -104,8 +101,11 @@ export default templateCompositeFrom({
           stableSortIndices.push(sourceIndex);
           sortedList.push(list[sourceIndex]);
 
-          if (stableIndex > 0 && !isEqual(symbol, symbols[stableIndex - 1])) {
-            unstableIndex++;
+          if (stableIndex > 0) {
+            const previous = symbols[stableIndex - 1];
+            if (!isEqual(symbol, previous)) {
+              unstableIndex++;
+            }
           }
 
           unstableSortIndices[sourceIndex] = unstableIndex;

--- a/src/data/composite/data/withSortedList.js
+++ b/src/data/composite/data/withSortedList.js
@@ -95,11 +95,16 @@ export default templateCompositeFrom({
           return comparison;
         });
 
-        const sortIndices =
-          symbols.map(symbol => symbolToIndex.get(symbol));
+        const symbolToStable = new Map();
+        const stableSortIndices = [];
+        const sortedList = [];
 
-        const sortedList =
-          sortIndices.map(index => list[index]);
+        for (const [stableIndex, symbol] of symbols.entries()) {
+          const sourceIndex = symbolToIndex.get(symbol);
+          stableSortIndices.push(sourceIndex);
+          symbolToStable.set(symbol, stableIndex);
+          sortedList.push(list[sourceIndex]);
+        }
 
         const push = (array, value) => {
           array.push(value);
@@ -119,12 +124,12 @@ export default templateCompositeFrom({
         const unstableSortIndices =
           originalIndices
             .map(index => indexToSymbol.get(index))
-            .map(symbol => symbols.indexOf(symbol))
+            .map(symbol => symbolToStable.get(symbol))
             .map(stable => stableToUnstable[stable]);
 
         return continuation({
           ['#sortedList']: sortedList,
-          ['#sortIndices']: sortIndices,
+          ['#sortIndices']: stableSortIndices,
           ['#unstableSortIndices']: unstableSortIndices,
         });
       },

--- a/src/data/composite/data/withSortedList.js
+++ b/src/data/composite/data/withSortedList.js
@@ -98,7 +98,6 @@ export default templateCompositeFrom({
 
         for (const [stableIndex, symbol] of symbols.entries()) {
           const sourceIndex = symbolToIndex.get(symbol);
-          stableSortIndices.push(sourceIndex);
           sortedList.push(list[sourceIndex]);
 
           if (stableIndex > 0) {
@@ -108,6 +107,7 @@ export default templateCompositeFrom({
             }
           }
 
+          stableSortIndices[sourceIndex] = stableIndex;
           unstableSortIndices[sourceIndex] = unstableIndex;
         }
 

--- a/src/data/composite/data/withSortedList.js
+++ b/src/data/composite/data/withSortedList.js
@@ -92,7 +92,7 @@ export default templateCompositeFrom({
         const sortedList =
           sortIndices.map(index => list[index]);
 
-        const unstableSortIndices =
+        const stableToUnstable =
           symbols
             .map((current, index) => {
               if (index === 0) {
@@ -116,6 +116,9 @@ export default templateCompositeFrom({
 
               return accumulator;
             }, [0]);
+
+        const unstableSortIndices =
+          sortIndices.map(stable => stableToUnstable[stable]);
 
         return continuation({
           ['#sortedList']: sortedList,


### PR DESCRIPTION
Holy guacamole this pull request is a rollercoaster.

This pull request makes `withSortedList` (which serves as the basis for `withThingsSortedAlphabetically`, and other sorting functions for compositional data that don't... actually exist yet...) set appropriate values on `#sortIndices` and, importantly, `#unstableSortIndices`!

The essential issue, as we understand it, is that these indices were being returned relative to the final sort. They weren't serving as a mapping from source items to sorted items - but from sorted items to sorted items! This meant the indices couldn't actually be used compositionally, as in `withThingsSortedAlphabetically`, which is trouble and a half. (Basically that sort was completely broken, and certainly non-deterministic).

This went through a million iterations, but the final code is generally a bit nicer than the original stuff, and it appears to actually be doing what it's supposed to now. (Mind that this PR doesn't *change* the meaning of those outputs at all - it just makes the implementation match the description at the top of the file.)

See individual commits for a fantastic time.