### PR TITLE
Better directories!

### DIFF
--- a/src/util/wiki-data.js
+++ b/src/util/wiki-data.js
@@ -13,12 +13,45 @@ export {filterMultipleArrays} from './sugar.js';
 
 export function getKebabCase(name) {
   return name
+
+    // Spaces to dashes
     .split(' ')
     .join('-')
-    .replace(/&/g, 'and')
-    .replace(/[^a-zA-Z0-9-]/g, '')
+
+    // Punctuation as words
+    .replace(/&/g, '-and-')
+    .replace(/\+/g, '-plus-')
+    .replace(/%/g, '-percent-')
+
+    // Punctuation which only divides words, not single characters
+    .replace(/(\b[^\s-.]{2,})\./g, '$1-')
+    .replace(/\.([^\s-.]{2,})\b/g, '-$1')
+
+    // Punctuation which doesn't divide a number following a non-number
+    .replace(/(?<=[0-9])\^/g, '-')
+    .replace(/\^(?![0-9])/g, '-')
+
+    // General punctuation which always separates surrounding words
+    .replace(/[/@#$%*()_=,[\]{}|\\;:<>?`~]/g, '-')
+
+    // Accented characters
+    .replace(/[áâäàå]/gi, 'a')
+    .replace(/[çč]/gi, 'c')
+    .replace(/[éêëè]/gi, 'e')
+    .replace(/[íîïì]/gi, 'i')
+    .replace(/[óôöò]/gi, 'o')
+    .replace(/[úûüù]/gi, 'u')
+
+    // Strip other characters
+    .replace(/[^a-z0-9-]/gi, '')
+
+    // Combine consecutive dashes
     .replace(/-{2,}/g, '-')
+
+    // Trim dashes on boundaries
     .replace(/^-+|-+$/g, '')
+
+    // Always lowercase
     .toLowerCase();
 }
 


### PR DESCRIPTION
This PR adds a bunch more `.replace()` calls to `getKebabCase` to make it generate better directories than it has previously. Since there's kind of a lot now, they're chunked into sections and commented, but it's still a normal `.replace()` chain and should be trivial to port into other programming languages or contexts. (Apart from making everything extremely explicit and easy to trace, that's another reason we *didn't* use a library or Unicode shenanigans to convert e.g. `/[éêëè]/gi` into `'e'`.)

This does alter a few existing directories that were reasonable but not preferred for the general case, or which were just broken before but still didn't look quite right with these changes, and we adapted for those in... uh... standalone commits https://github.com/hsmusic/hsmusic-data/commit/ceccea3d06be9e1a922a8fc0d899266df7eacb3c and https://github.com/hsmusic/hsmusic-media/commit/cb644f441fa1656b70a69384b9b23967b045e004 LOL. Check out the changelog contents for a whole ton of examples.