### PR TITLE
New --cache-path general cache folder

### DIFF
--- a/src/web-routes.js
+++ b/src/web-routes.js
@@ -36,6 +36,7 @@ export const allStaticWebRoutes = [
 export async function identifyDynamicWebRoutes({
   mediaPath,
   mediaCachePath,
+  wikiCachePath,
 }) {
   const routeFunctions = [
     () => Promise.resolve([


### PR DESCRIPTION
Makes hsmusic like to have a new option, `--cache-path` (or `HSMUSIC_CACHE`), which it'll make available to internal systems for general caching availability! Hooks the media system into this as well, and adds better messaging and tools for dealing with completely missing `thumbnail-cache.json` files.

This aims to consolidate the media cache and other generally reused, automatically generated files into one shared cache directory, so as to avoid clutter (in your workspace or the CLI options), make workspaces more portable (just move the whole dang cache at once), and simplify interfacing for internal systems. It doesn't make `--cache-path` *required,* so systems must cleanly exit if `wikiCachePath` is not available.

Thumbnail generation continues to reuse existing in-place or adjacent media cache, but will no longer newly generate an adjacent media cache — it'll only newly generate a media cache which is contained inside `--cache-path`, so will error if no `--cache-path` is provided and no other media cache exists. This gets custom messaging asking the user to create a `cache` folder and provide it with `--cache-path`.

We probably won't merge this PR until we actually introduce some other retained files besides the media cache are ready, e.g. 👻 the search corpus. This should be a ready-to-use PR for branching off of, though!