### PR TITLE
Add "chunkwrap" metatag

### DIFF
--- a/src/content/dependencies/generateAdditionalNamesBoxItem.js
+++ b/src/content/dependencies/generateAdditionalNamesBoxItem.js
@@ -61,7 +61,9 @@ export default {
       itemParts.push('withAccent');
       itemOptions.accent =
         html.tag('span', {class: 'accent'},
-          language.$(...accentParts, accentOptions));
+          html.metatag('chunkwrap', {split: ','},
+            html.resolve(
+              language.$(...accentParts, accentOptions))));
     }
 
     return language.$(...itemParts, itemOptions);

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -1133,7 +1133,6 @@ h1 a[href="#additional-names-box"]:hover {
 
 #additional-names-box li .accent {
   opacity: 0.8;
-  display: inline-block;
 }
 
 #additional-names-box li .additional-name > img {

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -499,7 +499,7 @@ a:not([href]):hover {
   white-space: nowrap;
 }
 
-.blockwrap {
+.blockwrap, .chunkwrap {
   display: inline-block;
 }
 

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -706,8 +706,16 @@ export class Tag {
       }
     }
 
-    if (seenChunkwrapSplitter) {
-      content += '</span>';
+    if (chunkwrapSplitter) {
+      if (seenChunkwrapSplitter) {
+        content += '</span>';
+      } else {
+        // Since chunkwraps take responsibility for wrapping *away* from the
+        // parent element, we generally always want there to be at least one
+        // chunk that gets wrapped as a single unit. So if no chunkwrap has
+        // been seen at all, just wrap everything in one now.
+        content = `<span class="chunkwrap">${content}</span>`;
+      }
     }
 
     content += blockwrapClosers;

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -527,17 +527,24 @@ export class Tag {
         : '\n'));
   }
 
+  #getContentJoiner() {
+    if (this.joinChildren === undefined) {
+      return '\n';
+    }
+
+    if (this.joinChildren === '') {
+      return '';
+    }
+
+    return `\n${this.joinChildren}\n`;
+  }
+
   #stringifyContent() {
     if (this.selfClosing) {
       return '';
     }
 
-    const joiner =
-      (this.joinChildren === undefined
-        ? '\n'
-     : this.joinChildren === ''
-        ? ''
-        : `\n${this.joinChildren}\n`);
+    const joiner = this.#getContentJoiner();
 
     let content = '';
     let blockwrapClosers = '';


### PR DESCRIPTION
Development:

* Towards #341.

Notes:

* Chunkwrap is magic!
* Chunkwrap is very pure and safe magic. Chunkwrap would never hurt you.
* Chunkwrap may not play nice with alternate localization, and this is left as a concern to address later.
* Chunkwrap takes inline-block wrapping responsibilities away from the parent and moves it into each of a sequence of children which chunkwrap creates, by splitting after each instance of a specified marker (for example `,` as in an accent). The parent gets no special wrapping behavior, at each child is treated as its own wrappable unit.
* Chunkwrap is currently used to make word wrapping in the additional names box nice.

Technical details:

* Apart from `html.tag('chunkwrap', {split: ','})`, this PR also introduces a new utility `html.smush()`. Smushing is a simple recursive operation which provides a nice, even, not-bumpy layer of top-level texts and tags. It takes hierarchies of content-only tags nested directly under other content-only tags, such as produced by `language.formatString` or any call to `html.tags([...])`, and evens them out into a single continuous layer. Any adjacent bits of text, including opposite boundaries of `html.tags([])` containing text as well as tags, are combined into single strings, so they can be conveniently operated on.
  * Smushing always results in a hierarchy that stringifies to the same output as if the input hadn't been smushed.
  * Smush will traverse tags which are `contentOnly`, but *never* tags which are *not.* Smush doesn't care at all about what's going on inside a normal element; it only wants to smooth a run of apparently top-level tags and apparently top-level texts into one layer of *actually* top-level tags and texts.
  * Smush will resolve templates, but only at the top level. This is so that it can actually see everything that's going on at the top-level. If a template returns `html.tags([])` which directly nests *more* templates, those will also be resolved, but only until everything at the top layer is a sequence of tags and texts.
  * Smushing never results in two strings next to each other, but it can result in two tags next to each other, if there wasn't any text between them.
  * Smushing respects the smushee's `[html.joinChildren]` attribute *at each layer.* This means it applies the appropriate joiner wherever stringifying would; each parent applies its joiner to between *own* children, not between the children that each *recursively smushed* child will actually be represented as.
* Smushing exists to address the "transparent" layers which we've made use of in these prior pull requests:
  * #269 
  * #348
* The chunkwrap metatag smushes its own contents (i.e itself) so that it has direct access to the text components which divide its non-text chlidren. Chunkwrap never splits *inside* elements (nor inside attribute values!!), so it needs a clean hierarchy of just the top-level texts. *Those* are safe to split inside.