### PR TITLE
Web routes (local-to-web mapping, shared by build modes)

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         "#thumbs": "./src/gen-thumbs.js",
         "#urls": "./src/util/urls.js",
         "#validators": "./src/data/validators.js",
+        "#web-routes": "./src/web-routes.js",
         "#wiki-data": "./src/util/wiki-data.js",
         "#yaml": "./src/data/yaml.js"
     },

--- a/src/upd8.js
+++ b/src/upd8.js
@@ -551,16 +551,27 @@ async function main() {
           logWarn`Redundant option ${cliPart}`;
         }
       } else {
-        if (cliFlagNegates) {
-          step.status = STATUS_NOT_APPLICABLE;
-          step.annotation = `--${cliFlag} provided`;
-        }
+        step.status =
+          (cliFlagNegates
+            ? STATUS_NOT_APPLICABLE
+            : STATUS_NOT_STARTED);
+
+        step.annotation = `--${cliFlag} provided`;
+
         if (cliFlagWarning) {
           for (const line of cliFlagWarning.split('\n')) {
             logWarn(line);
           }
         }
+
+        return;
       }
+    }
+
+    if (buildConfig?.required === true) {
+      step.status = STATUS_NOT_STARTED;
+      step.annotation = `required for --${selectedBuildModeFlag}`;
+      return;
     }
 
     if (buildConfig?.applicable === false) {
@@ -571,6 +582,12 @@ async function main() {
 
     if (buildConfig?.default === 'skip') {
       step.status = STATUS_NOT_APPLICABLE;
+      step.annotation = `default for --${selectedBuildModeFlag}`;
+      return;
+    }
+
+    if (buildConfig?.default === 'perform') {
+      step.status = STATUS_NOT_STARTED;
       step.annotation = `default for --${selectedBuildModeFlag}`;
       return;
     }

--- a/src/url-spec.js
+++ b/src/url-spec.js
@@ -1,12 +1,16 @@
 import {withEntries} from '#sugar';
 
+const genericPaths = {
+  root: '',
+  path: '<>/',
+};
+
 const urlSpec = {
   data: {
     prefix: 'data/',
 
     paths: {
-      root: '',
-      path: '<>',
+      ...genericPaths,
 
       album: 'album/<>',
       artist: 'artist/<>',
@@ -19,8 +23,7 @@ const urlSpec = {
     // prefix: '_languageCode',
 
     paths: {
-      root: '',
-      path: '<>',
+      ...genericPaths,
       page: '<>/',
 
       home: '',
@@ -61,8 +64,7 @@ const urlSpec = {
 
   shared: {
     paths: {
-      root: '',
-      path: '<>',
+      ...genericPaths,
 
       utilityRoot: 'util',
       staticRoot: 'static',
@@ -78,8 +80,7 @@ const urlSpec = {
     prefix: 'media/',
 
     paths: {
-      root: '',
-      path: '<>',
+      ...genericPaths,
 
       albumAdditionalFile: 'album-additional/<>/<>',
       albumBanner: 'album-art/<>/banner.<>',
@@ -96,11 +97,7 @@ const urlSpec = {
 
   thumb: {
     prefix: 'thumb/',
-
-    paths: {
-      root: '',
-      path: '<>',
-    },
+    paths: genericPaths,
   },
 };
 

--- a/src/url-spec.js
+++ b/src/url-spec.js
@@ -99,6 +99,16 @@ const urlSpec = {
     prefix: 'thumb/',
     paths: genericPaths,
   },
+
+  static: {
+    prefix: 'static/',
+    paths: genericPaths,
+  },
+
+  util: {
+    prefix: 'util/',
+    paths: genericPaths,
+  },
 };
 
 // This gets automatically switched in place when working from a baseDirectory,

--- a/src/web-routes.js
+++ b/src/web-routes.js
@@ -17,12 +17,12 @@ function getNodeDependencyRootPath(dependencyName) {
 export const stationaryCodeRoutes = [
   {
     from: path.join(codeSrcPath, 'static'),
-    to: '/static',
+    to: ['static.root'],
   },
 
   {
     from: path.join(codeSrcPath, 'util'),
-    to: '/util',
+    to: ['util.root'],
   },
 ];
 
@@ -39,8 +39,8 @@ export async function identifyDynamicWebRoutes({
 }) {
   const routeFunctions = [
     () => Promise.resolve([
-      {from: path.resolve(mediaPath), to: '/media'},
-      {from: path.resolve(mediaCachePath), to: '/thumb'},
+      {from: path.resolve(mediaPath), to: ['media.root']},
+      {from: path.resolve(mediaCachePath), to: ['thumb.root']},
     ]),
   ];
 

--- a/src/web-routes.js
+++ b/src/web-routes.js
@@ -1,0 +1,61 @@
+import {readdir} from 'node:fs/promises';
+import * as path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const codeSrcPath = __dirname;
+const codeRootPath = path.resolve(codeSrcPath, '..');
+
+function getNodeDependencyRootPath(dependencyName) {
+  const packageJSON =
+    import.meta.resolve(dependencyName + '/package.json');
+
+  return path.dirname(fileURLToPath(packageJSON));
+}
+
+export const stationaryCodeRoutes = [
+  {
+    from: path.join(codeSrcPath, 'static'),
+    to: '/static',
+  },
+
+  {
+    from: path.join(codeSrcPath, 'util'),
+    to: '/util',
+  },
+];
+
+export const dependencyRoutes = [];
+
+export const allStaticWebRoutes = [
+  ...stationaryCodeRoutes,
+  ...dependencyRoutes,
+];
+
+export async function identifyDynamicWebRoutes({
+  mediaPath,
+  mediaCachePath,
+}) {
+  const routeFunctions = [
+    () => Promise.resolve([
+      {from: path.resolve(mediaPath), to: '/media'},
+      {from: path.resolve(mediaCachePath), to: '/thumb'},
+    ]),
+  ];
+
+  const routeCheckPromises =
+    routeFunctions.map(fn => fn());
+
+  const routeCheckResults =
+    await Promise.all(routeCheckPromises);
+
+  return routeCheckResults.flat();
+}
+
+export async function identifyAllWebRoutes(opts) {
+  return [
+    ...allStaticWebRoutes,
+    ...await identifyDynamicWebRoutes(opts),
+  ];
+}

--- a/src/write/build-modes/live-dev-server.js
+++ b/src/write/build-modes/live-dev-server.js
@@ -225,10 +225,10 @@ export async function go({
 
     const matchedWebRoute =
       webRoutes
-        .find(({to}) => pathname.startsWith(to));
+        .find(({to}) => pathname.startsWith('/' + to));
 
     if (matchedWebRoute) {
-      const localFilePath = pathname.slice(matchedWebRoute.to.length);
+      const localFilePath = pathname.slice(1 + matchedWebRoute.to.length);
 
       // Not security tested, man, this is a dev server!!
       const safePath =

--- a/src/write/build-modes/live-dev-server.js
+++ b/src/write/build-modes/live-dev-server.js
@@ -27,19 +27,19 @@ export const description = `Hosts a local HTTP server which generates page conte
 
 export const config = {
   fileSizes: {
-    default: true,
+    default: 'perform',
   },
 
   languageReloading: {
-    default: true,
+    default: 'perform',
   },
 
   mediaValidation: {
-    default: true,
+    default: 'perform',
   },
 
   thumbs: {
-    default: true,
+    default: 'perform',
   },
 };
 

--- a/src/write/build-modes/repl.js
+++ b/src/write/build-modes/repl.js
@@ -6,7 +6,7 @@ export const config = {
   },
 
   languageReloading: {
-    default: true,
+    default: 'perform',
   },
 
   mediaValidation: {

--- a/src/write/build-modes/static-build.js
+++ b/src/write/build-modes/static-build.js
@@ -438,17 +438,7 @@ function writeWebRouteSymlinks({
 }) {
   const promises =
     webRoutes.map(async route => {
-      // TODO: Make web routes specify `to` via url spec
-      /*
-      const pathname = urls.from('shared.root').toDevice(urlKey);
-      const file = path.join(outputPath, pathname);
-      */
-
-      const parts =
-        route.to
-          .replace(/^\//, '')
-          .split('/');
-
+      const parts = route.to.split('/');
       const parentDirectoryParts = parts.slice(0, -1);
       const symlinkNamePart = parts.at(-1);
 

--- a/src/write/build-modes/static-build.js
+++ b/src/write/build-modes/static-build.js
@@ -38,7 +38,7 @@ export const description = `Generates all page content in one build (according t
 
 export const config = {
   fileSizes: {
-    default: true,
+    default: 'perform',
   },
 
   languageReloading: {
@@ -46,11 +46,11 @@ export const config = {
   },
 
   mediaValidation: {
-    default: true,
+    default: 'perform',
   },
 
   thumbs: {
-    default: true,
+    default: 'perform',
   },
 };
 


### PR DESCRIPTION
Towards #440.

Adds a new, fairly minimal system of "web routes", which specify a mapping from local file-system paths, to web paths where the contents of the local path should be exposed. Details:

* Web routes replace and consolidate previously hard-coded behavior duplicated between build modes (i.e. live-dev-server and static-build)! The diffs under `src/write/build-modes` are particularly nice. As a result, new local paths can be exposed in a build without actually editing the build modes' code — just add a new entry in `#web-routes`.
* Web routes all fundamentally behave the same (and have the same shape), but for legibility, we've divided them into a few sections in the code file:
  * `stationaryCodeRoutes`: Mappings to expose essential internal files, i.e. `static` and `util`.
  * `dependencyRoutes`: Mappings to expose npm-installed packages. A utility function `getNodeDependencyRootPath` exists to help with this, though there's nothing in this section yet.
  * `identifyDynamicWebRoutes`: Function that takes paths provided by the user (`mediaPath` and `mediaCachePath`) and makes mappings out of those (to `media` and `thumb` respectively).
* Web routes map from an on-device path (which is cwd-relative or absolute, and a proper system path) and to a wiki web path defined by `#url-spec`.
  * `#web-routes` itself doesn't access a `urls` object; it just defines, for each mapping, the path that should be provided to `urls.from('shared.root').to(...)`.
  * However, build modes don't access those raw path arrays; they get the result of the `urls` call, preprocessed by `upd8.js`. So, as far as builds are concerned, `to` is always a `/`-divided path which does *not* start with `/`.