### PR TITLE
Dynamically position tooltips relative to line boxes

### DIFF
--- a/src/static/client3.js
+++ b/src/static/client3.js
@@ -193,6 +193,34 @@ class WikiRect extends DOMRect {
     return this.fromRect(element.getBoundingClientRect());
   }
 
+  static fromMouse() {
+    const {clientX, clientY} = liveMousePositionInfo.state;
+
+    return WikiRect.fromRect({
+      x: clientX,
+      y: clientY,
+      width: 0,
+      height: 0,
+    });
+  }
+
+  static fromElementUnderMouse(element) {
+    const mouseRect = WikiRect.fromMouse();
+
+    const rects =
+      Array.from(element.getClientRects())
+        .map(rect => WikiRect.fromRect(rect));
+
+    const rectUnderMouse =
+      rects.find(rect => rect.contains(mouseRect));
+
+    if (rectUnderMouse) {
+      return rectUnderMouse;
+    } else {
+      return rects[0];
+    }
+  }
+
   static leftOf(origin, offset = 0) {
     // Returns a rectangle representing everywhere to the left of the provided
     // point or rectangle (with no top or bottom bounds), towards negative x.

--- a/src/static/client3.js
+++ b/src/static/client3.js
@@ -1642,7 +1642,7 @@ function getTooltipFromHoverablePlacementOpportunityAreas(hoverable) {
     getTooltipBaselineOpportunityAreas(tooltip);
 
   const hoverableRect =
-    WikiRect.fromElement(hoverable).toExtended(5, 10);
+    WikiRect.fromElementUnderMouse(hoverable).toExtended(5, 10);
 
   const tooltipRect =
     peekTooltipClientRect(tooltip);

--- a/src/static/client3.js
+++ b/src/static/client3.js
@@ -689,6 +689,29 @@ function mutateCSSCompatibilityContent() {
 clientSteps.getPageReferences.push(getCSSCompatibilityAssistantInfoReferences);
 clientSteps.mutatePageContent.push(mutateCSSCompatibilityContent);
 
+// Ever-updating mouse position helper --------------------
+
+const liveMousePositionInfo = initInfo('liveMousePositionInfo', {
+  state: {
+    clientX: null,
+    clientY: null,
+  },
+});
+
+function addLiveMousePositionPageListeners() {
+  const info = liveMousePositionInfo;
+  const {state} = info;
+
+  document.body.addEventListener('mousemove', domEvent => {
+    Object.assign(state, {
+      clientX: domEvent.clientX,
+      clientY: domEvent.clientY,
+    });
+  });
+}
+
+clientSteps.addPageListeners.push(addLiveMousePositionPageListeners);
+
 // JS-based links -----------------------------------------
 
 const scriptedLinkInfo = initInfo('scriptedLinkInfo', {


### PR DESCRIPTION
This is a fairly small fix to avoid alignment problems when handling an inline hoverable broken across multiple lines.

Previously we were using `getBoundingClientRect`, which gets the rectangle which *bounds* the maximum opposing corners that any part of the element occupies; this is trouble for line-broken inline elements, which are really composed of multiple rectangles!

Now we check each of those rectangles using `getClientRects` and try to find one under the mouse pointer. If there is none, we just fall back to the first rectangle (rather than the bounding one, which would cause alignment problems as before).

Rather than work with mouse events (which aren't especially relevant anyway, since tooltips appear after a timed delay), we're just keeping an ever-live track of the current mouse position in an isolated state variable (accessible to other libraries/code). We basically couldn't be doing *less* work in that event handler, so hopefully this isn't cause for performance / energy concern.
