### PR TITLE
Platforms column in artist external links tooltip

### DIFF
--- a/src/content/dependencies/linkContribution.js
+++ b/src/content/dependencies/linkContribution.js
@@ -1,4 +1,4 @@
-import {empty} from '#sugar';
+import {empty, stitchArrays} from '#sugar';
 
 export default {
   contentDependencies: [
@@ -34,6 +34,7 @@ export default {
   data(contribution) {
     return {
       what: contribution.what,
+      urls: contribution.who.urls,
     };
   },
 
@@ -74,12 +75,21 @@ export default {
                   {[html.joinChildren]: ''},
 
                 content:
-                  relations.artistIcons
-                    .map(icon =>
+                  stitchArrays({
+                    icon: relations.artistIcons,
+                    url: data.urls,
+                  }).map(({icon, url}) => [
                       icon.slots({
                         context: 'artist',
                         withText: true,
-                      })),
+                      }),
+
+                      html.tag('span', {class: 'icon-platform'},
+                        language.formatExternalLink(url, {
+                          context: 'artist',
+                          style: 'platform',
+                        })),
+                    ]),
               }),
           })
         : relations.artistLink);

--- a/src/content/dependencies/linkContribution.js
+++ b/src/content/dependencies/linkContribution.js
@@ -78,18 +78,33 @@ export default {
                   stitchArrays({
                     icon: relations.artistIcons,
                     url: data.urls,
-                  }).map(({icon, url}) => [
-                      icon.slots({
+                  }).map(({icon, url}) => {
+                      icon.setSlots({
                         context: 'artist',
                         withText: true,
-                      }),
+                      });
 
-                      html.tag('span', {class: 'icon-platform'},
+                      let platformText =
                         language.formatExternalLink(url, {
                           context: 'artist',
                           style: 'platform',
-                        })),
-                    ]),
+                        });
+
+                      // This is a pretty ridiculous hack, but we currently
+                      // don't have a way of telling formatExternalLink to *not*
+                      // use the fallback string, which just formats the URL as
+                      // its host/domain... so is technically detectable.
+                      if (platformText.toString() === (new URL(url)).host) {
+                        platformText =
+                          language.$('misc.artistLink.noExternalLinkPlatformName');
+                      }
+
+                      const platformSpan =
+                        html.tag('span', {class: 'icon-platform'},
+                          platformText);
+
+                      return [icon, platformSpan];
+                    }),
               }),
           })
         : relations.artistLink);

--- a/src/static/client3.js
+++ b/src/static/client3.js
@@ -5,7 +5,8 @@
 // that cannot 8e done at static-site compile time, 8y its fundamentally
 // ephemeral nature.
 
-import {empty, filterMultipleArrays, stitchArrays} from '../util/sugar.js';
+import {accumulateSum, empty, filterMultipleArrays, stitchArrays}
+  from '../util/sugar.js';
 
 const clientInfo = window.hsmusicClientInfo = Object.create(null);
 
@@ -3035,6 +3036,210 @@ function addDatestampTooltipPageListeners() {
 
 clientSteps.getPageReferences.push(getDatestampTooltipReferences);
 clientSteps.addPageListeners.push(addDatestampTooltipPageListeners);
+
+// Artist external link tooltips --------------------------
+
+// These don't need to have tooltip events specially added as
+// they're implemented with "text with tooltip" components.
+
+const artistExternalLinkTooltipInfo = initInfo('artistExternalLinkTooltipInfo', {
+  tooltips: null,
+  tooltipRows: null,
+
+  settings: {
+    // This is the maximum distance, in CSS pixels, that the mouse
+    // can appear to be moving per second while still considered
+    // "idle". A greater value means higher tolerance for small
+    // movements.
+    maximumIdleSpeed: 40,
+
+    // Leaving the mouse idle for this amount of time, over a single
+    // row of the tooltip, will cause a column of supplemental info
+    // to display.
+    mouseIdleShowInfoDelay: 1000,
+
+    // If none of these tooltips are visible for this amount of time,
+    // the supplemental info column is hidden. It'll never disappear
+    // while a tooltip is actually visible.
+    hideInfoAfterTooltipHiddenDelay: 2250,
+  },
+
+  state: {
+    // This is shared by all tooltips.
+    showingTooltipInfo: false,
+
+    mouseIdleTimeout: null,
+    hideInfoTimeout: null,
+
+    mouseMovementPositions: [],
+    mouseMovementTimestamps: [],
+  },
+});
+
+function getArtistExternalLinkTooltipPageReferences() {
+  const info = artistExternalLinkTooltipInfo;
+
+  info.tooltips =
+    Array.from(document.getElementsByClassName('icons-tooltip'));
+
+  info.tooltipRows =
+    info.tooltips.map(tooltip =>
+      Array.from(tooltip.getElementsByClassName('icon')));
+}
+
+function addArtistExternalLinkTooltipInternalListeners() {
+  const info = artistExternalLinkTooltipInfo;
+
+  hoverableTooltipInfo.event.whenTooltipShows.push(({tooltip}) => {
+    const {state} = info;
+
+    if (info.tooltips.includes(tooltip)) {
+      clearTimeout(state.hideInfoTimeout);
+      state.hideInfoTimeout = null;
+    }
+  });
+
+  hoverableTooltipInfo.event.whenTooltipHides.push(() => {
+    const {settings, state} = info;
+
+    if (state.showingTooltipInfo) {
+      state.hideInfoTimeout =
+        setTimeout(() => {
+          state.hideInfoTimeout = null;
+          hideArtistExternalLinkTooltipInfo();
+        }, settings.hideInfoAfterTooltipHiddenDelay);
+    } else {
+      clearTimeout(state.mouseIdleTimeout);
+      state.mouseIdleTimeout = null;
+    }
+  });
+}
+
+function addArtistExternalLinkTooltipPageListeners() {
+  const info = artistExternalLinkTooltipInfo;
+
+  for (const tooltip of info.tooltips) {
+    tooltip.addEventListener('mousemove', domEvent => {
+      handleArtistExternalLinkTooltipMouseMoved(domEvent);
+    });
+
+    tooltip.addEventListener('mouseout', () => {
+      const {state} = info;
+
+      clearTimeout(state.mouseIdleTimeout);
+      state.mouseIdleTimeout = null;
+    });
+  }
+
+  for (const tooltipRow of info.tooltipRows.flat()) {
+    tooltipRow.addEventListener('mouseover', () => {
+      const {state} = info;
+
+      clearTimeout(state.mouseIdleTimeout);
+      state.mouseIdleTimeout = null;
+    });
+  }
+}
+
+function handleArtistExternalLinkTooltipMouseMoved(domEvent) {
+  const info = artistExternalLinkTooltipInfo;
+  const {settings, state} = info;
+
+  if (state.showingTooltipInfo) {
+    return;
+  }
+
+  // Clean out expired mouse movements
+
+  const expiryTime = 1000;
+
+  if (!empty(state.mouseMovementTimestamps)) {
+    const firstRecentMovementIndex =
+      state.mouseMovementTimestamps
+        .findIndex(value => Date.now() - value <= expiryTime);
+
+    if (firstRecentMovementIndex === -1) {
+      state.mouseMovementTimestamps.splice(0);
+      state.mouseMovementPositions.splice(0);
+    } else if (firstRecentMovementIndex > 0) {
+      state.mouseMovementTimestamps.splice(0, firstRecentMovementIndex - 1);
+      state.mouseMovementPositions.splice(0, firstRecentMovementIndex - 1);
+    }
+  }
+
+  const currentMovementDistance =
+    Math.sqrt(domEvent.movementX ** 2 + domEvent.movementY ** 2);
+
+  state.mouseMovementTimestamps.push(Date.now());
+  state.mouseMovementPositions.push([domEvent.screenX, domEvent.screenY]);
+
+  // We can't really compute speed without having
+  // at least two data points!
+  if (state.mouseMovementPositions.length < 2) {
+    return;
+  }
+
+  const movementTravelDistances =
+    state.mouseMovementPositions.map((current, index, array) => {
+      if (index === 0) return 0;
+
+      const previous = array[index - 1];
+      const deltaX = current[0] - previous[0];
+      const deltaY = current[1] - previous[1];
+      return Math.sqrt(deltaX ** 2 + deltaY ** 2);
+    });
+
+  const totalTravelDistance =
+    accumulateSum(movementTravelDistances);
+
+  // In seconds rather than milliseconds.
+  const timeSinceFirstMovement =
+    (Date.now() - state.mouseMovementTimestamps[0]) / 1000;
+
+  const averageSpeed =
+    Math.floor(totalTravelDistance / timeSinceFirstMovement);
+
+  if (averageSpeed > settings.maximumIdleSpeed) {
+    clearTimeout(state.mouseIdleTimeout);
+    state.mouseIdleTimeout = null;
+  }
+
+  if (state.mouseIdleTimeout) {
+    return;
+  }
+
+  state.mouseIdleTimeout =
+    setTimeout(() => {
+      state.mouseIdleTimeout = null;
+      showArtistExternalLinkTooltipInfo();
+    }, settings.mouseIdleShowInfoDelay);
+}
+
+function showArtistExternalLinkTooltipInfo() {
+  const info = artistExternalLinkTooltipInfo;
+  const {state} = info;
+
+  state.showingTooltipInfo = true;
+
+  for (const tooltip of info.tooltips) {
+    tooltip.classList.add('show-info');
+  }
+}
+
+function hideArtistExternalLinkTooltipInfo() {
+  const info = artistExternalLinkTooltipInfo;
+  const {state} = info;
+
+  state.showingTooltipInfo = false;
+
+  for (const tooltip of info.tooltips) {
+    tooltip.classList.remove('show-info');
+  }
+}
+
+clientSteps.getPageReferences.push(getArtistExternalLinkTooltipPageReferences);
+clientSteps.addInternalListeners.push(addArtistExternalLinkTooltipInternalListeners);
+clientSteps.addPageListeners.push(addArtistExternalLinkTooltipPageListeners);
 
 // Sticky commentary sidebar ------------------------------
 

--- a/src/static/client3.js
+++ b/src/static/client3.js
@@ -1075,6 +1075,11 @@ const hoverableTooltipInfo = initInfo('hoverableTooltipInfo', {
     currentTouchIdentifiers: new Set(),
     touchIdentifiersBanishedByScrolling: new Set(),
   },
+
+  event: {
+    whenTooltipShows: [],
+    whenTooltipHides: [],
+  },
 });
 
 // Adds DOM event listeners, so must be called during addPageListeners step.
@@ -1476,7 +1481,7 @@ function endTransitioningTooltipHidden() {
 }
 
 function hideCurrentlyShownTooltip(intendingToReplace = false) {
-  const {settings, state} = hoverableTooltipInfo;
+  const {settings, state, event} = hoverableTooltipInfo;
   const {currentlyShownTooltip: tooltip} = state;
 
   // If there was no tooltip to begin with, we're functionally in the desired
@@ -1516,11 +1521,15 @@ function hideCurrentlyShownTooltip(intendingToReplace = false) {
     state.tooltipWasJustHidden = false;
   });
 
+  dispatchInternalEvent(event, 'whenTooltipHides', {
+    tooltip,
+  });
+
   return true;
 }
 
 function showTooltipFromHoverable(hoverable) {
-  const {state} = hoverableTooltipInfo;
+  const {state, event} = hoverableTooltipInfo;
   const {tooltip} = state.registeredHoverables.get(hoverable);
 
   if (!hideCurrentlyShownTooltip(true)) return false;
@@ -1540,6 +1549,10 @@ function showTooltipFromHoverable(hoverable) {
   state.currentlyActiveHoverable = hoverable;
 
   state.tooltipWasJustHidden = false;
+
+  dispatchInternalEvent(event, 'whenTooltipShows', {
+    tooltip,
+  });
 
   return true;
 }

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -594,6 +594,48 @@ li:not(:first-child:last-child) .tooltip,
           user-select: none;
 
   cursor: default;
+
+  display: grid;
+
+  grid-template-columns:
+    [icon-start] auto [icon-end domain-start] auto [domain-end];
+}
+
+.icons-tooltip .icon {
+  grid-column-start: icon-start;
+  grid-column-end: icon-end;
+}
+
+.icons-tooltip .icon-platform {
+  display: none;
+
+  grid-column-start: domain-start;
+  grid-column-end: domain-end;
+
+  --icon-platform-opacity: 0.8;
+  padding-right: 4px;
+  opacity: 0.8;
+}
+
+.icons-tooltip.show-info .icon-platform {
+  display: inline;
+  animation: icon-platform 0.2s forwards linear;
+}
+
+@keyframes icon-platform {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: var(--icon-platform-opacity);
+  }
+}
+
+.icons-tooltip .icon:hover + .icon-platform {
+  --icon-platform-opacity: 1;
+  text-decoration: underline;
+  text-decoration-color: #ffffffaa;
 }
 
 .datetimestamp-tooltip .tooltip-content,

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -453,6 +453,10 @@ misc:
     # Combination of above.
     withContribution.withExternalLinks: "{ARTIST} ({CONTRIB}) ({LINKS})"
 
+    # Displayed in an artist's tooltip, if one of their URLs
+    # isn't a specially detected web platform.
+    noExternalLinkPlatformName: "Other"
+
   # chronology:
   #
   #   "Chronology links" are a section that appear in the nav bar for


### PR DESCRIPTION
Adds a column, appearing after a time delay of keeping the mouse more or less idle, which identifies the platform for each row/link by name.

<img width="441" alt="Example tooltip from Toby Fox, showing a table layout: one row for each of four links, showing the logo for the platform, Toby's name on that platform, and the name of the platform. The name-of-platform column is mostly dimmed out, but the cell corresponding to the currently-hovered link is brighter and underlined." src="https://github.com/hsmusic/hsmusic-wiki/assets/9948030/3c76c47c-fd98-4486-a65c-b27060dcaadf">

<img width="340" alt="Another example for artist Kara Roas, who has many links on various different platforms, including two for Tumblr. Highlighted is a link to a Carrd page, which has a pretty unfamiliar logo, but is identified clearly as Carrd by the platform name in the new column." src="https://github.com/hsmusic/hsmusic-wiki/assets/9948030/2c3358c7-222f-4b69-bbaf-f70f5c030e1c">

This *currently* is only accessible via mouse, so no keyboard or mobile support, but we'll probably investigate what would work best for those modes later on.
