### PR TITLE
Nice external links

### DIFF
--- a/src/content/dependencies/generatePageLayout.js
+++ b/src/content/dependencies/generatePageLayout.js
@@ -289,8 +289,11 @@ export default {
     let footerContent = slots.footerContent;
 
     if (html.isBlank(footerContent) && relations.defaultFooterContent) {
-      footerContent = relations.defaultFooterContent
-        .slot('mode', 'multiline');
+      footerContent =
+        relations.defaultFooterContent.slots({
+          mode: 'multiline',
+          indicateExternalLinks: false,
+        });
     }
 
     const mainHTML =

--- a/src/content/dependencies/linkExternal.js
+++ b/src/content/dependencies/linkExternal.js
@@ -51,8 +51,8 @@ export default {
         });
     }
 
+    linkAttributes.set('class', 'external-link');
     linkAttributes.set('href', data.url);
-    linkAttributes.set('class', 'nowrap');
 
     if (slots.tab === 'separate') {
       linkAttributes.set('target', '_blank');

--- a/src/content/dependencies/linkExternal.js
+++ b/src/content/dependencies/linkExternal.js
@@ -33,7 +33,7 @@ export default {
       });
 
     // Fall back to platform if nothing matched the desired style.
-    if (!formattedText && slots.style !== 'platform') {
+    if (html.isBlank(formattedText) && slots.style !== 'platform') {
       formattedText =
         language.formatExternalLink(data.url, {
           style: 'platform',

--- a/src/content/dependencies/linkExternal.js
+++ b/src/content/dependencies/linkExternal.js
@@ -24,6 +24,11 @@ export default {
       default: 'generic',
     },
 
+    fromContent: {
+      type: 'boolean',
+      default: false,
+    },
+
     indicateExternal: {
       type: 'boolean',
       default: false,
@@ -91,6 +96,10 @@ export default {
                 language.$('misc.external.invalidURL.annotation')),
           });
       }
+    }
+
+    if (slots.fromContent) {
+      linkAttributes.add('class', 'from-content');
     }
 
     if (urlIsValid && slots.indicateExternal) {

--- a/src/content/dependencies/linkExternal.js
+++ b/src/content/dependencies/linkExternal.js
@@ -26,31 +26,30 @@ export default {
   },
 
   generate(data, slots, {html, language}) {
-    let formattedText =
+    const linkAttributes = html.attributes();
+
+    let linkContent =
       language.formatExternalLink(data.url, {
         style: slots.style,
         context: slots.context,
       });
 
     // Fall back to platform if nothing matched the desired style.
-    if (html.isBlank(formattedText) && slots.style !== 'platform') {
-      formattedText =
+    if (html.isBlank(linkContent) && slots.style !== 'platform') {
+      linkContent =
         language.formatExternalLink(data.url, {
           style: 'platform',
           context: slots.context,
         });
     }
 
-    const link =
-      html.tag('a', formattedText);
-
-    link.attributes.set('href', data.url);
-    link.attributes.set('class', 'nowrap');
+    linkAttributes.set('href', data.url);
+    linkAttributes.set('class', 'nowrap');
 
     if (slots.tab === 'separate') {
-      link.attributes.set('target', '_blank');
+      linkAttributes.set('target', '_blank');
     }
 
-    return link;
+    return html.tag('a', linkAttributes, linkContent);
   },
 };

--- a/src/content/dependencies/linkExternal.js
+++ b/src/content/dependencies/linkExternal.js
@@ -6,6 +6,11 @@ export default {
   data: (url) => ({url}),
 
   slots: {
+    content: {
+      type: 'html',
+      mutable: false,
+    },
+
     style: {
       // This awkward syntax is because the slot descriptor validator can't
       // differentiate between a function that returns a validator (the usual
@@ -27,12 +32,15 @@ export default {
 
   generate(data, slots, {html, language}) {
     const linkAttributes = html.attributes();
+    let linkContent = slots.content;
 
-    let linkContent =
-      language.formatExternalLink(data.url, {
-        style: slots.style,
-        context: slots.context,
-      });
+    if (html.isBlank(linkContent)) {
+      linkContent =
+        language.formatExternalLink(data.url, {
+          style: slots.style,
+          context: slots.context,
+        });
+    }
 
     // Fall back to platform if nothing matched the desired style.
     if (html.isBlank(linkContent) && slots.style !== 'platform') {

--- a/src/content/dependencies/transformContent.js
+++ b/src/content/dependencies/transformContent.js
@@ -255,18 +255,31 @@ export default {
             } = node;
 
             if (node.inline) {
+              let content =
+                html.tag('img',
+                  src && {src},
+                  width && {width},
+                  height && {height},
+                  style && {style},
+
+                  pixelate &&
+                    {class: 'pixelate'});
+
+              if (link) {
+                // TODO: Would be nice to use an external link component here,
+                // just for the title text (ex. "YouTube (opens in new tab)")
+                content =
+                  html.tag('a',
+                    {href: link},
+                    {target: '_blank'},
+
+                    content);
+              }
+
               return {
                 type: 'processed-image',
                 inline: true,
-                data:
-                  html.tag('img',
-                    src && {src},
-                    width && {width},
-                    height && {height},
-                    style && {style},
-
-                    pixelate &&
-                      {class: 'pixelate'}),
+                data: content,
               };
             }
 

--- a/src/content/dependencies/transformContent.js
+++ b/src/content/dependencies/transformContent.js
@@ -347,7 +347,10 @@ export default {
             const {label} = node.data;
             const externalLink = relations.externalLinks[externalLinkIndex++];
 
-            externalLink.setSlot('content', label);
+            externalLink.setSlots({
+              content: label,
+              fromContent: true,
+            });
 
             if (slots.indicateExternalLinks) {
               externalLink.setSlots({

--- a/src/content/dependencies/transformContent.js
+++ b/src/content/dependencies/transformContent.js
@@ -114,7 +114,7 @@ export default {
 
             data.hash = enteredHash ?? null;
 
-            return {i: node.i, iEnd: node.iEnd, type: 'link', data};
+            return {i: node.i, iEnd: node.iEnd, type: 'internal-link', data};
           }
 
           // This will be another {type: 'tag'} node which gets processed in
@@ -238,7 +238,7 @@ export default {
 
             if (node.inline) {
               return {
-                type: 'image',
+                type: 'processed-image',
                 inline: true,
                 data:
                   html.tag('img',
@@ -255,7 +255,7 @@ export default {
             const image = relations.images[imageIndex++];
 
             return {
-              type: 'image',
+              type: 'processed-image',
               inline: false,
               data:
                 html.tag('div', {class: 'content-image-container'},
@@ -322,7 +322,7 @@ export default {
               link.setSlot('tooltipStyle', 'none');
             }
 
-            return {type: 'link', data: link};
+            return {type: 'processed-link', data: link};
           }
 
           case 'tag': {
@@ -358,7 +358,9 @@ export default {
     // access to its slots.
 
     if (slots.mode === 'single-link') {
-      const link = contentFromNodes.find(node => node.type === 'link');
+      const link =
+        contentFromNodes.find(node =>
+          node.type === 'processed-link');
 
       if (!link) {
         return html.blank();
@@ -390,7 +392,7 @@ export default {
             'data-type': node.type,
           });
 
-          if (node.type === 'image') {
+          if (node.type === 'processed-image') {
             attributes.set('data-inline', node.inline);
           }
 
@@ -426,7 +428,7 @@ export default {
         // the surrounding <p> tag that marked generates. The HTML parser
         // treats a <div> that starts inside a <p> as a Crocker-class
         // misgiving, and will treat you very badly if you feed it that.
-        if (attributes.get('data-type') === 'image') {
+        if (attributes.get('data-type') === 'processed-image') {
           if (!attributes.get('data-inline')) {
             tags[tags.length - 1] = tags[tags.length - 1].replace(/<p>$/, '');
             deleteParagraph = true;

--- a/src/content/dependencies/transformContent.js
+++ b/src/content/dependencies/transformContent.js
@@ -216,6 +216,11 @@ export default {
       default: false,
     },
 
+    indicateExternalLinks: {
+      type: 'boolean',
+      default: true,
+    },
+
     thumb: {
       validate: v => v.is('small', 'medium', 'large'),
       default: 'large',
@@ -342,12 +347,15 @@ export default {
             const {label} = node.data;
             const externalLink = relations.externalLinks[externalLinkIndex++];
 
-            externalLink.setSlots({
-              indicateExternal: true,
-              tab: 'separate',
-              style: 'platform',
-              content: label,
-            });
+            externalLink.setSlot('content', label);
+
+            if (slots.indicateExternalLinks) {
+              externalLink.setSlots({
+                indicateExternal: true,
+                tab: 'separate',
+                style: 'platform',
+              });
+            }
 
             return {type: 'processed-external-link', data: externalLink};
           }

--- a/src/content/dependencies/transformContent.js
+++ b/src/content/dependencies/transformContent.js
@@ -37,6 +37,7 @@ export default {
         .map(description => description.link)
         .filter(Boolean)),
     'image',
+    'linkExternal',
   ],
 
   extraDependencies: ['html', 'language', 'to', 'wikiData'],
@@ -187,6 +188,15 @@ export default {
             }
           }),
 
+      externalLinks:
+        nodes
+          .filter(({type}) => type === 'external-link')
+          .map(node => {
+            const {href} = node.data;
+
+            return relation('linkExternal', href);
+          }),
+
       images:
         nodes
           .filter(({type}) => type === 'image')
@@ -215,6 +225,7 @@ export default {
   generate(data, relations, slots, {html, language, to}) {
     let imageIndex = 0;
     let internalLinkIndex = 0;
+    let externalLinkIndex = 0;
 
     const contentFromNodes =
       data.nodes.map(node => {
@@ -327,6 +338,15 @@ export default {
             return {type: 'processed-internal-link', data: link};
           }
 
+          case 'external-link': {
+            const {label} = node.data;
+            const externalLink = relations.externalLinks[externalLinkIndex++];
+
+            externalLink.setSlot('content', label);
+
+            return {type: 'processed-external-link', data: externalLink};
+          }
+
           case 'tag': {
             const {replacerKey, replacerValue} = node.data;
 
@@ -362,7 +382,8 @@ export default {
     if (slots.mode === 'single-link') {
       const link =
         contentFromNodes.find(node =>
-          node.type === 'processed-internal-link');
+          node.type === 'processed-internal-link' ||
+          node.type === 'processed-external-link');
 
       if (!link) {
         return html.blank();

--- a/src/content/dependencies/transformContent.js
+++ b/src/content/dependencies/transformContent.js
@@ -342,7 +342,12 @@ export default {
             const {label} = node.data;
             const externalLink = relations.externalLinks[externalLinkIndex++];
 
-            externalLink.setSlot('content', label);
+            externalLink.setSlots({
+              indicateExternal: true,
+              tab: 'separate',
+              style: 'platform',
+              content: label,
+            });
 
             return {type: 'processed-external-link', data: externalLink};
           }

--- a/src/data/checks.js
+++ b/src/data/checks.js
@@ -574,6 +574,16 @@ export function reportContentTextErrors(wikiData, {
             continue;
           }
         }
+      } else if (node.type === 'external-link') {
+        try {
+          new URL(node.data.href);
+        } catch (error) {
+          yield {
+            index, length,
+            message:
+              `Invalid URL ${colors.red(`"${node.data.href}"`)}`,
+          };
+        }
       }
     }
   }

--- a/src/data/things/language.js
+++ b/src/data/things/language.js
@@ -540,10 +540,16 @@ export class Language extends Thing {
 
     isExternalLinkStyle(style);
 
-    return getExternalLinkStringOfStyleFromDescriptors(url, style, this.externalLinkSpec, {
-      language: this,
-      context,
-    });
+    const result =
+      getExternalLinkStringOfStyleFromDescriptors(url, style, this.externalLinkSpec, {
+        language: this,
+        context,
+      });
+
+    // It's possible for there to not actually be any string available for the
+    // given URL, style, and context, and we want this to be detectable via
+    // html.blank().
+    return result ?? html.blank();
   }
 
   formatIndex(value) {

--- a/src/data/validators.js
+++ b/src/data/validators.js
@@ -420,6 +420,14 @@ const illegalContentSpec = [
   {illegal: '\u2005', annotation: `four-per-em space`, ...illegalVisibleSpace},
   {illegal: '\u205f', annotation: `medium mathematical space`, ...illegalVisibleSpace},
   {illegal: '\xa0', annotation: `non-breaking space`, ...illegalVisibleSpace},
+
+  {
+    action: 'replace',
+    illegal: '<a href',
+    annotation: `HTML-style link`,
+    with: '[...](...)',
+    withAnnotation: `markdown`,
+  },
 ];
 
 for (const entry of illegalContentSpec) {

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -468,6 +468,10 @@ a:not([href]):hover {
   text-decoration: none;
 }
 
+.external-link {
+  white-space: nowrap;
+}
+
 .nav-main-links .nav-link.current > span.nav-link-content > a {
   font-weight: 800;
 }
@@ -799,6 +803,10 @@ ul.image-details li {
 
 .commentary-entry-accent {
   font-style: oblique;
+}
+
+.commentary-entry-body .external-link {
+  white-space: normal;
 }
 
 .commentary-art {

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -472,6 +472,14 @@ a:not([href]):hover {
   white-space: nowrap;
 }
 
+.external-link.indicate-external::after {
+  content: ' ➚';
+}
+
+.external-link.indicate-external:hover::after {
+  color: white;
+}
+
 .nav-main-links .nav-link.current > span.nav-link-content > a {
   font-weight: 800;
 }

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -468,7 +468,7 @@ a:not([href]):hover {
   text-decoration: none;
 }
 
-.external-link {
+.external-link:not(.from-content) {
   white-space: nowrap;
 }
 
@@ -811,10 +811,6 @@ ul.image-details li {
 
 .commentary-entry-accent {
   font-style: oblique;
-}
-
-.commentary-entry-body .external-link {
-  white-space: normal;
 }
 
 .commentary-art {

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -504,6 +504,11 @@ misc:
     withHandle:
       "{PLATFORM} ({HANDLE})"
 
+    opensInNewTab:
+      _: "{LINK} ({ANNOTATION})"
+      annotation:
+        "opens in new tab"
+
     appleMusic: "Apple Music"
     artstation: "ArtStation"
     bandcamp: "Bandcamp"

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -506,8 +506,11 @@ misc:
 
     opensInNewTab:
       _: "{LINK} ({ANNOTATION})"
-      annotation:
-        "opens in new tab"
+      annotation: "opens in new tab"
+
+    invalidURL:
+      _: "{LINK} ({ANNOTATION})"
+      annotation: "invalid URL"
 
     appleMusic: "Apple Music"
     artstation: "ArtStation"

--- a/src/util/replacer.js
+++ b/src/util/replacer.js
@@ -591,7 +591,7 @@ export function postprocessExternalLinks(inputNodes) {
       continue;
     }
 
-    const plausibleLinkRegexp = /\[.*\)/g;
+    const plausibleLinkRegexp = /\[.*?\)/g;
 
     let textContent = '';
 

--- a/src/util/replacer.js
+++ b/src/util/replacer.js
@@ -462,7 +462,14 @@ export function postprocessImages(inputNodes) {
       let match = null, parseFrom = 0;
       while (match = imageRegexp.exec(node.data)) {
         const previousText = node.data.slice(parseFrom, match.index);
-        outputNodes.push({type: 'text', data: previousText});
+
+        outputNodes.push({
+          type: 'text',
+          data: previousText,
+          i: node.i + parseFrom,
+          iEnd: node.i + parseFrom + match.index,
+        });
+
         parseFrom = match.index + match[0].length;
 
         const imageNode = {type: 'image'};
@@ -534,6 +541,8 @@ export function postprocessImages(inputNodes) {
         outputNodes.push({
           type: 'text',
           data: node.data.slice(parseFrom),
+          i: node.i + parseFrom,
+          iEnd: node.iEnd,
         });
       }
 
@@ -576,7 +585,12 @@ export function postprocessHeadings(inputNodes) {
       textContent += node.data.slice(parseFrom);
     }
 
-    outputNodes.push({type: 'text', data: textContent});
+    outputNodes.push({
+      type: 'text',
+      data: textContent,
+      i: node.i,
+      iEnd: node.iEnd,
+    });
   }
 
   return outputNodes;
@@ -613,12 +627,17 @@ export function postprocessExternalLinks(inputNodes) {
           textContent = '';
         }
 
-        outputNodes.push({type: 'external-link', data: {label, href}});
+        const offset = plausibleMatch.index + definiteMatch.index;
+        const length = definiteMatch[0].length;
 
-        parseFrom =
-          plausibleMatch.index +
-          definiteMatch.index +
-          definiteMatch[0].length;
+        outputNodes.push({
+          i: node.i + offset,
+          iEnd: node.i + offset + length,
+          type: 'external-link',
+          data: {label, href},
+        });
+
+        parseFrom = offset + length;
       } else {
         parseFrom = plausibleMatch.index;
       }

--- a/src/util/replacer.js
+++ b/src/util/replacer.js
@@ -613,9 +613,16 @@ export function postprocessExternalLinks(inputNodes) {
     while (plausibleMatch = plausibleLinkRegexp.exec(node.data)) {
       textContent += node.data.slice(parseFrom, plausibleMatch.index);
 
+      // Pedantic rules use more particular parentheses detection in link
+      // destinations - they allow one level of balanced parentheses, and
+      // otherwise, parentheses must be escaped. This allows for entire links
+      // to be wrapped in parentheses, e.g below:
+      //
+      //   This is so cool. ([You know??](https://example.com))
+      //
       const definiteMatch =
-        marked.Lexer.rules.inline.link.exec(
-          node.data.slice(plausibleMatch.index));
+        marked.Lexer.rules.inline.pedantic.link
+          .exec(node.data.slice(plausibleMatch.index));
 
       if (definiteMatch) {
         const {1: label, 2: href} = definiteMatch;

--- a/tap-snapshots/test/snapshot/linkExternal.js.test.cjs
+++ b/tap-snapshots/test/snapshot/linkExternal.js.test.cjs
@@ -6,223 +6,223 @@
  */
 'use strict'
 exports[`test/snapshot/linkExternal.js > TAP > linkExternal (snapshot) > context: album, style: handle 1`] = `
-<a href="https://youtu.be/abc" class="nowrap">YouTube</a>
-<a href="https://youtube.com/watch?v=abc" class="nowrap">YouTube</a>
-<a href="https://youtube.com/Playlist?list=kweh" class="nowrap">YouTube</a>
+<a class="external-link" href="https://youtu.be/abc">YouTube</a>
+<a class="external-link" href="https://youtube.com/watch?v=abc">YouTube</a>
+<a class="external-link" href="https://youtube.com/Playlist?list=kweh">YouTube</a>
 `
 
 exports[`test/snapshot/linkExternal.js > TAP > linkExternal (snapshot) > context: album, style: platform 1`] = `
-<a href="https://youtu.be/abc" class="nowrap">YouTube</a>
-<a href="https://youtube.com/watch?v=abc" class="nowrap">YouTube</a>
-<a href="https://youtube.com/Playlist?list=kweh" class="nowrap">YouTube</a>
+<a class="external-link" href="https://youtu.be/abc">YouTube</a>
+<a class="external-link" href="https://youtube.com/watch?v=abc">YouTube</a>
+<a class="external-link" href="https://youtube.com/Playlist?list=kweh">YouTube</a>
 `
 
 exports[`test/snapshot/linkExternal.js > TAP > linkExternal (snapshot) > context: albumMultipleTracks, style: handle 1`] = `
-<a href="https://youtu.be/abc" class="nowrap">YouTube (full album)</a>
-<a href="https://youtube.com/watch?v=abc" class="nowrap">YouTube (full album)</a>
-<a href="https://youtube.com/Playlist?list=kweh" class="nowrap">YouTube</a>
+<a class="external-link" href="https://youtu.be/abc">YouTube (full album)</a>
+<a class="external-link" href="https://youtube.com/watch?v=abc">YouTube (full album)</a>
+<a class="external-link" href="https://youtube.com/Playlist?list=kweh">YouTube</a>
 `
 
 exports[`test/snapshot/linkExternal.js > TAP > linkExternal (snapshot) > context: albumMultipleTracks, style: platform 1`] = `
-<a href="https://youtu.be/abc" class="nowrap">YouTube (full album)</a>
-<a href="https://youtube.com/watch?v=abc" class="nowrap">YouTube (full album)</a>
-<a href="https://youtube.com/Playlist?list=kweh" class="nowrap">YouTube</a>
+<a class="external-link" href="https://youtu.be/abc">YouTube (full album)</a>
+<a class="external-link" href="https://youtube.com/watch?v=abc">YouTube (full album)</a>
+<a class="external-link" href="https://youtube.com/Playlist?list=kweh">YouTube</a>
 `
 
 exports[`test/snapshot/linkExternal.js > TAP > linkExternal (snapshot) > context: albumNoTracks, style: handle 1`] = `
-<a href="https://youtu.be/abc" class="nowrap">YouTube</a>
-<a href="https://youtube.com/watch?v=abc" class="nowrap">YouTube</a>
-<a href="https://youtube.com/Playlist?list=kweh" class="nowrap">YouTube</a>
+<a class="external-link" href="https://youtu.be/abc">YouTube</a>
+<a class="external-link" href="https://youtube.com/watch?v=abc">YouTube</a>
+<a class="external-link" href="https://youtube.com/Playlist?list=kweh">YouTube</a>
 `
 
 exports[`test/snapshot/linkExternal.js > TAP > linkExternal (snapshot) > context: albumNoTracks, style: platform 1`] = `
-<a href="https://youtu.be/abc" class="nowrap">YouTube</a>
-<a href="https://youtube.com/watch?v=abc" class="nowrap">YouTube</a>
-<a href="https://youtube.com/Playlist?list=kweh" class="nowrap">YouTube</a>
+<a class="external-link" href="https://youtu.be/abc">YouTube</a>
+<a class="external-link" href="https://youtube.com/watch?v=abc">YouTube</a>
+<a class="external-link" href="https://youtube.com/Playlist?list=kweh">YouTube</a>
 `
 
 exports[`test/snapshot/linkExternal.js > TAP > linkExternal (snapshot) > context: albumOneTrack, style: handle 1`] = `
-<a href="https://youtu.be/abc" class="nowrap">YouTube</a>
-<a href="https://youtube.com/watch?v=abc" class="nowrap">YouTube</a>
-<a href="https://youtube.com/Playlist?list=kweh" class="nowrap">YouTube</a>
+<a class="external-link" href="https://youtu.be/abc">YouTube</a>
+<a class="external-link" href="https://youtube.com/watch?v=abc">YouTube</a>
+<a class="external-link" href="https://youtube.com/Playlist?list=kweh">YouTube</a>
 `
 
 exports[`test/snapshot/linkExternal.js > TAP > linkExternal (snapshot) > context: albumOneTrack, style: platform 1`] = `
-<a href="https://youtu.be/abc" class="nowrap">YouTube</a>
-<a href="https://youtube.com/watch?v=abc" class="nowrap">YouTube</a>
-<a href="https://youtube.com/Playlist?list=kweh" class="nowrap">YouTube</a>
+<a class="external-link" href="https://youtu.be/abc">YouTube</a>
+<a class="external-link" href="https://youtube.com/watch?v=abc">YouTube</a>
+<a class="external-link" href="https://youtube.com/Playlist?list=kweh">YouTube</a>
 `
 
 exports[`test/snapshot/linkExternal.js > TAP > linkExternal (snapshot) > context: flash, style: handle 1`] = `
-<a href="https://www.bgreco.net/hsflash/002238.html" class="nowrap">bgreco.net (high quality audio)</a>
-<a href="https://homestuck.com/story/1234" class="nowrap">Homestuck (page 1234)</a>
-<a href="https://homestuck.com/story/pony" class="nowrap">Homestuck (secret page)</a>
-<a href="https://www.youtube.com/watch?v=wKgOp3Kg2wI" class="nowrap">YouTube (on any device)</a>
-<a href="https://youtu.be/IOcvkkklWmY" class="nowrap">YouTube (on any device)</a>
-<a href="https://some.external.site/foo/bar/" class="nowrap">some.external.site</a>
+<a class="external-link" href="https://www.bgreco.net/hsflash/002238.html">bgreco.net (high quality audio)</a>
+<a class="external-link" href="https://homestuck.com/story/1234">Homestuck (page 1234)</a>
+<a class="external-link" href="https://homestuck.com/story/pony">Homestuck (secret page)</a>
+<a class="external-link" href="https://www.youtube.com/watch?v=wKgOp3Kg2wI">YouTube (on any device)</a>
+<a class="external-link" href="https://youtu.be/IOcvkkklWmY">YouTube (on any device)</a>
+<a class="external-link" href="https://some.external.site/foo/bar/">some.external.site</a>
 `
 
 exports[`test/snapshot/linkExternal.js > TAP > linkExternal (snapshot) > context: flash, style: platform 1`] = `
-<a href="https://www.bgreco.net/hsflash/002238.html" class="nowrap">bgreco.net (high quality audio)</a>
-<a href="https://homestuck.com/story/1234" class="nowrap">Homestuck (page 1234)</a>
-<a href="https://homestuck.com/story/pony" class="nowrap">Homestuck (secret page)</a>
-<a href="https://www.youtube.com/watch?v=wKgOp3Kg2wI" class="nowrap">YouTube (on any device)</a>
-<a href="https://youtu.be/IOcvkkklWmY" class="nowrap">YouTube (on any device)</a>
-<a href="https://some.external.site/foo/bar/" class="nowrap">some.external.site</a>
+<a class="external-link" href="https://www.bgreco.net/hsflash/002238.html">bgreco.net (high quality audio)</a>
+<a class="external-link" href="https://homestuck.com/story/1234">Homestuck (page 1234)</a>
+<a class="external-link" href="https://homestuck.com/story/pony">Homestuck (secret page)</a>
+<a class="external-link" href="https://www.youtube.com/watch?v=wKgOp3Kg2wI">YouTube (on any device)</a>
+<a class="external-link" href="https://youtu.be/IOcvkkklWmY">YouTube (on any device)</a>
+<a class="external-link" href="https://some.external.site/foo/bar/">some.external.site</a>
 `
 
 exports[`test/snapshot/linkExternal.js > TAP > linkExternal (snapshot) > context: generic, style: handle 1`] = `
-<a href="https://music.apple.com/us/artist/system-of-a-down/462715" class="nowrap">Apple Music</a>
-<a href="https://www.artstation.com/eevaningtea" class="nowrap">eevaningtea</a>
-<a href="https://witnesstheabsurd.artstation.com/" class="nowrap">witnesstheabsurd</a>
-<a href="https://music.solatrus.com/" class="nowrap">music.solatrus.com</a>
-<a href="https://homestuck.bandcamp.com/" class="nowrap">homestuck</a>
-<a href="https://bsky.app/profile/jacobtheloofah.bsky.social" class="nowrap">jacobtheloofah</a>
-<a href="https://aliceflare.carrd.co" class="nowrap">aliceflare</a>
-<a href="https://bigchaslappa.carrd.co/" class="nowrap">bigchaslappa</a>
-<a href="https://cohost.org/cosmoptera" class="nowrap">cosmoptera</a>
-<a href="https://music.deconreconstruction.com/albums/catch-322" class="nowrap">MUSIC@DCRC</a>
-<a href="https://music.deconreconstruction.com/albums/catch-322?track=arcjecs-theme" class="nowrap">MUSIC@DCRC</a>
-<a href="https://www.deconreconstruction.com/" class="nowrap">Deconreconstruction</a>
-<a href="https://culdhira.deviantart.com" class="nowrap">culdhira</a>
-<a href="https://www.deviantart.com/chesswanderlust-sama" class="nowrap">chesswanderlust-sama</a>
-<a href="https://www.deviantart.com/shilloshilloh/art/Homestuck-Jake-English-268874606" class="nowrap">DeviantArt</a>
-<a href="https://www.facebook.com/DoomedCloud/" class="nowrap">DoomedCloud</a>
-<a href="https://www.facebook.com/pages/WoodenToaster/280642235307371" class="nowrap">WoodenToaster</a>
-<a href="https://www.facebook.com/Svixy/posts/400018786702633" class="nowrap">Facebook</a>
-<a href="https://mspaintadventures.fandom.com/wiki/Draconian_Dignitary" class="nowrap">MSPA Wiki (Draconian Dignitary)</a>
-<a href="https://mspaintadventures.fandom.com/wiki/" class="nowrap">MSPA Wiki</a>
-<a href="https://mspaintadventures.fandom.com/" class="nowrap">MSPA Wiki</a>
-<a href="https://community.fandom.com/" class="nowrap">Fandom</a>
-<a href="https://community.fandom.com/wiki/" class="nowrap">Fandom</a>
-<a href="https://community.fandom.com/wiki/Community_Central" class="nowrap">Fandom</a>
-<a href="https://gamebanana.com/members/2028092" class="nowrap">GameBanana</a>
-<a href="https://gamebanana.com/mods/459476" class="nowrap">GameBanana</a>
-<a href="https://homestuck.com/" class="nowrap">Homestuck</a>
-<a href="https://hsmusic.wiki/media/misc/archive/Firefly%20Cloud%20Remix.mp3" class="nowrap">HSMusic (wiki archive)</a>
-<a href="https://hsmusic.wiki/feedback/" class="nowrap">HSMusic</a>
-<a href="https://archive.org/details/a-life-well-lived" class="nowrap">Internet Archive</a>
-<a href="https://archive.org/details/VastError_Volume1/11+Renaissance.mp3" class="nowrap">Internet Archive</a>
-<a href="https://instagram.com/bass.and.noises" class="nowrap">bass.and.noises</a>
-<a href="https://www.instagram.com/levc_egm/" class="nowrap">levc_egm</a>
-<a href="https://tuyoki.itch.io/" class="nowrap">tuyoki</a>
-<a href="https://itch.io/profile/bravelittletoreador" class="nowrap">bravelittletoreador</a>
-<a href="https://ko-fi.com/gnaach" class="nowrap">gnaach</a>
-<a href="https://linktr.ee/bbpanzu" class="nowrap">bbpanzu</a>
-<a href="https://types.pl/" class="nowrap">types.pl</a>
-<a href="https://canwc.mspfa.com/" class="nowrap">MSPFA</a>
-<a href="https://mspfa.com/?s=12003&p=1045" class="nowrap">MSPFA</a>
-<a href="https://mspfa.com/user/?u=103334508819793669241" class="nowrap">MSPFA</a>
-<a href="https://wodaro.neocities.org" class="nowrap">wodaro.neocities.org</a>
-<a href="https://neomints.neocities.org/" class="nowrap">neomints.neocities.org</a>
-<a href="https://buzinkai.newgrounds.com/" class="nowrap">buzinkai</a>
-<a href="https://www.newgrounds.com/audio/listen/1256058" class="nowrap">Newgrounds</a>
-<a href="https://www.patreon.com/CecilyRenns" class="nowrap">CecilyRenns</a>
-<a href="https://www.poetryfoundation.org/poets/christina-rossetti" class="nowrap">Poetry Foundation</a>
-<a href="https://www.poetryfoundation.org/poems/45000/remember-56d224509b7ae" class="nowrap">Poetry Foundation</a>
-<a href="https://soundcloud.com/plazmataz" class="nowrap">plazmataz</a>
-<a href="https://soundcloud.com/worthikids/1-i-accidentally-broke-my" class="nowrap">SoundCloud</a>
-<a href="https://open.spotify.com/artist/63SNNpNOicDzG3LY82G4q3" class="nowrap">Spotify</a>
-<a href="https://open.spotify.com/album/0iHvPD8rM3hQa0qeVtPQ3t" class="nowrap">Spotify</a>
-<a href="https://open.spotify.com/track/6YEGQH32aAXb9vQQbBrPlw" class="nowrap">Spotify</a>
-<a href="https://www.tiktok.com/@richaadeb" class="nowrap">richaadeb</a>
-<a href="https://toyhou.se/ghastaboo" class="nowrap">ghastaboo</a>
-<a href="https://aeritus.tumblr.com/" class="nowrap">aeritus</a>
-<a href="https://vol5anthology.tumblr.com/post/159528808107/hey-everyone-its-413-and-that-means-we-have" class="nowrap">vol5anthology</a>
-<a href="https://www.tumblr.com/electricwestern" class="nowrap">electricwestern</a>
-<a href="https://www.tumblr.com/spellmynamewithabang/142767566733/happy-413-this-is-the-first-time-anyones-heard" class="nowrap">Tumblr</a>
-<a href="https://www.twitch.tv/ajhebard" class="nowrap">ajhebard</a>
-<a href="https://www.twitch.tv/vargskelethor/" class="nowrap">vargskelethor/</a>
-<a href="https://twitter.com/awkwarddoesart" class="nowrap">awkwarddoesart</a>
-<a href="https://twitter.com/purenonsens/" class="nowrap">purenonsens</a>
-<a href="https://twitter.com/circlejourney/status/1202265927183548416" class="nowrap">Twitter</a>
-<a href="https://web.archive.org/web/20120405160556/https://homestuck.bandcamp.com/album/colours-and-mayhem-universe-a" class="nowrap">Wayback Machine</a>
-<a href="https://web.archive.org/web/20160807111207/http://griffinspacejam.com:80/" class="nowrap">Wayback Machine</a>
-<a href="https://en.wikipedia.org/wiki/Haydn_Quartet_(vocal_ensemble)" class="nowrap">Wikipedia</a>
-<a href="https://youtube.com/@bani-chan8949" class="nowrap">bani-chan8949</a>
-<a href="https://www.youtube.com/@Razzie16" class="nowrap">Razzie16</a>
-<a href="https://www.youtube.com/channel/UCQXfvlKkpbOqEz4BepHqK7g" class="nowrap">YouTube</a>
-<a href="https://www.youtube.com/watch?v=6ekVnZm29kw" class="nowrap">YouTube</a>
-<a href="https://youtu.be/WBkC038wSio" class="nowrap">YouTube</a>
-<a href="https://www.youtube.com/playlist?list=PLy5UGIMKOXpONMExgI7lVYFwQa54QFp_H" class="nowrap">YouTube</a>
+<a class="external-link" href="https://music.apple.com/us/artist/system-of-a-down/462715">Apple Music</a>
+<a class="external-link" href="https://www.artstation.com/eevaningtea">eevaningtea</a>
+<a class="external-link" href="https://witnesstheabsurd.artstation.com/">witnesstheabsurd</a>
+<a class="external-link" href="https://music.solatrus.com/">music.solatrus.com</a>
+<a class="external-link" href="https://homestuck.bandcamp.com/">homestuck</a>
+<a class="external-link" href="https://bsky.app/profile/jacobtheloofah.bsky.social">jacobtheloofah</a>
+<a class="external-link" href="https://aliceflare.carrd.co">aliceflare</a>
+<a class="external-link" href="https://bigchaslappa.carrd.co/">bigchaslappa</a>
+<a class="external-link" href="https://cohost.org/cosmoptera">cosmoptera</a>
+<a class="external-link" href="https://music.deconreconstruction.com/albums/catch-322">MUSIC@DCRC</a>
+<a class="external-link" href="https://music.deconreconstruction.com/albums/catch-322?track=arcjecs-theme">MUSIC@DCRC</a>
+<a class="external-link" href="https://www.deconreconstruction.com/">Deconreconstruction</a>
+<a class="external-link" href="https://culdhira.deviantart.com">culdhira</a>
+<a class="external-link" href="https://www.deviantart.com/chesswanderlust-sama">chesswanderlust-sama</a>
+<a class="external-link" href="https://www.deviantart.com/shilloshilloh/art/Homestuck-Jake-English-268874606">DeviantArt</a>
+<a class="external-link" href="https://www.facebook.com/DoomedCloud/">DoomedCloud</a>
+<a class="external-link" href="https://www.facebook.com/pages/WoodenToaster/280642235307371">WoodenToaster</a>
+<a class="external-link" href="https://www.facebook.com/Svixy/posts/400018786702633">Facebook</a>
+<a class="external-link" href="https://mspaintadventures.fandom.com/wiki/Draconian_Dignitary">MSPA Wiki (Draconian Dignitary)</a>
+<a class="external-link" href="https://mspaintadventures.fandom.com/wiki/">MSPA Wiki</a>
+<a class="external-link" href="https://mspaintadventures.fandom.com/">MSPA Wiki</a>
+<a class="external-link" href="https://community.fandom.com/">Fandom</a>
+<a class="external-link" href="https://community.fandom.com/wiki/">Fandom</a>
+<a class="external-link" href="https://community.fandom.com/wiki/Community_Central">Fandom</a>
+<a class="external-link" href="https://gamebanana.com/members/2028092">GameBanana</a>
+<a class="external-link" href="https://gamebanana.com/mods/459476">GameBanana</a>
+<a class="external-link" href="https://homestuck.com/">Homestuck</a>
+<a class="external-link" href="https://hsmusic.wiki/media/misc/archive/Firefly%20Cloud%20Remix.mp3">HSMusic (wiki archive)</a>
+<a class="external-link" href="https://hsmusic.wiki/feedback/">HSMusic</a>
+<a class="external-link" href="https://archive.org/details/a-life-well-lived">Internet Archive</a>
+<a class="external-link" href="https://archive.org/details/VastError_Volume1/11+Renaissance.mp3">Internet Archive</a>
+<a class="external-link" href="https://instagram.com/bass.and.noises">bass.and.noises</a>
+<a class="external-link" href="https://www.instagram.com/levc_egm/">levc_egm</a>
+<a class="external-link" href="https://tuyoki.itch.io/">tuyoki</a>
+<a class="external-link" href="https://itch.io/profile/bravelittletoreador">bravelittletoreador</a>
+<a class="external-link" href="https://ko-fi.com/gnaach">gnaach</a>
+<a class="external-link" href="https://linktr.ee/bbpanzu">bbpanzu</a>
+<a class="external-link" href="https://types.pl/">types.pl</a>
+<a class="external-link" href="https://canwc.mspfa.com/">MSPFA</a>
+<a class="external-link" href="https://mspfa.com/?s=12003&p=1045">MSPFA</a>
+<a class="external-link" href="https://mspfa.com/user/?u=103334508819793669241">MSPFA</a>
+<a class="external-link" href="https://wodaro.neocities.org">wodaro.neocities.org</a>
+<a class="external-link" href="https://neomints.neocities.org/">neomints.neocities.org</a>
+<a class="external-link" href="https://buzinkai.newgrounds.com/">buzinkai</a>
+<a class="external-link" href="https://www.newgrounds.com/audio/listen/1256058">Newgrounds</a>
+<a class="external-link" href="https://www.patreon.com/CecilyRenns">CecilyRenns</a>
+<a class="external-link" href="https://www.poetryfoundation.org/poets/christina-rossetti">Poetry Foundation</a>
+<a class="external-link" href="https://www.poetryfoundation.org/poems/45000/remember-56d224509b7ae">Poetry Foundation</a>
+<a class="external-link" href="https://soundcloud.com/plazmataz">plazmataz</a>
+<a class="external-link" href="https://soundcloud.com/worthikids/1-i-accidentally-broke-my">SoundCloud</a>
+<a class="external-link" href="https://open.spotify.com/artist/63SNNpNOicDzG3LY82G4q3">Spotify</a>
+<a class="external-link" href="https://open.spotify.com/album/0iHvPD8rM3hQa0qeVtPQ3t">Spotify</a>
+<a class="external-link" href="https://open.spotify.com/track/6YEGQH32aAXb9vQQbBrPlw">Spotify</a>
+<a class="external-link" href="https://www.tiktok.com/@richaadeb">richaadeb</a>
+<a class="external-link" href="https://toyhou.se/ghastaboo">ghastaboo</a>
+<a class="external-link" href="https://aeritus.tumblr.com/">aeritus</a>
+<a class="external-link" href="https://vol5anthology.tumblr.com/post/159528808107/hey-everyone-its-413-and-that-means-we-have">vol5anthology</a>
+<a class="external-link" href="https://www.tumblr.com/electricwestern">electricwestern</a>
+<a class="external-link" href="https://www.tumblr.com/spellmynamewithabang/142767566733/happy-413-this-is-the-first-time-anyones-heard">Tumblr</a>
+<a class="external-link" href="https://www.twitch.tv/ajhebard">ajhebard</a>
+<a class="external-link" href="https://www.twitch.tv/vargskelethor/">vargskelethor/</a>
+<a class="external-link" href="https://twitter.com/awkwarddoesart">awkwarddoesart</a>
+<a class="external-link" href="https://twitter.com/purenonsens/">purenonsens</a>
+<a class="external-link" href="https://twitter.com/circlejourney/status/1202265927183548416">Twitter</a>
+<a class="external-link" href="https://web.archive.org/web/20120405160556/https://homestuck.bandcamp.com/album/colours-and-mayhem-universe-a">Wayback Machine</a>
+<a class="external-link" href="https://web.archive.org/web/20160807111207/http://griffinspacejam.com:80/">Wayback Machine</a>
+<a class="external-link" href="https://en.wikipedia.org/wiki/Haydn_Quartet_(vocal_ensemble)">Wikipedia</a>
+<a class="external-link" href="https://youtube.com/@bani-chan8949">bani-chan8949</a>
+<a class="external-link" href="https://www.youtube.com/@Razzie16">Razzie16</a>
+<a class="external-link" href="https://www.youtube.com/channel/UCQXfvlKkpbOqEz4BepHqK7g">YouTube</a>
+<a class="external-link" href="https://www.youtube.com/watch?v=6ekVnZm29kw">YouTube</a>
+<a class="external-link" href="https://youtu.be/WBkC038wSio">YouTube</a>
+<a class="external-link" href="https://www.youtube.com/playlist?list=PLy5UGIMKOXpONMExgI7lVYFwQa54QFp_H">YouTube</a>
 `
 
 exports[`test/snapshot/linkExternal.js > TAP > linkExternal (snapshot) > context: generic, style: platform 1`] = `
-<a href="https://music.apple.com/us/artist/system-of-a-down/462715" class="nowrap">Apple Music</a>
-<a href="https://www.artstation.com/eevaningtea" class="nowrap">ArtStation</a>
-<a href="https://witnesstheabsurd.artstation.com/" class="nowrap">ArtStation</a>
-<a href="https://music.solatrus.com/" class="nowrap">Bandcamp (music.solatrus.com)</a>
-<a href="https://homestuck.bandcamp.com/" class="nowrap">Bandcamp</a>
-<a href="https://bsky.app/profile/jacobtheloofah.bsky.social" class="nowrap">Bluesky</a>
-<a href="https://aliceflare.carrd.co" class="nowrap">Carrd</a>
-<a href="https://bigchaslappa.carrd.co/" class="nowrap">Carrd</a>
-<a href="https://cohost.org/cosmoptera" class="nowrap">Cohost</a>
-<a href="https://music.deconreconstruction.com/albums/catch-322" class="nowrap">MUSIC@DCRC</a>
-<a href="https://music.deconreconstruction.com/albums/catch-322?track=arcjecs-theme" class="nowrap">MUSIC@DCRC</a>
-<a href="https://www.deconreconstruction.com/" class="nowrap">Deconreconstruction</a>
-<a href="https://culdhira.deviantart.com" class="nowrap">DeviantArt</a>
-<a href="https://www.deviantart.com/chesswanderlust-sama" class="nowrap">DeviantArt</a>
-<a href="https://www.deviantart.com/shilloshilloh/art/Homestuck-Jake-English-268874606" class="nowrap">DeviantArt</a>
-<a href="https://www.facebook.com/DoomedCloud/" class="nowrap">Facebook</a>
-<a href="https://www.facebook.com/pages/WoodenToaster/280642235307371" class="nowrap">Facebook</a>
-<a href="https://www.facebook.com/Svixy/posts/400018786702633" class="nowrap">Facebook</a>
-<a href="https://mspaintadventures.fandom.com/wiki/Draconian_Dignitary" class="nowrap">MSPA Wiki (Draconian Dignitary)</a>
-<a href="https://mspaintadventures.fandom.com/wiki/" class="nowrap">MSPA Wiki</a>
-<a href="https://mspaintadventures.fandom.com/" class="nowrap">MSPA Wiki</a>
-<a href="https://community.fandom.com/" class="nowrap">Fandom</a>
-<a href="https://community.fandom.com/wiki/" class="nowrap">Fandom</a>
-<a href="https://community.fandom.com/wiki/Community_Central" class="nowrap">Fandom</a>
-<a href="https://gamebanana.com/members/2028092" class="nowrap">GameBanana</a>
-<a href="https://gamebanana.com/mods/459476" class="nowrap">GameBanana</a>
-<a href="https://homestuck.com/" class="nowrap">Homestuck</a>
-<a href="https://hsmusic.wiki/media/misc/archive/Firefly%20Cloud%20Remix.mp3" class="nowrap">HSMusic (wiki archive)</a>
-<a href="https://hsmusic.wiki/feedback/" class="nowrap">HSMusic</a>
-<a href="https://archive.org/details/a-life-well-lived" class="nowrap">Internet Archive</a>
-<a href="https://archive.org/details/VastError_Volume1/11+Renaissance.mp3" class="nowrap">Internet Archive</a>
-<a href="https://instagram.com/bass.and.noises" class="nowrap">Instagram</a>
-<a href="https://www.instagram.com/levc_egm/" class="nowrap">Instagram</a>
-<a href="https://tuyoki.itch.io/" class="nowrap">itch.io</a>
-<a href="https://itch.io/profile/bravelittletoreador" class="nowrap">itch.io</a>
-<a href="https://ko-fi.com/gnaach" class="nowrap">Ko-fi</a>
-<a href="https://linktr.ee/bbpanzu" class="nowrap">Linktree</a>
-<a href="https://types.pl/" class="nowrap">Mastodon (types.pl)</a>
-<a href="https://canwc.mspfa.com/" class="nowrap">MSPFA</a>
-<a href="https://mspfa.com/?s=12003&p=1045" class="nowrap">MSPFA</a>
-<a href="https://mspfa.com/user/?u=103334508819793669241" class="nowrap">MSPFA</a>
-<a href="https://wodaro.neocities.org" class="nowrap">Neocities</a>
-<a href="https://neomints.neocities.org/" class="nowrap">Neocities</a>
-<a href="https://buzinkai.newgrounds.com/" class="nowrap">Newgrounds</a>
-<a href="https://www.newgrounds.com/audio/listen/1256058" class="nowrap">Newgrounds</a>
-<a href="https://www.patreon.com/CecilyRenns" class="nowrap">Patreon</a>
-<a href="https://www.poetryfoundation.org/poets/christina-rossetti" class="nowrap">Poetry Foundation</a>
-<a href="https://www.poetryfoundation.org/poems/45000/remember-56d224509b7ae" class="nowrap">Poetry Foundation</a>
-<a href="https://soundcloud.com/plazmataz" class="nowrap">SoundCloud</a>
-<a href="https://soundcloud.com/worthikids/1-i-accidentally-broke-my" class="nowrap">SoundCloud</a>
-<a href="https://open.spotify.com/artist/63SNNpNOicDzG3LY82G4q3" class="nowrap">Spotify</a>
-<a href="https://open.spotify.com/album/0iHvPD8rM3hQa0qeVtPQ3t" class="nowrap">Spotify</a>
-<a href="https://open.spotify.com/track/6YEGQH32aAXb9vQQbBrPlw" class="nowrap">Spotify</a>
-<a href="https://www.tiktok.com/@richaadeb" class="nowrap">TikTok</a>
-<a href="https://toyhou.se/ghastaboo" class="nowrap">Toyhouse</a>
-<a href="https://aeritus.tumblr.com/" class="nowrap">Tumblr</a>
-<a href="https://vol5anthology.tumblr.com/post/159528808107/hey-everyone-its-413-and-that-means-we-have" class="nowrap">Tumblr</a>
-<a href="https://www.tumblr.com/electricwestern" class="nowrap">Tumblr</a>
-<a href="https://www.tumblr.com/spellmynamewithabang/142767566733/happy-413-this-is-the-first-time-anyones-heard" class="nowrap">Tumblr</a>
-<a href="https://www.twitch.tv/ajhebard" class="nowrap">Twitch</a>
-<a href="https://www.twitch.tv/vargskelethor/" class="nowrap">Twitch</a>
-<a href="https://twitter.com/awkwarddoesart" class="nowrap">Twitter</a>
-<a href="https://twitter.com/purenonsens/" class="nowrap">Twitter</a>
-<a href="https://twitter.com/circlejourney/status/1202265927183548416" class="nowrap">Twitter</a>
-<a href="https://web.archive.org/web/20120405160556/https://homestuck.bandcamp.com/album/colours-and-mayhem-universe-a" class="nowrap">Wayback Machine</a>
-<a href="https://web.archive.org/web/20160807111207/http://griffinspacejam.com:80/" class="nowrap">Wayback Machine</a>
-<a href="https://en.wikipedia.org/wiki/Haydn_Quartet_(vocal_ensemble)" class="nowrap">Wikipedia</a>
-<a href="https://youtube.com/@bani-chan8949" class="nowrap">YouTube</a>
-<a href="https://www.youtube.com/@Razzie16" class="nowrap">YouTube</a>
-<a href="https://www.youtube.com/channel/UCQXfvlKkpbOqEz4BepHqK7g" class="nowrap">YouTube</a>
-<a href="https://www.youtube.com/watch?v=6ekVnZm29kw" class="nowrap">YouTube</a>
-<a href="https://youtu.be/WBkC038wSio" class="nowrap">YouTube</a>
-<a href="https://www.youtube.com/playlist?list=PLy5UGIMKOXpONMExgI7lVYFwQa54QFp_H" class="nowrap">YouTube</a>
+<a class="external-link" href="https://music.apple.com/us/artist/system-of-a-down/462715">Apple Music</a>
+<a class="external-link" href="https://www.artstation.com/eevaningtea">ArtStation</a>
+<a class="external-link" href="https://witnesstheabsurd.artstation.com/">ArtStation</a>
+<a class="external-link" href="https://music.solatrus.com/">Bandcamp (music.solatrus.com)</a>
+<a class="external-link" href="https://homestuck.bandcamp.com/">Bandcamp</a>
+<a class="external-link" href="https://bsky.app/profile/jacobtheloofah.bsky.social">Bluesky</a>
+<a class="external-link" href="https://aliceflare.carrd.co">Carrd</a>
+<a class="external-link" href="https://bigchaslappa.carrd.co/">Carrd</a>
+<a class="external-link" href="https://cohost.org/cosmoptera">Cohost</a>
+<a class="external-link" href="https://music.deconreconstruction.com/albums/catch-322">MUSIC@DCRC</a>
+<a class="external-link" href="https://music.deconreconstruction.com/albums/catch-322?track=arcjecs-theme">MUSIC@DCRC</a>
+<a class="external-link" href="https://www.deconreconstruction.com/">Deconreconstruction</a>
+<a class="external-link" href="https://culdhira.deviantart.com">DeviantArt</a>
+<a class="external-link" href="https://www.deviantart.com/chesswanderlust-sama">DeviantArt</a>
+<a class="external-link" href="https://www.deviantart.com/shilloshilloh/art/Homestuck-Jake-English-268874606">DeviantArt</a>
+<a class="external-link" href="https://www.facebook.com/DoomedCloud/">Facebook</a>
+<a class="external-link" href="https://www.facebook.com/pages/WoodenToaster/280642235307371">Facebook</a>
+<a class="external-link" href="https://www.facebook.com/Svixy/posts/400018786702633">Facebook</a>
+<a class="external-link" href="https://mspaintadventures.fandom.com/wiki/Draconian_Dignitary">MSPA Wiki (Draconian Dignitary)</a>
+<a class="external-link" href="https://mspaintadventures.fandom.com/wiki/">MSPA Wiki</a>
+<a class="external-link" href="https://mspaintadventures.fandom.com/">MSPA Wiki</a>
+<a class="external-link" href="https://community.fandom.com/">Fandom</a>
+<a class="external-link" href="https://community.fandom.com/wiki/">Fandom</a>
+<a class="external-link" href="https://community.fandom.com/wiki/Community_Central">Fandom</a>
+<a class="external-link" href="https://gamebanana.com/members/2028092">GameBanana</a>
+<a class="external-link" href="https://gamebanana.com/mods/459476">GameBanana</a>
+<a class="external-link" href="https://homestuck.com/">Homestuck</a>
+<a class="external-link" href="https://hsmusic.wiki/media/misc/archive/Firefly%20Cloud%20Remix.mp3">HSMusic (wiki archive)</a>
+<a class="external-link" href="https://hsmusic.wiki/feedback/">HSMusic</a>
+<a class="external-link" href="https://archive.org/details/a-life-well-lived">Internet Archive</a>
+<a class="external-link" href="https://archive.org/details/VastError_Volume1/11+Renaissance.mp3">Internet Archive</a>
+<a class="external-link" href="https://instagram.com/bass.and.noises">Instagram</a>
+<a class="external-link" href="https://www.instagram.com/levc_egm/">Instagram</a>
+<a class="external-link" href="https://tuyoki.itch.io/">itch.io</a>
+<a class="external-link" href="https://itch.io/profile/bravelittletoreador">itch.io</a>
+<a class="external-link" href="https://ko-fi.com/gnaach">Ko-fi</a>
+<a class="external-link" href="https://linktr.ee/bbpanzu">Linktree</a>
+<a class="external-link" href="https://types.pl/">Mastodon (types.pl)</a>
+<a class="external-link" href="https://canwc.mspfa.com/">MSPFA</a>
+<a class="external-link" href="https://mspfa.com/?s=12003&p=1045">MSPFA</a>
+<a class="external-link" href="https://mspfa.com/user/?u=103334508819793669241">MSPFA</a>
+<a class="external-link" href="https://wodaro.neocities.org">Neocities</a>
+<a class="external-link" href="https://neomints.neocities.org/">Neocities</a>
+<a class="external-link" href="https://buzinkai.newgrounds.com/">Newgrounds</a>
+<a class="external-link" href="https://www.newgrounds.com/audio/listen/1256058">Newgrounds</a>
+<a class="external-link" href="https://www.patreon.com/CecilyRenns">Patreon</a>
+<a class="external-link" href="https://www.poetryfoundation.org/poets/christina-rossetti">Poetry Foundation</a>
+<a class="external-link" href="https://www.poetryfoundation.org/poems/45000/remember-56d224509b7ae">Poetry Foundation</a>
+<a class="external-link" href="https://soundcloud.com/plazmataz">SoundCloud</a>
+<a class="external-link" href="https://soundcloud.com/worthikids/1-i-accidentally-broke-my">SoundCloud</a>
+<a class="external-link" href="https://open.spotify.com/artist/63SNNpNOicDzG3LY82G4q3">Spotify</a>
+<a class="external-link" href="https://open.spotify.com/album/0iHvPD8rM3hQa0qeVtPQ3t">Spotify</a>
+<a class="external-link" href="https://open.spotify.com/track/6YEGQH32aAXb9vQQbBrPlw">Spotify</a>
+<a class="external-link" href="https://www.tiktok.com/@richaadeb">TikTok</a>
+<a class="external-link" href="https://toyhou.se/ghastaboo">Toyhouse</a>
+<a class="external-link" href="https://aeritus.tumblr.com/">Tumblr</a>
+<a class="external-link" href="https://vol5anthology.tumblr.com/post/159528808107/hey-everyone-its-413-and-that-means-we-have">Tumblr</a>
+<a class="external-link" href="https://www.tumblr.com/electricwestern">Tumblr</a>
+<a class="external-link" href="https://www.tumblr.com/spellmynamewithabang/142767566733/happy-413-this-is-the-first-time-anyones-heard">Tumblr</a>
+<a class="external-link" href="https://www.twitch.tv/ajhebard">Twitch</a>
+<a class="external-link" href="https://www.twitch.tv/vargskelethor/">Twitch</a>
+<a class="external-link" href="https://twitter.com/awkwarddoesart">Twitter</a>
+<a class="external-link" href="https://twitter.com/purenonsens/">Twitter</a>
+<a class="external-link" href="https://twitter.com/circlejourney/status/1202265927183548416">Twitter</a>
+<a class="external-link" href="https://web.archive.org/web/20120405160556/https://homestuck.bandcamp.com/album/colours-and-mayhem-universe-a">Wayback Machine</a>
+<a class="external-link" href="https://web.archive.org/web/20160807111207/http://griffinspacejam.com:80/">Wayback Machine</a>
+<a class="external-link" href="https://en.wikipedia.org/wiki/Haydn_Quartet_(vocal_ensemble)">Wikipedia</a>
+<a class="external-link" href="https://youtube.com/@bani-chan8949">YouTube</a>
+<a class="external-link" href="https://www.youtube.com/@Razzie16">YouTube</a>
+<a class="external-link" href="https://www.youtube.com/channel/UCQXfvlKkpbOqEz4BepHqK7g">YouTube</a>
+<a class="external-link" href="https://www.youtube.com/watch?v=6ekVnZm29kw">YouTube</a>
+<a class="external-link" href="https://youtu.be/WBkC038wSio">YouTube</a>
+<a class="external-link" href="https://www.youtube.com/playlist?list=PLy5UGIMKOXpONMExgI7lVYFwQa54QFp_H">YouTube</a>
 `
 
 exports[`test/snapshot/linkExternal.js > TAP > linkExternal (snapshot) > unknown domain (arbitrary world wide web path) 1`] = `
-<a href="https://snoo.ping.as/usual/i/see/" class="nowrap">snoo.ping.as</a>
+<a class="external-link" href="https://snoo.ping.as/usual/i/see/">snoo.ping.as</a>
 `


### PR DESCRIPTION
This PR redesigns the visual appearance of *in-content* external links:

<img width="659" alt="Screenshot of commentary from Even in Death (T'Morra's Belly Mix). The commentary is cited to a Tumblr post, and the Tumblr link, underlined because it's being hovered, has a white arrow pointing up and to the right, and tooltip text: Tumblr (opens in new tab). Links in the commentary also have up-right arrows, and these show that there are in fact three external links in a row. External links are generally easy to pick out of a crowd of other text and internal links, some of which are not specially colored." src="https://github.com/hsmusic/hsmusic-wiki/assets/9948030/16c4fadc-dbce-467c-b9a8-0a00d92691f3">

External links now open in a new tab by default, and have tooltip text which always indicates the platform that the link leads to. (Thanks to recent changes in #445, platforms which aren't specially recognized by `#external-links` show the domain, and not just the word "External".)

This PR doesn't change the appearance or behavior of links outside of content (i.e. commentary, static pages, etc). This means listening links and artist tooltip links still open the page in the same tab, for example.

This PR makes it **mandatory** to write links in content using the Markdown format, because they're parsed and processed (via `#replacer`) with regular expression matching. (We use, by reference, the regex Marked provides.) This is automatically reported.via `isContentString` by a new entry in `illegalContentSpec`.

In exceptional cases where we *don't* want to parse and process an external link node, `<html:a>` syntax may be used instead. These should only be technical concessions, e.g. because the content of the link needs to be a tag and we don't support processing a tag *inside* an external link (or recursively at all), for example.

The commits and design in this PR are mostly a bit older, circa the beginning of March. The implementation in `linkExternal.js` is refactored compared to the original code's appearance, but all the behavior is essentially the same. The rest of the changes are all the same as before.