### PR TITLE
Fixes for sorting-by-duration in artist group contributions info

### DIFF
--- a/src/content/dependencies/generateArtistGroupContributionsInfo.js
+++ b/src/content/dependencies/generateArtistGroupContributionsInfo.js
@@ -189,16 +189,16 @@ export default {
                     data.groupDurationsSortedByCount,
                     data.groupDurationsApproximateSortedByCount),
               }).map(({group, count, duration}) =>
-                html.tag('li',
-                  html.tag('div', {class: 'group-contributions-row'}, [
-                    group,
-                    html.tag('span', {class: 'group-contributions-metrics'},
-                      // When sorting by count, duration details aren't necessarily
-                      // available for all items.
-                      (slots.showBothColumns && duration
-                        ? language.$('artistPage.groupContributions.item.countDurationAccent', {count, duration})
-                        : language.$('artistPage.groupContributions.item.countAccent', {count}))),
-                  ])))
+                  html.tag('li',
+                    html.tag('div', {class: 'group-contributions-row'}, [
+                      group,
+                      html.tag('span', {class: 'group-contributions-metrics'},
+                        // When sorting by count, duration details aren't necessarily
+                        // available for all items.
+                        (slots.showBothColumns && duration
+                          ? language.$('artistPage.groupContributions.item.countDurationAccent', {count, duration})
+                          : language.$('artistPage.groupContributions.item.countAccent', {count}))),
+                    ])))
 
             : stitchArrays({
                 group: relations.groupLinksSortedByDuration,
@@ -208,17 +208,17 @@ export default {
                     data.groupDurationsSortedByDuration,
                     data.groupDurationsApproximateSortedByCount),
               }).map(({group, count, duration}) =>
-                html.tag('li',
-                  html.tag('div', {class: 'group-contributions-row'}, [
-                    group,
-                    html.tag('span', {class: 'group-contributions-metrics'},
-                      // Count details are always available, since they're just the
-                      // number of contributions directly. And duration details are
-                      // guaranteed for every item when sorting by duration.
-                      (slots.showBothColumns
-                        ? language.$('artistPage.groupContributions.item.durationCountAccent', {duration, count})
-                        : language.$('artistPage.groupContributions.item.durationAccent', {duration}))),
-                  ])))))),
+                  html.tag('li',
+                    html.tag('div', {class: 'group-contributions-row'}, [
+                      group,
+                      html.tag('span', {class: 'group-contributions-metrics'},
+                        // Count details are always available, since they're just the
+                        // number of contributions directly. And duration details are
+                        // guaranteed for every item when sorting by duration.
+                        (slots.showBothColumns
+                          ? language.$('artistPage.groupContributions.item.durationCountAccent', {duration, count})
+                          : language.$('artistPage.groupContributions.item.durationAccent', {duration}))),
+                    ])))))),
     ]);
   },
 };

--- a/src/content/dependencies/generateArtistGroupContributionsInfo.js
+++ b/src/content/dependencies/generateArtistGroupContributionsInfo.js
@@ -206,7 +206,7 @@ export default {
                 duration:
                   getDurations(
                     data.groupDurationsSortedByDuration,
-                    data.groupDurationsApproximateSortedByCount),
+                    data.groupDurationsApproximateSortedByDuration),
               }).map(({group, count, duration}) =>
                   html.tag('li',
                     html.tag('div', {class: 'group-contributions-row'}, [

--- a/src/content/dependencies/generateArtistGroupContributionsInfo.js
+++ b/src/content/dependencies/generateArtistGroupContributionsInfo.js
@@ -45,6 +45,7 @@ export default {
 
     const groupsSortedByCount =
       allGroupsOrdered
+        .slice()
         .sort((a, b) => groupToCountMap.get(b) - groupToCountMap.get(a));
 
     // The filter here ensures all displayed groups have at least some duration


### PR DESCRIPTION
Bundles a couple of fixes:

* Fixes sort-by-count "leaking" into sort-by-duration (by-duration was falling back to by-count before by-category; both are supposed to fall back directly and only to by-category).
* Fixes mystery `NaN:NaN` entries that were showing up ([#issuefication-zone, Lan](https://discord.com/channels/749042497610842152/935007764042874931/1212597538243215390)) at the bottom when sorting by duration.
