### PR TITLE
Customizable flash sides!

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "#composite/wiki-properties": "./src/data/composite/wiki-properties/index.js",
         "#composite/things/album": "./src/data/composite/things/album/index.js",
         "#composite/things/flash": "./src/data/composite/things/flash/index.js",
+        "#composite/things/flash-act": "./src/data/composite/things/flash-act/index.js",
         "#composite/things/track": "./src/data/composite/things/track/index.js",
         "#content-dependencies": "./src/content/dependencies/index.js",
         "#content-function": "./src/content-function.js",

--- a/src/content/dependencies/generateFlashActSidebar.js
+++ b/src/content/dependencies/generateFlashActSidebar.js
@@ -1,5 +1,4 @@
-import find from '#find';
-import {filterMultipleArrays, stitchArrays} from '#sugar';
+import {stitchArrays} from '#sugar';
 
 export default {
   contentDependencies: ['linkFlash', 'linkFlashAct', 'linkFlashIndex'],
@@ -7,67 +6,20 @@ export default {
 
   // So help me Gog, the flash sidebar is heavily hard-coded.
 
-  sprawl: ({flashActData}) => ({flashActData}),
+  sprawl: ({flashActData, flashSideData}) => ({flashActData, flashSideData}),
 
   query(sprawl, act, flash) {
-    const findFlashAct = directory =>
-      find.flashAct(directory, sprawl.flashActData, {mode: 'quiet'});
+    const sideNames =
+      sprawl.flashSideData
+        .map(side => side.name);
 
-    const homestuckSide1 = findFlashAct('flash-act:a1');
-
-    const sideFirstActs = [
-      sprawl.flashActData[0],
-      findFlashAct('flash-act:a6a1'),
-      findFlashAct('flash-act:hiveswap'),
-      findFlashAct('flash-act:cool-and-new-web-comic'),
-      findFlashAct('flash-act:sunday-night-strifin'),
-    ];
-
-    const sideNames = [
-      (homestuckSide1
-        ? `Side 1 (Acts 1-5)`
-        : `All flashes & games`),
-      `Side 2 (Acts 6-7)`,
-      `Additional Canon`,
-      `Fan Adventures`,
-      `Fan Games & More`,
-    ];
-
-    const sideColors = [
-      (homestuckSide1
-        ? '#4ac925'
-        : null),
-      '#3796c6',
-      '#f2a400',
-      '#c466ff',
-      '#32c7fe',
-    ];
-
-    filterMultipleArrays(sideFirstActs, sideNames, sideColors,
-      firstAct => firstAct);
-
-    const sideFirstActIndexes =
-      sideFirstActs
-        .map(act => sprawl.flashActData.indexOf(act));
-
-    const actSideIndexes =
-      sprawl.flashActData
-        .map((act, actIndex) => actIndex)
-        .map(actIndex =>
-          sideFirstActIndexes
-            .findIndex((firstActIndex, i) =>
-              i === sideFirstActs.length - 1 ||
-                firstActIndex <= actIndex &&
-                sideFirstActIndexes[i + 1] > actIndex));
+    const sideColors =
+      sprawl.flashSideData
+        .map(side => side.color);
 
     const sideActs =
-      sideNames
-        .map((name, sideIndex) =>
-          stitchArrays({
-            act: sprawl.flashActData,
-            actSideIndex: actSideIndexes,
-          }).filter(({actSideIndex}) => actSideIndex === sideIndex)
-            .map(({act}) => act));
+      sprawl.flashSideData
+        .map(side => side.acts);
 
     const currentActFlashes =
       act.flashes;
@@ -76,7 +28,7 @@ export default {
       currentActFlashes.indexOf(flash);
 
     const currentSideIndex =
-      actSideIndexes[sprawl.flashActData.indexOf(act)];
+      sideActs.findIndex(acts => acts.includes(act));
 
     const currentSideActs =
       sideActs[currentSideIndex];

--- a/src/content/dependencies/generateFlashActSidebar.js
+++ b/src/content/dependencies/generateFlashActSidebar.js
@@ -4,8 +4,6 @@ export default {
   contentDependencies: ['linkFlash', 'linkFlashAct', 'linkFlashIndex'],
   extraDependencies: ['getColors', 'html', 'language', 'wikiData'],
 
-  // So help me Gog, the flash sidebar is heavily hard-coded.
-
   sprawl: ({flashActData, flashSideData}) => ({flashActData, flashSideData}),
 
   query(sprawl, act, flash) {
@@ -37,9 +35,7 @@ export default {
       currentSideActs.indexOf(act);
 
     const fallbackListTerminology =
-      (currentSideIndex <= 1
-        ? 'flashesInThisAct'
-        : 'entriesInThisSection');
+      'entriesInThisSection';
 
     return {
       sideNames,

--- a/src/content/dependencies/generateFlashIndexPage.js
+++ b/src/content/dependencies/generateFlashIndexPage.js
@@ -20,7 +20,7 @@ export default {
 
     const jumpActs =
       flashActs
-        .filter(act => act.jump);
+        .filter(act => act.side.acts.indexOf(act) === 0);
 
     return {flashActs, jumpActs};
   },
@@ -31,7 +31,7 @@ export default {
 
     jumpLinkColorStyles:
       query.jumpActs
-        .map(act => relation('generateColorStyleAttribute', act.jumpColor)),
+        .map(act => relation('generateColorStyleAttribute', act.side.color)),
 
     actColorStyles:
       query.flashActs
@@ -63,7 +63,7 @@ export default {
 
     jumpLinkLabels:
       query.jumpActs
-        .map(act => act.jump),
+        .map(act => act.side.name),
 
     actAnchors:
       query.flashActs

--- a/src/data/checks.js
+++ b/src/data/checks.js
@@ -488,6 +488,10 @@ export function reportContentTextErrors(wikiData, {
       listTerminology: '_content',
     }],
 
+    ['flashSideData', {
+      listTerminology: '_content',
+    }],
+
     ['groupData', {
       description: '_content',
     }],

--- a/src/data/checks.js
+++ b/src/data/checks.js
@@ -485,7 +485,6 @@ export function reportContentTextErrors(wikiData, {
     }],
 
     ['flashActData', {
-      jump: '_content',
       listTerminology: '_content',
     }],
 

--- a/src/data/composite/control-flow/exposeConstant.js
+++ b/src/data/composite/control-flow/exposeConstant.js
@@ -12,7 +12,7 @@ export default templateCompositeFrom({
   compose: false,
 
   inputs: {
-    value: input.staticValue(),
+    value: input.staticValue({acceptsNull: true}),
   },
 
   steps: () => [

--- a/src/data/composite/things/flash-act/index.js
+++ b/src/data/composite/things/flash-act/index.js
@@ -1,0 +1,1 @@
+export {default as withFlashSide} from './withFlashSide.js';

--- a/src/data/composite/things/flash-act/withFlashSide.js
+++ b/src/data/composite/things/flash-act/withFlashSide.js
@@ -1,0 +1,22 @@
+// Gets the flash act's side. This will early exit if flashSideData is missing.
+// If there's no side whose list of flash acts includes this act, the output
+// dependency will be null.
+
+import {input, templateCompositeFrom} from '#composite';
+
+import {withUniqueReferencingThing} from '#composite/wiki-data';
+
+export default templateCompositeFrom({
+  annotation: `withFlashSide`,
+
+  outputs: ['#flashSide'],
+
+  steps: () => [
+    withUniqueReferencingThing({
+      data: 'flashSideData',
+      list: input.value('acts'),
+    }).outputs({
+      ['#uniqueReferencingThing']: '#flashSide',
+    }),
+  ],
+});

--- a/src/data/composite/things/flash/withFlashAct.js
+++ b/src/data/composite/things/flash/withFlashAct.js
@@ -1,15 +1,10 @@
 // Gets the flash's act. This will early exit if flashActData is missing.
 // If there's no flash whose list of flashes includes this flash, the output
 // dependency will be null.
-//
-// This step models with Flash.withAlbum.
 
 import {input, templateCompositeFrom} from '#composite';
-import {is} from '#validators';
 
-import {exitWithoutDependency, raiseOutputWithoutDependency}
-  from '#composite/control-flow';
-import {withPropertyFromList} from '#composite/data';
+import {withUniqueReferencingThing} from '#composite/wiki-data';
 
 export default templateCompositeFrom({
   annotation: `withFlashAct`,
@@ -17,42 +12,11 @@ export default templateCompositeFrom({
   outputs: ['#flashAct'],
 
   steps: () => [
-    exitWithoutDependency({
-      dependency: 'flashActData',
-      mode: input.value('null'),
+    withUniqueReferencingThing({
+      data: 'flashActData',
+      list: input.value('flashes'),
+    }).outputs({
+      ['#uniqueReferencingThing']: '#flashAct',
     }),
-
-    withPropertyFromList({
-      list: 'flashActData',
-      property: input.value('flashes'),
-    }),
-
-    {
-      dependencies: [input.myself(), '#flashActData.flashes'],
-      compute: (continuation, {
-        [input.myself()]: track,
-        ['#flashActData.flashes']: flashLists,
-      }) => continuation({
-        ['#flashActIndex']:
-          flashLists.findIndex(flashes => flashes.includes(track)),
-      }),
-    },
-
-    raiseOutputWithoutDependency({
-      dependency: '#flashActIndex',
-      mode: input.value('index'),
-      output: input.value({'#album': null}),
-    }),
-
-    {
-      dependencies: ['flashActData', '#flashActIndex'],
-      compute: (continuation, {
-        ['flashActData']: flashActData,
-        ['#flashActIndex']: flashActIndex,
-      }) => continuation.raiseOutput({
-        ['#flashAct']:
-          flashActData[flashActIndex],
-      }),
-    },
   ],
 });

--- a/src/data/composite/things/flash/withFlashAct.js
+++ b/src/data/composite/things/flash/withFlashAct.js
@@ -1,59 +1,26 @@
 // Gets the flash's act. This will early exit if flashActData is missing.
-// By default, if there's no flash whose list of flashes includes this flash,
-// the output dependency will be null; set {notFoundMode: 'exit'} to early
-// exit instead.
+// If there's no flash whose list of flashes includes this flash, the output
+// dependency will be null.
 //
 // This step models with Flash.withAlbum.
 
 import {input, templateCompositeFrom} from '#composite';
 import {is} from '#validators';
 
-import {exitWithoutDependency, withResultOfAvailabilityCheck}
+import {exitWithoutDependency, raiseOutputWithoutDependency}
   from '#composite/control-flow';
 import {withPropertyFromList} from '#composite/data';
 
 export default templateCompositeFrom({
   annotation: `withFlashAct`,
 
-  inputs: {
-    notFoundMode: input({
-      validate: is('exit', 'null'),
-      defaultValue: 'null',
-    }),
-  },
-
   outputs: ['#flashAct'],
 
   steps: () => [
-    // null flashActData is always an early exit.
-
     exitWithoutDependency({
       dependency: 'flashActData',
       mode: input.value('null'),
     }),
-
-    // empty flashActData conditionally exits early or outputs null.
-
-    withResultOfAvailabilityCheck({
-      from: 'flashActData',
-      mode: input.value('empty'),
-    }).outputs({
-      '#availability': '#flashActDataAvailability',
-    }),
-
-    {
-      dependencies: [input('notFoundMode'), '#flashActDataAvailability'],
-      compute(continuation, {
-        [input('notFoundMode')]: notFoundMode,
-        ['#flashActDataAvailability']: flashActDataIsAvailable,
-      }) {
-        if (flashActDataIsAvailable) return continuation();
-        switch (notFoundMode) {
-          case 'exit': return continuation.exit(null);
-          case 'null': return continuation.raiseOutput({'#flashAct': null});
-        }
-      },
-    },
 
     withPropertyFromList({
       list: 'flashActData',
@@ -71,28 +38,11 @@ export default templateCompositeFrom({
       }),
     },
 
-    // album not found conditionally exits or outputs null.
-
-    withResultOfAvailabilityCheck({
-      from: '#flashActIndex',
+    raiseOutputWithoutDependency({
+      dependency: '#flashActIndex',
       mode: input.value('index'),
-    }).outputs({
-      '#availability': '#flashActAvailability',
+      output: input.value({'#album': null}),
     }),
-
-    {
-      dependencies: [input('notFoundMode'), '#flashActAvailability'],
-      compute(continuation, {
-        [input('notFoundMode')]: notFoundMode,
-        ['#flashActAvailability']: flashActIsAvailable,
-      }) {
-        if (flashActIsAvailable) return continuation();
-        switch (notFoundMode) {
-          case 'exit': return continuation.exit(null);
-          case 'null': return continuation.raiseOutput({'#flashAct': null});
-        }
-      },
-    },
 
     {
       dependencies: ['flashActData', '#flashActIndex'],

--- a/src/data/composite/things/track/withAlbum.js
+++ b/src/data/composite/things/track/withAlbum.js
@@ -1,15 +1,10 @@
 // Gets the track's album. This will early exit if albumData is missing.
 // If there's no album whose list of tracks includes this track, the output
 // dependency will be null.
-//
-// This step models with Flash.withFlashAct.
 
 import {input, templateCompositeFrom} from '#composite';
-import {is} from '#validators';
 
-import {exitWithoutDependency, raiseOutputWithoutDependency}
-  from '#composite/control-flow';
-import {withPropertyFromList} from '#composite/data';
+import {withUniqueReferencingThing} from '#composite/wiki-data';
 
 export default templateCompositeFrom({
   annotation: `withAlbum`,
@@ -17,42 +12,11 @@ export default templateCompositeFrom({
   outputs: ['#album'],
 
   steps: () => [
-    exitWithoutDependency({
-      dependency: 'albumData',
-      mode: input.value('null'),
+    withUniqueReferencingThing({
+      data: 'albumData',
+      list: input.value('tracks'),
+    }).outputs({
+      ['#uniqueReferencingThing']: '#album',
     }),
-
-    withPropertyFromList({
-      list: 'albumData',
-      property: input.value('tracks'),
-    }),
-
-    {
-      dependencies: [input.myself(), '#albumData.tracks'],
-      compute: (continuation, {
-        [input.myself()]: track,
-        ['#albumData.tracks']: trackLists,
-      }) => continuation({
-        ['#albumIndex']:
-          trackLists.findIndex(tracks => tracks.includes(track)),
-      }),
-    },
-
-    raiseOutputWithoutDependency({
-      dependency: '#albumIndex',
-      mode: input.value('index'),
-      output: input.value({'#album': null}),
-    }),
-
-    {
-      dependencies: ['albumData', '#albumIndex'],
-      compute: (continuation, {
-        ['albumData']: albumData,
-        ['#albumIndex']: albumIndex,
-      }) => continuation.raiseOutput({
-        ['#album']:
-          albumData[albumIndex],
-      }),
-    },
   ],
 });

--- a/src/data/composite/things/track/withContainingTrackSection.js
+++ b/src/data/composite/things/track/withContainingTrackSection.js
@@ -1,63 +1,42 @@
 // Gets the track section containing this track from its album's track list.
-// If notFoundMode is set to 'exit', this will early exit if the album can't be
-// found or if none of its trackSections includes the track for some reason.
 
 import {input, templateCompositeFrom} from '#composite';
 import {is} from '#validators';
+
+import {raiseOutputWithoutDependency} from '#composite/control-flow';
 
 import withPropertyFromAlbum from './withPropertyFromAlbum.js';
 
 export default templateCompositeFrom({
   annotation: `withContainingTrackSection`,
 
-  inputs: {
-    notFoundMode: input({
-      validate: is('exit', 'null'),
-      defaultValue: 'null',
-    }),
-  },
-
   outputs: ['#trackSection'],
 
   steps: () => [
     withPropertyFromAlbum({
       property: input.value('trackSections'),
-      notFoundMode: input('notFoundMode'),
+    }),
+
+    raiseOutputWithoutDependency({
+      dependency: '#album.trackSections',
+      output: input.value({'#trackSection': null}),
     }),
 
     {
       dependencies: [
         input.myself(),
-        input('notFoundMode'),
         '#album.trackSections',
       ],
 
-      compute(continuation, {
+      compute: (continuation, {
         [input.myself()]: track,
         [input('notFoundMode')]: notFoundMode,
         ['#album.trackSections']: trackSections,
-      }) {
-        if (!trackSections) {
-          return continuation.raiseOutput({
-            ['#trackSection']: null,
-          });
-        }
-
-        const trackSection =
-          trackSections.find(({tracks}) => tracks.includes(track));
-
-        if (trackSection) {
-          return continuation.raiseOutput({
-            ['#trackSection']: trackSection,
-          });
-        } else if (notFoundMode === 'exit') {
-          return continuation.exit(null);
-        } else {
-          return continuation.raiseOutput({
-            ['#trackSection']: null,
-          });
-        }
-      },
+      }) => continuation({
+        ['#trackSection']:
+          trackSections.find(({tracks}) => tracks.includes(track))
+            ?? null,
+      }),
     },
   ],
 });

--- a/src/data/composite/things/track/withPropertyFromAlbum.js
+++ b/src/data/composite/things/track/withPropertyFromAlbum.js
@@ -1,7 +1,5 @@
 // Gets a single property from this track's album, providing it as the same
-// property name prefixed with '#album.' (by default). If the track's album
-// isn't available, then by default, the property will be provided as null;
-// set {notFoundMode: 'exit'} to early exit instead.
+// property name prefixed with '#album.' (by default).
 
 import {input, templateCompositeFrom} from '#composite';
 import {is} from '#validators';
@@ -15,11 +13,6 @@ export default templateCompositeFrom({
 
   inputs: {
     property: input.staticValue({type: 'string'}),
-
-    notFoundMode: input({
-      validate: is('exit', 'null'),
-      defaultValue: 'null',
-    }),
   },
 
   outputs: ({
@@ -27,9 +20,7 @@ export default templateCompositeFrom({
   }) => ['#album.' + property],
 
   steps: () => [
-    withAlbum({
-      notFoundMode: input('notFoundMode'),
-    }),
+    withAlbum(),
 
     withPropertyFromObject({
       object: '#album',

--- a/src/data/composite/wiki-data/index.js
+++ b/src/data/composite/wiki-data/index.js
@@ -13,3 +13,4 @@ export {default as withResolvedReferenceList} from './withResolvedReferenceList.
 export {default as withReverseContributionList} from './withReverseContributionList.js';
 export {default as withReverseReferenceList} from './withReverseReferenceList.js';
 export {default as withThingsSortedAlphabetically} from './withThingsSortedAlphabetically.js';
+export {default as withUniqueReferencingThing} from './withUniqueReferencingThing.js';

--- a/src/data/composite/wiki-data/withUniqueReferencingThing.js
+++ b/src/data/composite/wiki-data/withUniqueReferencingThing.js
@@ -1,0 +1,52 @@
+// Like withReverseReferenceList, but this is specifically for special "unique"
+// references, meaning this thing is referenced by exactly one or zero things
+// in the data list.
+
+import {input, templateCompositeFrom} from '#composite';
+
+import {exitWithoutDependency, raiseOutputWithoutDependency}
+  from '#composite/control-flow';
+
+import inputWikiData from './inputWikiData.js';
+import withReverseReferenceList from './withReverseReferenceList.js';
+
+export default templateCompositeFrom({
+  annotation: `withUniqueReferencingThing`,
+
+  inputs: {
+    data: inputWikiData({allowMixedTypes: false}),
+    list: input({type: 'string'}),
+  },
+
+  outputs: ['#uniqueReferencingThing'],
+
+  steps: () => [
+    // withReverseRefernceList does this check too, but it early exits with
+    // an empty array. That's no good here!
+    exitWithoutDependency({
+      dependency: input('data'),
+      mode: input.value('empty'),
+    }),
+
+    withReverseReferenceList({
+      data: input('data'),
+      list: input('list'),
+    }),
+
+    raiseOutputWithoutDependency({
+      dependency: '#reverseReferenceList',
+      mode: input.value('empty'),
+      output: input.value({'#uniqueReferencingThing': null}),
+    }),
+
+    {
+      dependencies: ['#reverseReferenceList'],
+      compute: (continuation, {
+        ['#reverseReferenceList']: reverseReferenceList,
+      }) => continuation({
+        ['#uniqueReferencingThing']:
+          reverseReferenceList[0],
+      }),
+    },
+  ],
+});

--- a/src/data/things/flash.js
+++ b/src/data/things/flash.js
@@ -4,12 +4,18 @@ import {input} from '#composite';
 import find from '#find';
 import {sortFlashesChronologically} from '#sort';
 import Thing from '#thing';
-import {anyOf, isColor, isDirectory, isNumber, isString} from '#validators';
+import {anyOf, isColor, isContentString, isDirectory, isNumber, isString}
+  from '#validators';
 import {parseDate, parseContributors} from '#yaml';
 
-import {exposeDependency, exposeUpdateValueOrContinue}
-  from '#composite/control-flow';
 import {withPropertyFromObject} from '#composite/data';
+
+import {
+  exposeConstant,
+  exposeDependency,
+  exposeDependencyOrContinue,
+  exposeUpdateValueOrContinue,
+} from '#composite/control-flow';
 
 import {
   color,
@@ -179,7 +185,27 @@ export class FlashAct extends Thing {
     name: name('Unnamed Flash Act'),
     directory: directory(),
     color: color(),
-    listTerminology: contentString(),
+
+    listTerminology: [
+      exposeUpdateValueOrContinue({
+        validate: input.value(isContentString),
+      }),
+
+      withFlashSide(),
+
+      withPropertyFromObject({
+        object: '#flashSide',
+        property: input.value('listTerminology'),
+      }),
+
+      exposeDependencyOrContinue({
+        dependency: '#flashSide.listTerminology',
+      }),
+
+      exposeConstant({
+        value: input.value(null),
+      }),
+    ],
 
     flashes: referenceList({
       class: input.value(Flash),
@@ -235,6 +261,7 @@ export class FlashSide extends Thing {
     name: name('Unnamed Flash Side'),
     directory: directory(),
     color: color(),
+    listTerminology: contentString(),
 
     acts: referenceList({
       class: input.value(FlashAct),
@@ -254,6 +281,7 @@ export class FlashSide extends Thing {
       'Side': {property: 'name'},
       'Directory': {property: 'directory'},
       'Color': {property: 'color'},
+      'List Terminology': {property: 'listTerminology'},
     },
   };
 

--- a/src/data/things/flash.js
+++ b/src/data/things/flash.js
@@ -181,18 +181,6 @@ export class FlashAct extends Thing {
     color: color(),
     listTerminology: contentString(),
 
-    jump: contentString(),
-
-    jumpColor: {
-      flags: {update: true, expose: true},
-      update: {validate: isColor},
-      expose: {
-        dependencies: ['color'],
-        transform: (jumpColor, {color}) =>
-          jumpColor ?? color,
-      }
-    },
-
     flashes: referenceList({
       class: input.value(Flash),
       find: input.value(find.flash),
@@ -231,9 +219,6 @@ export class FlashAct extends Thing {
 
       'Color': {property: 'color'},
       'List Terminology': {property: 'listTerminology'},
-
-      'Jump': {property: 'jump'},
-      'Jump Color': {property: 'jumpColor'},
 
       'Review Points': {ignore: true},
     },

--- a/src/data/things/flash.js
+++ b/src/data/things/flash.js
@@ -105,16 +105,10 @@ export class Flash extends Thing {
 
     // Expose only
 
-    act: {
-      flags: {expose: true},
-
-      expose: {
-        dependencies: ['this', 'flashActData'],
-
-        compute: ({this: flash, flashActData}) =>
-          flashActData.find((act) => act.flashes.includes(flash)) ?? null,
-      },
-    },
+    act: [
+      withFlashAct(),
+      exposeDependency({dependency: '#flashAct'}),
+    ],
   });
 
   static [Thing.getSerializeDescriptors] = ({

--- a/src/data/things/flash.js
+++ b/src/data/things/flash.js
@@ -2,6 +2,7 @@ export const FLASH_DATA_FILE = 'flashes.yaml';
 
 import {input} from '#composite';
 import find from '#find';
+import {empty} from '#sugar';
 import {sortFlashesChronologically} from '#sort';
 import Thing from '#thing';
 import {anyOf, isColor, isContentString, isDirectory, isNumber, isString}
@@ -308,15 +309,22 @@ export class FlashSide extends Thing {
         : Flash),
 
     save(results) {
-      let thing;
-      for (let index = 0; thing = results[index]; index++) {
-        if (index === 0 && !(thing instanceof FlashSide)) {
-          throw new Error(`Expected a side at top of flash data file`);
-        }
+      // JavaScript likes you.
 
-        // JavaScript likes you.
+      if (!empty(results) && !(results[0] instanceof FlashSide)) {
+        throw new Error(`Expected a side at top of flash data file`);
+      }
+
+      let index = 0;
+      let thing;
+      for (; thing = results[index]; index++) {
         const flashSide = thing;
         const flashActRefs = [];
+
+        if (results[index + 1] instanceof Flash) {
+          throw new Error(`Expected an act to immediately follow a side`);
+        }
+
         for (
           index++;
           (thing = results[index]) && thing instanceof FlashAct;

--- a/src/data/yaml.js
+++ b/src/data/yaml.js
@@ -942,6 +942,11 @@ export function linkWikiDataArrays(wikiData) {
 
     [wikiData.flashActData, [
       'flashData',
+      'flashSideData',
+    ]],
+
+    [wikiData.flashSideData, [
+      'flashActData',
     ]],
 
     [wikiData.groupData, [

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -1069,9 +1069,8 @@ flashIndex:
 flashSidebar:
   flashList:
 
-    # These two strings are the default ones used when a flash act
-    # doesn't specify a custom phrasing.
-    flashesInThisAct: "Flashes in this act"
+    # This is the default string used when neither a flash act nor its side
+    # specifies a custom phrasing.
     entriesInThisSection: "Entries in this section"
 
 #

--- a/src/upd8.js
+++ b/src/upd8.js
@@ -981,6 +981,7 @@ async function main() {
       if (wikiData.flashData) {
         logThings('flashData', 'flashes');
         logThings('flashActData', 'flash acts');
+        logThings('flashSideData', 'flash sides');
       }
       logThings('groupData', 'groups');
       logThings('groupCategoryData', 'group categories');

--- a/test/unit/data/composite/things/track/withAlbum.js
+++ b/test/unit/data/composite/things/track/withAlbum.js
@@ -40,7 +40,7 @@ t.test(`withAlbum: basic behavior`, t => {
     null);
 });
 
-t.test(`withAlbum: early exit conditions (notFoundMode: null)`, t => {
+t.test(`withAlbum: early exit conditions`, t => {
   t.plan(4);
 
   const composite = compositeFrom({
@@ -80,59 +80,6 @@ t.test(`withAlbum: early exit conditions (notFoundMode: null)`, t => {
     }),
     'bimbam',
     `does not early exit if albumData is empty array`);
-
-  t.equal(
-    composite.expose.compute({
-      albumData: null,
-      this: fakeTrack1,
-    }),
-    null,
-    `early exits if albumData is null`);
-});
-
-t.test(`withAlbum: early exit conditions (notFoundMode: exit)`, t => {
-  t.plan(4);
-
-  const composite = compositeFrom({
-    compose: false,
-    steps: [
-      withAlbum({
-        notFoundMode: input.value('exit'),
-      }),
-
-      exposeConstant({
-        value: input.value('bimbam'),
-      }),
-    ],
-  });
-
-  const fakeTrack1 = {directory: 'foo'};
-  const fakeTrack2 = {directory: 'bar'};
-  const fakeAlbum = {directory: 'baz', tracks: [fakeTrack1]};
-
-  t.equal(
-    composite.expose.compute({
-      albumData: [fakeAlbum],
-      this: fakeTrack1,
-    }),
-    'bimbam',
-    `does not early exit if albumData is present and contains the track`);
-
-  t.equal(
-    composite.expose.compute({
-      albumData: [fakeAlbum],
-      this: fakeTrack2,
-    }),
-    null,
-    `early exits if albumData is present and does not contain the track`);
-
-  t.equal(
-    composite.expose.compute({
-      albumData: [],
-      this: fakeTrack1,
-    }),
-    null,
-    `early exits if albumData is empty array`);
 
   t.equal(
     composite.expose.compute({


### PR DESCRIPTION
This PR makes "sides", which section flash *acts* (similar to how categories section groups), a customizable feature via `flashes.yaml`! This means we get to avoid hard-coding a bunch of information in `generateFlashActSidebar`, and since they graduate to proper thing objects (rather than being a nebulous UI-first concept), we get nicer logic too.

Apart from customizing the sidebar, customizable sides *also* completely replace the pre-existing "Jump" and "Jump Color" fields, which could be specified on acts.

Plus, sides can specify a default `List Terminology` to apply to all acts (which don't specifically customize it) — this controls the "Flashes in this act" list title in the flash act sidebar. You could previously specify this on individual acts already, but inheriting makes for nicer data, and means we don't hard-code the text "Flashes for this act" as the default for the top-two sides.

Besides improved flashes, this PR also simplifies the common code between `withAlbum`, `withFlashAct`, and the new `withFlashSide`, and refactors it into a new, general `withUniqueReferencingThing` utility. This meant cutting out some more `notFoundMode` cruft, and the actual functionality is hopefully a lot easier to follow.

This is a breaking change to how flashes are processed (the file *needs* to start with and include at least one `Side`), so merge this alongside hsmusic/hsmusic-data#444.