### PR TITLE
Sidebar components!

### DIFF
--- a/src/content/dependencies/generateAlbumCommentaryPage.js
+++ b/src/content/dependencies/generateAlbumCommentaryPage.js
@@ -10,6 +10,7 @@ export default {
     'generateContentHeading',
     'generateTrackCoverArtwork',
     'generatePageLayout',
+    'generatePageSidebar',
     'linkAlbum',
     'linkExternal',
     'linkTrack',
@@ -22,6 +23,9 @@ export default {
 
     relations.layout =
       relation('generatePageLayout');
+
+    relations.sidebar =
+      relation('generatePageSidebar');
 
     relations.albumStyleRules =
       relation('generateAlbumStyleRules', album, null);
@@ -249,17 +253,22 @@ export default {
           },
         ],
 
-        leftSidebarStickyMode: 'column',
-        leftSidebarClass: 'commentary-track-list-sidebar-box',
-        leftSidebarContent: [
-          html.tag('h1', relations.sidebarAlbumLink),
-          relations.sidebarTrackSections.map(section =>
-            section.slots({
-              anchor: true,
-              open: true,
-              mode: 'commentary',
-            })),
-        ],
+        leftSidebar:
+          relations.sidebar.slots({
+            attributes: {class: 'commentary-track-list-sidebar-box'},
+
+            stickyMode: 'column',
+
+            content: [
+              html.tag('h1', relations.sidebarAlbumLink),
+              relations.sidebarTrackSections.map(section =>
+                section.slots({
+                  anchor: true,
+                  open: true,
+                  mode: 'commentary',
+                })),
+            ],
+          }),
       });
   },
 };

--- a/src/content/dependencies/generateAlbumInfoPage.js
+++ b/src/content/dependencies/generateAlbumInfoPage.js
@@ -265,7 +265,7 @@ export default {
 
         secondaryNav: relations.secondaryNav,
 
-        ...relations.sidebar,
+        leftSidebar: relations.sidebar,
 
         socialEmbed: relations.socialEmbed,
       });

--- a/src/content/dependencies/generateAlbumSidebar.js
+++ b/src/content/dependencies/generateAlbumSidebar.js
@@ -2,6 +2,7 @@ export default {
   contentDependencies: [
     'generateAlbumSidebarGroupBox',
     'generateAlbumSidebarTrackSection',
+    'generatePageSidebar',
     'linkAlbum',
   ],
 
@@ -9,6 +10,9 @@ export default {
 
   relations(relation, album, track) {
     const relations = {};
+
+    relations.sidebar =
+      relation('generatePageSidebar');
 
     relations.albumLink =
       relation('linkAlbum', album);
@@ -29,34 +33,27 @@ export default {
   },
 
   generate(data, relations, {html}) {
-    const trackListBox = {
-      class: 'track-list-sidebar-box',
-      content:
-        html.tags([
-          html.tag('h1', relations.albumLink),
-          relations.trackSections,
-        ]),
-    };
+    const multipleContents = [];
+    const multipleAttributes = [];
+
+    multipleAttributes.push({class: 'track-list-sidebar-box'});
+    multipleContents.push(
+      html.tags([
+        html.tag('h1', relations.albumLink),
+        relations.trackSections,
+      ]));
 
     if (data.isAlbumPage) {
-      const groupBoxes =
+      multipleAttributes.push(...
         relations.groupBoxes
-          .map(content => ({
-            class: 'individual-group-sidebar-box',
-            content: content.slot('mode', 'album'),
-          }));
+          .map(() => ({class: 'individual-group-sidebar-box'})));
 
-      return {
-        leftSidebarMultiple: [
-          ...groupBoxes,
-          trackListBox,
-        ],
-      };
-    }
-
-    const conjoinedGroupBox = {
-      class: 'conjoined-group-sidebar-box',
-      content:
+      multipleContents.push(...
+        relations.groupBoxes
+          .map(content => content.slot('mode', 'album')));
+    } else {
+      multipleAttributes.push({class: 'conjoined-group-sidebar-box'});
+      multipleContents.push(
         relations.groupBoxes
           .flatMap((content, i, {length}) => [
             content.slot('mode', 'track'),
@@ -65,15 +62,13 @@ export default {
                 style: `border-color: var(--primary-color); border-style: none none dotted none`
               }),
           ])
-          .filter(Boolean),
-    };
+          .filter(Boolean));
+    }
 
-    return {
-      // leftSidebarStickyMode: 'column',
-      leftSidebarMultiple: [
-        trackListBox,
-        conjoinedGroupBox,
-      ],
-    };
+    return relations.sidebar.slots({
+      // stickyMode: 'column',
+      multipleContents,
+      multipleAttributes,
+    });
   },
 };

--- a/src/content/dependencies/generateAlbumSidebar.js
+++ b/src/content/dependencies/generateAlbumSidebar.js
@@ -28,19 +28,20 @@ export default {
   generate: (data, relations) =>
     relations.sidebar.slots({
       boxes: [
+        data.isAlbumPage &&
+          relations.groupBoxes
+            .map(box => box.slot('mode', 'album')),
+
         relations.trackListBox,
 
-        (data.isAlbumPage
-          ? relations.groupBoxes
-              .map(box => box.slot('mode', 'album'))
-
-          : relations.conjoinedBox.slots({
-              attributes: {class: 'conjoined-group-sidebar-box'},
-              boxes:
-                relations.groupBoxes
-                  .map(box => box.slot('mode', 'track'))
-                  .map(box => box.content), /* TODO: Kludge. */
-            })),
+        !data.isAlbumPage &&
+          relations.conjoinedBox.slots({
+            attributes: {class: 'conjoined-group-sidebar-box'},
+            boxes:
+              relations.groupBoxes
+                .map(box => box.slot('mode', 'track'))
+                .map(box => box.content), /* TODO: Kludge. */
+          }),
       ],
     }),
 };

--- a/src/content/dependencies/generateAlbumSidebarGroupBox.js
+++ b/src/content/dependencies/generateAlbumSidebarGroupBox.js
@@ -3,6 +3,7 @@ import {atOffset, empty} from '#sugar';
 
 export default {
   contentDependencies: [
+    'generatePageSidebarBox',
     'linkAlbum',
     'linkExternal',
     'linkGroup',
@@ -40,6 +41,9 @@ export default {
   relations(relation, query, album, group) {
     const relations = {};
 
+    relations.box =
+      relation('generatePageSidebarBox');
+
     relations.groupLink =
       relation('linkGroup', group);
 
@@ -72,39 +76,41 @@ export default {
     },
   },
 
-  generate(relations, slots, {html, language}) {
-    return html.tags([
-      html.tag('h1',
-        language.$('albumSidebar.groupBox.title', {
-          group: relations.groupLink,
-        })),
-
-      slots.mode === 'album' &&
-        relations.description
-          ?.slot('mode', 'multiline'),
-
-      !empty(relations.externalLinks) &&
-        html.tag('p',
-          language.$('releaseInfo.visitOn', {
-            links:
-              language.formatDisjunctionList(
-                relations.externalLinks
-                  .map(link => link.slot('context', 'group'))),
+  generate: (relations, slots, {html, language}) =>
+    relations.box.slots({
+      attributes: {class: 'individual-group-sidebar-box'},
+      content: [
+        html.tag('h1',
+          language.$('albumSidebar.groupBox.title', {
+            group: relations.groupLink,
           })),
 
-      slots.mode === 'album' &&
-      relations.nextAlbumLink &&
-        html.tag('p', {class: 'group-chronology-link'},
-          language.$('albumSidebar.groupBox.next', {
-            album: relations.nextAlbumLink,
-          })),
+        slots.mode === 'album' &&
+          relations.description
+            ?.slot('mode', 'multiline'),
 
-      slots.mode === 'album' &&
-      relations.previousAlbumLink &&
-        html.tag('p', {class: 'group-chronology-link'},
-          language.$('albumSidebar.groupBox.previous', {
-            album: relations.previousAlbumLink,
-          })),
-    ]);
-  },
+        !empty(relations.externalLinks) &&
+          html.tag('p',
+            language.$('releaseInfo.visitOn', {
+              links:
+                language.formatDisjunctionList(
+                  relations.externalLinks
+                    .map(link => link.slot('context', 'group'))),
+            })),
+
+        slots.mode === 'album' &&
+        relations.nextAlbumLink &&
+          html.tag('p', {class: 'group-chronology-link'},
+            language.$('albumSidebar.groupBox.next', {
+              album: relations.nextAlbumLink,
+            })),
+
+        slots.mode === 'album' &&
+        relations.previousAlbumLink &&
+          html.tag('p', {class: 'group-chronology-link'},
+            language.$('albumSidebar.groupBox.previous', {
+              album: relations.previousAlbumLink,
+            })),
+      ],
+    }),
 };

--- a/src/content/dependencies/generateAlbumSidebarTrackListBox.js
+++ b/src/content/dependencies/generateAlbumSidebarTrackListBox.js
@@ -1,0 +1,31 @@
+export default {
+  contentDependencies: [
+    'generateAlbumSidebarTrackSection',
+    'generatePageSidebarBox',
+    'linkAlbum',
+  ],
+
+  extraDependencies: ['html'],
+
+  relations: (relation, album, track) => ({
+    box:
+      relation('generatePageSidebarBox'),
+
+    albumLink:
+      relation('linkAlbum', album),
+
+    trackSections:
+      album.trackSections.map(trackSection =>
+        relation('generateAlbumSidebarTrackSection', album, track, trackSection)),
+  }),
+
+  generate: (relations, {html}) =>
+    relations.box.slots({
+      attributes: {class: 'track-list-sidebar-box'},
+
+      content: [
+        html.tag('h1', relations.albumLink),
+        relations.trackSections,
+      ],
+    })
+};

--- a/src/content/dependencies/generateFlashActGalleryPage.js
+++ b/src/content/dependencies/generateFlashActGalleryPage.js
@@ -85,7 +85,7 @@ export default {
 
       navBottomRowContent: relations.flashActNavAccent,
 
-      ...relations.sidebar,
+      leftSidebar: relations.sidebar,
     });
   },
 };

--- a/src/content/dependencies/generateFlashActSidebar.js
+++ b/src/content/dependencies/generateFlashActSidebar.js
@@ -1,182 +1,30 @@
-import {stitchArrays} from '#sugar';
-
 export default {
   contentDependencies: [
+    'generateFlashActSidebarCurrentActBox',
+    'generateFlashActSidebarSideMapBox',
     'generatePageSidebar',
-    'generatePageSidebarBox',
-    'linkFlash',
-    'linkFlashAct',
-    'linkFlashIndex',
   ],
 
-  extraDependencies: ['getColors', 'html', 'language', 'wikiData'],
-
-  sprawl: ({flashActData, flashSideData}) => ({flashActData, flashSideData}),
-
-  query(sprawl, act, flash) {
-    const sideNames =
-      sprawl.flashSideData
-        .map(side => side.name);
-
-    const sideColors =
-      sprawl.flashSideData
-        .map(side => side.color);
-
-    const sideActs =
-      sprawl.flashSideData
-        .map(side => side.acts);
-
-    const currentActFlashes =
-      act.flashes;
-
-    const currentFlashIndex =
-      currentActFlashes.indexOf(flash);
-
-    const currentSideIndex =
-      sideActs.findIndex(acts => acts.includes(act));
-
-    const currentSideActs =
-      sideActs[currentSideIndex];
-
-    const currentActIndex =
-      currentSideActs.indexOf(act);
-
-    const fallbackListTerminology =
-      'entriesInThisSection';
-
-    return {
-      sideNames,
-      sideColors,
-      sideActs,
-
-      currentSideIndex,
-      currentSideActs,
-      currentActIndex,
-      currentActFlashes,
-      currentFlashIndex,
-
-      fallbackListTerminology,
-    };
-  },
-
-  relations: (relation, query, sprawl, act, _flash) => ({
+  relations: (relation, act, flash) => ({
     sidebar:
       relation('generatePageSidebar'),
 
     currentActBox:
-      relation('generatePageSidebarBox'),
+      relation('generateFlashActSidebarCurrentActBox', act, flash),
 
     sideMapBox:
-      relation('generatePageSidebarBox'),
-
-    currentActLink:
-      relation('linkFlashAct', act),
-
-    flashIndexLink:
-      relation('linkFlashIndex'),
-
-    sideActLinks:
-      query.sideActs
-        .map(acts => acts
-          .map(act => relation('linkFlashAct', act))),
-
-    currentActFlashLinks:
-      act.flashes
-        .map(flash => relation('linkFlash', flash)),
+      relation('generateFlashActSidebarSideMapBox', act, flash),
   }),
 
-  data: (query, sprawl, act, flash) => ({
+  data: (_act, flash) => ({
     isFlashActPage: !flash,
-
-    sideColors: query.sideColors,
-    sideNames: query.sideNames,
-
-    currentSideIndex: query.currentSideIndex,
-    currentActIndex: query.currentActIndex,
-    currentFlashIndex: query.currentFlashIndex,
-
-    customListTerminology: act.listTerminology,
-    fallbackListTerminology: query.fallbackListTerminology,
   }),
 
-  generate(data, relations, {getColors, html, language}) {
-    const currentActBoxContent = html.tags([
-      html.tag('h1', relations.currentActLink),
-
-      html.tag('details',
-        (data.isFlashActPage
-          ? {}
-          : {class: 'current', open: true}),
-        [
-          html.tag('summary',
-            html.tag('span', {class: 'group-name'},
-              (data.customListTerminology
-                ? language.sanitize(data.customListTerminology)
-                : language.$('flashSidebar.flashList', data.fallbackListTerminology)))),
-
-          html.tag('ul',
-            relations.currentActFlashLinks
-              .map((flashLink, index) =>
-                html.tag('li',
-                  index === data.currentFlashIndex &&
-                    {class: 'current'},
-
-                  flashLink))),
-        ]),
-    ]);
-
-    const sideMapBoxContent = html.tags([
-      html.tag('h1', relations.flashIndexLink),
-
-      stitchArrays({
-        sideName: data.sideNames,
-        sideColor: data.sideColors,
-        actLinks: relations.sideActLinks,
-      }).map(({sideName, sideColor, actLinks}, sideIndex) =>
-          html.tag('details',
-            sideIndex === data.currentSideIndex &&
-              {class: 'current'},
-
-            data.isFlashActPage &&
-            sideIndex === data.currentSideIndex &&
-              {open: true},
-
-            sideColor &&
-              {style: `--primary-color: ${getColors(sideColor).primary}`},
-
-            [
-              html.tag('summary',
-                html.tag('span', {class: 'group-name'},
-                  sideName)),
-
-              html.tag('ul',
-                actLinks.map((actLink, actIndex) =>
-                  html.tag('li',
-                    sideIndex === data.currentSideIndex &&
-                    actIndex === data.currentActIndex &&
-                      {class: 'current'},
-
-                    actLink))),
-            ])),
-    ]);
-
-    const sideMapBox =
-      relations.sideMapBox.slots({
-        attributes: {class: 'flash-act-map-sidebar-box'},
-        content: sideMapBoxContent,
-      });
-
-    const currentActBox =
-      relations.currentActBox.slots({
-        attributes: {class: 'flash-current-act-sidebar-box'},
-        content: currentActBoxContent,
-      });
-
-    return relations.sidebar.slots({
+  generate: (data, relations) =>
+    relations.sidebar.slots({
       boxes:
         (data.isFlashActPage
-          ? [sideMapBox, currentActBox]
-          : [currentActBox, sideMapBox]),
-    });
-  },
+          ? [relations.sideMapBox, relations.currentActBox]
+          : [relations.currentActBox, relations.sideMapBox]),
+    }),
 };

--- a/src/content/dependencies/generateFlashActSidebar.js
+++ b/src/content/dependencies/generateFlashActSidebar.js
@@ -1,7 +1,14 @@
 import {stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: ['linkFlash', 'linkFlashAct', 'linkFlashIndex'],
+  contentDependencies: [
+    'generatePageSidebar',
+    'generatePageSidebarBox',
+    'linkFlash',
+    'linkFlashAct',
+    'linkFlashIndex',
+  ],
+
   extraDependencies: ['getColors', 'html', 'language', 'wikiData'],
 
   sprawl: ({flashActData, flashSideData}) => ({flashActData, flashSideData}),
@@ -53,6 +60,15 @@ export default {
   },
 
   relations: (relation, query, sprawl, act, _flash) => ({
+    sidebar:
+      relation('generatePageSidebar'),
+
+    currentActBox:
+      relation('generatePageSidebarBox'),
+
+    sideMapBox:
+      relation('generatePageSidebarBox'),
+
     currentActLink:
       relation('linkFlashAct', act),
 
@@ -144,21 +160,23 @@ export default {
             ])),
     ]);
 
-    const sideMapBox = {
-      class: 'flash-act-map-sidebar-box',
-      content: sideMapBoxContent,
-    };
+    const sideMapBox =
+      relations.sideMapBox.slots({
+        attributes: {class: 'flash-act-map-sidebar-box'},
+        content: sideMapBoxContent,
+      });
 
-    const currentActBox = {
-      class: 'flash-current-act-sidebar-box',
-      content: currentActBoxContent,
-    };
+    const currentActBox =
+      relations.currentActBox.slots({
+        attributes: {class: 'flash-current-act-sidebar-box'},
+        content: currentActBoxContent,
+      });
 
-    return {
-      leftSidebarMultiple:
+    return relations.sidebar.slots({
+      boxes:
         (data.isFlashActPage
           ? [sideMapBox, currentActBox]
           : [currentActBox, sideMapBox]),
-    };
+    });
   },
 };

--- a/src/content/dependencies/generateFlashActSidebarCurrentActBox.js
+++ b/src/content/dependencies/generateFlashActSidebarCurrentActBox.js
@@ -1,0 +1,63 @@
+export default {
+  contentDependencies: [
+    'generatePageSidebarBox',
+    'linkFlash',
+    'linkFlashAct',
+  ],
+
+  extraDependencies: ['html', 'language'],
+
+  relations: (relation, act, _flash) => ({
+    box:
+      relation('generatePageSidebarBox'),
+
+    actLink:
+      relation('linkFlashAct', act),
+
+    flashLinks:
+      act.flashes
+        .map(flash => relation('linkFlash', flash)),
+  }),
+
+  data: (act, flash) => ({
+    isFlashActPage:
+      !flash,
+
+    currentFlashIndex:
+      act.flashes.indexOf(flash),
+
+    customListTerminology:
+      act.listTerminology,
+  }),
+
+  generate: (data, relations, {html, language}) =>
+    relations.box.slots({
+      attributes: {class: 'flash-act-map-sidebar-box'},
+
+      content: [
+        html.tag('h1', relations.actLink),
+
+        html.tag('details',
+          (data.isFlashActPage
+            ? {}
+            : {class: 'current', open: true}),
+
+          [
+            html.tag('summary',
+              html.tag('span', {class: 'group-name'},
+                (data.customListTerminology
+                  ? language.sanitize(data.customListTerminology)
+                  : language.$('flashSidebar.flashList.entriesInThisSection')))),
+
+            html.tag('ul',
+              relations.flashLinks
+                .map((flashLink, index) =>
+                  html.tag('li',
+                    index === data.currentFlashIndex &&
+                      {class: 'current'},
+
+                    flashLink))),
+          ]),
+        ],
+    }),
+};

--- a/src/content/dependencies/generateFlashActSidebarSideMapBox.js
+++ b/src/content/dependencies/generateFlashActSidebarSideMapBox.js
@@ -1,0 +1,85 @@
+import {stitchArrays} from '#sugar';
+
+export default {
+  contentDependencies: [
+    'generatePageSidebarBox',
+    'linkFlashAct',
+    'linkFlashIndex',
+  ],
+
+  extraDependencies: ['getColors', 'html', 'wikiData'],
+
+  sprawl: ({flashSideData}) => ({flashSideData}),
+
+  relations: (relation, sprawl, _act, _flash) => ({
+    box:
+      relation('generatePageSidebarBox'),
+
+    flashIndexLink:
+      relation('linkFlashIndex'),
+
+    sideActLinks:
+      sprawl.flashSideData
+        .map(side => side.acts
+          .map(act => relation('linkFlashAct', act))),
+  }),
+
+  data: (sprawl, act, flash) => ({
+    isFlashActPage:
+      !flash,
+
+    sideNames:
+      sprawl.flashSideData
+        .map(side => side.name),
+
+    sideColors:
+      sprawl.flashSideData
+        .map(side => side.color),
+
+    currentSideIndex:
+      sprawl.flashSideData.indexOf(act.side),
+
+    currentActIndex:
+      act.side.acts.indexOf(act),
+  }),
+
+  generate: (data, relations, {getColors, html}) =>
+    relations.box.slots({
+      attributes: {class: 'flash-act-map-sidebar-box'},
+
+      content: [
+        html.tag('h1', relations.flashIndexLink),
+
+        stitchArrays({
+          sideName: data.sideNames,
+          sideColor: data.sideColors,
+          actLinks: relations.sideActLinks,
+        }).map(({sideName, sideColor, actLinks}, sideIndex) =>
+            html.tag('details',
+              sideIndex === data.currentSideIndex &&
+                {class: 'current'},
+
+              data.isFlashActPage &&
+              sideIndex === data.currentSideIndex &&
+                {open: true},
+
+              sideColor &&
+                {style: `--primary-color: ${getColors(sideColor).primary}`},
+
+              [
+                html.tag('summary',
+                  html.tag('span', {class: 'group-name'},
+                    sideName)),
+
+                html.tag('ul',
+                  actLinks.map((actLink, actIndex) =>
+                    html.tag('li',
+                      sideIndex === data.currentSideIndex &&
+                      actIndex === data.currentActIndex &&
+                        {class: 'current'},
+
+                      actLink))),
+              ])),
+      ],
+    }),
+};

--- a/src/content/dependencies/generateFlashActSidebarSideMapBox.js
+++ b/src/content/dependencies/generateFlashActSidebarSideMapBox.js
@@ -2,12 +2,13 @@ import {stitchArrays} from '#sugar';
 
 export default {
   contentDependencies: [
+    'generateColorStyleAttribute',
     'generatePageSidebarBox',
     'linkFlashAct',
     'linkFlashIndex',
   ],
 
-  extraDependencies: ['getColors', 'html', 'wikiData'],
+  extraDependencies: ['html', 'wikiData'],
 
   sprawl: ({flashSideData}) => ({flashSideData}),
 
@@ -17,6 +18,10 @@ export default {
 
     flashIndexLink:
       relation('linkFlashIndex'),
+
+    sideColorStyles:
+      sprawl.flashSideData
+        .map(side => relation('generateColorStyleAttribute', side.color)),
 
     sideActLinks:
       sprawl.flashSideData
@@ -32,10 +37,6 @@ export default {
       sprawl.flashSideData
         .map(side => side.name),
 
-    sideColors:
-      sprawl.flashSideData
-        .map(side => side.color),
-
     currentSideIndex:
       sprawl.flashSideData.indexOf(act.side),
 
@@ -43,7 +44,7 @@ export default {
       act.side.acts.indexOf(act),
   }),
 
-  generate: (data, relations, {getColors, html}) =>
+  generate: (data, relations, {html}) =>
     relations.box.slots({
       attributes: {class: 'flash-act-map-sidebar-box'},
 
@@ -52,9 +53,9 @@ export default {
 
         stitchArrays({
           sideName: data.sideNames,
-          sideColor: data.sideColors,
+          sideColorStyle: relations.sideColorStyles,
           actLinks: relations.sideActLinks,
-        }).map(({sideName, sideColor, actLinks}, sideIndex) =>
+        }).map(({sideName, sideColorStyle, actLinks}, sideIndex) =>
             html.tag('details',
               sideIndex === data.currentSideIndex &&
                 {class: 'current'},
@@ -63,8 +64,7 @@ export default {
               sideIndex === data.currentSideIndex &&
                 {open: true},
 
-              sideColor &&
-                {style: `--primary-color: ${getColors(sideColor).primary}`},
+              sideColorStyle.slot('context', 'primary-only'),
 
               [
                 html.tag('summary',

--- a/src/content/dependencies/generateFlashInfoPage.js
+++ b/src/content/dependencies/generateFlashInfoPage.js
@@ -169,7 +169,7 @@ export default {
 
       navBottomRowContent: sec.nav.flashNavAccent,
 
-      ...relations.sidebar,
+      leftSidebar: relations.sidebar,
     });
   },
 };

--- a/src/content/dependencies/generateGroupGalleryPage.js
+++ b/src/content/dependencies/generateGroupGalleryPage.js
@@ -178,10 +178,12 @@ export default {
             }),
         ],
 
-        ...
-          relations.sidebar
-            ?.slot('currentExtra', 'gallery')
-            ?.content,
+        leftSidebar:
+          (relations.sidebar
+            ? relations.sidebar
+                .slot('currentExtra', 'gallery')
+                .content /* TODO: Kludge. */
+            : null),
 
         navLinkStyle: 'hierarchical',
         navLinks:

--- a/src/content/dependencies/generateGroupInfoPage.js
+++ b/src/content/dependencies/generateGroupInfoPage.js
@@ -207,7 +207,11 @@ export default {
           ],
         ],
 
-        ...relations.sidebar?.content ?? {},
+        leftSidebar:
+          (relations.sidebar
+            ? relations.sidebar
+                .content /* TODO: Kludge. */
+            : null),
 
         navLinkStyle: 'hierarchical',
         navLinks: relations.navLinks.content,

--- a/src/content/dependencies/generateGroupSidebar.js
+++ b/src/content/dependencies/generateGroupSidebar.js
@@ -1,18 +1,21 @@
 export default {
-  contentDependencies: ['generateGroupSidebarCategoryDetails'],
+  contentDependencies: [
+    'generateGroupSidebarCategoryDetails',
+    'generatePageSidebar',
+  ],
+
   extraDependencies: ['html', 'language', 'wikiData'],
 
-  sprawl({groupCategoryData}) {
-    return {groupCategoryData};
-  },
+  sprawl: ({groupCategoryData}) => ({groupCategoryData}),
 
-  relations(relation, sprawl, group) {
-    return {
-      categoryDetails:
-        sprawl.groupCategoryData.map(category =>
-          relation('generateGroupSidebarCategoryDetails', category, group)),
-    };
-  },
+  relations: (relation, sprawl, group) => ({
+    sidebar:
+      relation('generatePageSidebar'),
+
+    categoryDetails:
+      sprawl.groupCategoryData.map(category =>
+        relation('generateGroupSidebarCategoryDetails', category, group)),
+  }),
 
   slots: {
     currentExtra: {
@@ -20,10 +23,11 @@ export default {
     },
   },
 
-  generate(relations, slots, {html, language}) {
-    return {
-      leftSidebarClass: 'category-map-sidebar-box',
-      leftSidebarContent: [
+  generate: (relations, slots, {html, language}) =>
+    relations.sidebar.slots({
+      attributes: {class: 'category-map-sidebar-box'},
+
+      content: [
         html.tag('h1',
           language.$('groupSidebar.title')),
 
@@ -31,6 +35,5 @@ export default {
           .map(details =>
             details.slot('currentExtra', slots.currentExtra)),
       ],
-    };
-  },
+    }),
 };

--- a/src/content/dependencies/generateListingPage.js
+++ b/src/content/dependencies/generateListingPage.js
@@ -276,7 +276,7 @@ export default {
         {auto: 'current'},
       ],
 
-      ...relations.sidebar,
+      leftSidebar: relations.sidebar,
     });
   },
 };

--- a/src/content/dependencies/generateListingSidebar.js
+++ b/src/content/dependencies/generateListingSidebar.js
@@ -1,21 +1,29 @@
 export default {
-  contentDependencies: ['generateListingIndexList', 'linkListingIndex'],
+  contentDependencies: [
+    'generateListingIndexList',
+    'generatePageSidebar',
+    'linkListingIndex',
+  ],
+
   extraDependencies: ['html'],
 
-  relations(relation, currentListing) {
-    return {
-      listingIndexLink: relation('linkListingIndex'),
-      listingIndexList: relation('generateListingIndexList', currentListing),
-    };
-  },
+  relations: (relation, currentListing) => ({
+    sidebar:
+      relation('generatePageSidebar'),
 
-  generate(relations, {html}) {
-    return {
-      leftSidebarClass: 'listing-map-sidebar-box',
-      leftSidebarContent: [
+    listingIndexLink:
+      relation('linkListingIndex'),
+
+    listingIndexList:
+      relation('generateListingIndexList', currentListing),
+  }),
+
+  generate: (relations, {html}) =>
+    relations.sidebar.slots({
+      attributes: {class: 'listing-map-sidebar-box'},
+      content: [
         html.tag('h1', relations.listingIndexLink),
         relations.listingIndexList.slot('mode', 'sidebar'),
       ],
-    };
-  },
+    }),
 };

--- a/src/content/dependencies/generateListingsIndexPage.js
+++ b/src/content/dependencies/generateListingsIndexPage.js
@@ -83,7 +83,7 @@ export default {
         {auto: 'current'},
       ],
 
-      ...relations.sidebar,
+      leftSidebar: relations.sidebar,
     });
   },
 };

--- a/src/content/dependencies/generatePageLayout.js
+++ b/src/content/dependencies/generatePageLayout.js
@@ -144,6 +144,16 @@ export default {
 
     // Sidebars
 
+    leftSidebar: {
+      type: 'html',
+      mutable: true,
+    },
+
+    rightSidebar: {
+      type: 'html',
+      mutable: true,
+    },
+
     ...legacySidebarSlots('leftSidebar'),
     ...legacySidebarSlots('rightSidebar'),
 
@@ -425,8 +435,21 @@ export default {
         wide: slots[side + 'Wide'],
       });
 
-    const leftSidebar = applyLegacySidebarSlots('leftSidebar', 'sidebar-left');
-    const rightSidebar = applyLegacySidebarSlots('rightSidebar', 'sidebar-right');
+    const applyUpdatedSidebar = (side, id) =>
+      slots[side].slots({
+        attributes:
+          slots[side]
+            .getSlotValue('attributes')
+            .with({id}),
+      });
+
+    const getSidebar = (side, id) =>
+      (html.isBlank(slots[side])
+        ? applyLegacySidebarSlots(side, id)
+        : applyUpdatedSidebar(side, id));
+
+    const leftSidebar = getSidebar('leftSidebar', 'sidebar-left');
+    const rightSidebar = getSidebar('rightSidebar', 'sidebar-right');
 
     const hasSidebarLeft = !html.isBlank(html.resolve(leftSidebar));
     const hasSidebarRight = !html.isBlank(html.resolve(rightSidebar));

--- a/src/content/dependencies/generatePageLayout.js
+++ b/src/content/dependencies/generatePageLayout.js
@@ -417,48 +417,54 @@ export default {
         ]);
 
     const generateSidebarHTML = (side, id) => {
-      const content = slots[side + 'Content'];
+      const attributes = html.attributes({
+        class: 'sidebar-column',
+        id,
+      });
+
       const topClass = slots[side + 'Class'];
-      const multiple = slots[side + 'Multiple'];
+      if (topClass) {
+        attributes.add('class', topClass);
+      }
+
+      if (slots[side + 'Wide']) {
+        attributes.add('class', 'wide');
+      }
+
+      if (!slots[side + 'Collapse']) {
+        attributes.add('class', 'no-hide');
+      }
+
       const stickyMode = slots[side + 'StickyMode'];
-      const wide = slots[side + 'Wide'];
-      const collapse = slots[side + 'Collapse'];
-
-      let sidebarClasses = [];
-      let sidebarContent = html.blank();
-
-      if (!html.isBlank(content)) {
-        sidebarClasses = ['sidebar', topClass];
-        sidebarContent = content;
-      } else if (multiple) {
-        sidebarClasses = ['sidebar-multiple', topClass];
-        sidebarContent =
-          multiple
-            .filter(Boolean)
-            .map(box =>
-              html.tag('div', {class: 'sidebar'},
-                {[html.onlyIfContent]: true},
-                {class: box.class},
-                box.content));
+      if (stickyMode !== 'static') {
+        attributes.add('class', `sticky-${stickyMode}`);
       }
 
-      if (html.isBlank(sidebarContent)) {
-        return html.blank();
+      let content = slots[side + 'Content'];
+
+      if (html.isBlank(content)) {
+        if (!slots[side + 'Multiple']) {
+          return html.blank();
+        }
+
+        const multiple =
+          slots[side + 'Multiple'].filter(Boolean);
+
+        if (empty(multiple)) {
+          return html.blank();
+        }
+
+        attributes.add('class', 'sidebar-multiple');
+        content =
+          multiple.map(box =>
+            html.tag('div', {class: 'sidebar'},
+              {class: box.class},
+              box.content));
+      } else {
+        attributes.add('class', 'sidebar');
       }
 
-      return html.tag('div', {class: 'sidebar-column'},
-        {id, class: sidebarClasses},
-
-        wide &&
-          {class: 'wide'},
-
-        !collapse &&
-          {class: 'no-hide'},
-
-        stickyMode !== 'static' &&
-          {class: `sticky-${stickyMode}`},
-
-        sidebarContent);
+      return html.tag('div', attributes, content);
     }
 
     const sidebarLeftHTML = generateSidebarHTML('leftSidebar', 'sidebar-left');

--- a/src/content/dependencies/generatePageLayout.js
+++ b/src/content/dependencies/generatePageLayout.js
@@ -35,6 +35,7 @@ export default {
     'generateColorStyleRules',
     'generateFooterLocalizationLinks',
     'generatePageSidebar',
+    'generatePageSidebarBox',
     'generateStickyHeadingContainer',
     'transformContent',
   ],
@@ -73,11 +74,11 @@ export default {
     relations.stickyHeadingContainer =
       relation('generateStickyHeadingContainer');
 
-    relations.leftSidebar =
+    relations.sidebar =
       relation('generatePageSidebar');
 
-    relations.rightSidebar =
-      relation('generatePageSidebar');
+    relations.sidebarBox =
+      relation('generatePageSidebarBox');
 
     if (sprawl.footerContent) {
       relations.defaultFooterContent =
@@ -409,7 +410,7 @@ export default {
         ]);
 
     const applyLegacySidebarSlots = (side, id) =>
-      relations[side].slots({
+      relations.sidebar.clone().slots({
         content: slots[side + 'Content'],
 
         attributes: [
@@ -418,16 +419,15 @@ export default {
             {class: slots[side + 'Class']},
         ],
 
-        multipleContents:
+        boxes:
           (slots[side + 'Multiple']
-            ? slots[side + 'Multiple']
-                .map(({content}) => content)
-            : null),
-
-        multipleAttributes:
-          (slots[side + 'Multiple']
-            ? slots[side + 'Multiple']
-                .map(({class: className}) => [{class: className}])
+            ? slots[side + 'Multiple'].map(box =>
+                relations.sidebarBox
+                  .clone()
+                  .slots({
+                    content: box.content,
+                    attributes: {class: box.class},
+                  }))
             : null),
 
         stickyMode: slots[side + 'StickyMode'],

--- a/src/content/dependencies/generatePageSidebar.js
+++ b/src/content/dependencies/generatePageSidebar.js
@@ -1,0 +1,121 @@
+import {empty, filterMultipleArrays, stitchArrays} from '#sugar';
+
+export default {
+  extraDependencies: ['html'],
+
+  slots: {
+    // Content is a flat HTML array. It'll generate one sidebar section
+    // if specified.
+    content: {
+      type: 'html',
+      mutable: false,
+    },
+
+    // Attributes to apply to the whole sidebar. If specifying multiple
+    // sections, this be added to the containing sidebar-column, arr - specify
+    // attributes on each section if that's more suitable.
+    attributes: {
+      type: 'attributes',
+      mutable: false,
+    },
+
+    // Chunks of content to be split into separate sections or "boxes" in the
+    // sidebar. Each of these can also be associated with HTML attributes.
+    multipleContents: {
+      validate: v => v.strictArrayOf(v.isHTML),
+    },
+
+    multipleAttributes: {
+      validate: v => v.strictArrayOf(v.isAttributes),
+    },
+
+    // Sticky mode controls which sidebar sections, if any, follow the
+    // scroll position, "sticking" to the top of the browser viewport.
+    //
+    // 'last' - last or only sidebar box is sticky
+    // 'column' - entire column, incl. multiple boxes from top, is sticky
+    // 'static' - sidebar not sticky at all, stays at top of page
+    //
+    // Note: This doesn't affect the content of any sidebar section, only
+    // the whole section's containing box (or the sidebar column as a whole).
+    stickyMode: {
+      validate: v => v.is('last', 'column', 'static'),
+      default: 'static',
+    },
+
+    // Collapsing sidebars disappear when the viewport is sufficiently
+    // thin. (This is the default.) Override as false to make the sidebar
+    // stay visible in thinner viewports, where the page layout will be
+    // reflowed so the sidebar is as wide as the screen and appears below
+    // nav, above the main content.
+    collapse: {
+      type: 'boolean',
+      default: true,
+    },
+
+    // Wide sidebars generally take up more horizontal space in the normal
+    // page layout, and should be used if the content of the sidebar has
+    // a greater than typical focus compared to main content.
+    wide: {
+      type: 'boolean',
+      default: false,
+    },
+  },
+
+  generate(slots, {html}) {
+    const attributes =
+      html.attributes({class: 'sidebar-column'});
+
+    attributes.add(slots.attributes);
+
+    if (slots.class) {
+      attributes.add('class', slots.class);
+    }
+
+    if (slots.wide) {
+      attributes.add('class', 'wide');
+    }
+
+    if (!slots.collapse) {
+      attributes.add('class', 'no-hide');
+    }
+
+    if (slots.stickyMode !== 'static') {
+      attributes.add('class', `sticky-${slots.stickyMode}`);
+    }
+
+    let content = slots.content;
+
+    if (html.isBlank(content)) {
+      if (!slots.multipleContents) {
+        return html.blank();
+      }
+
+      const multipleContents = slots.multipleContents.slice();
+      const multipleAttributes = slots.multipleAttributes?.slice() ?? [];
+
+      filterMultipleArrays(
+        multipleContents,
+        multipleAttributes,
+        content => !html.isBlank(content));
+
+      if (empty(multipleContents)) {
+        return html.blank();
+      }
+
+      attributes.add('class', 'sidebar-multiple');
+      content =
+        stitchArrays({
+          content: multipleContents,
+          attributes: multipleAttributes,
+        }).map(({content, attributes}) =>
+            html.tag('div', {class: 'sidebar'},
+              attributes,
+              content));
+    } else {
+      attributes.add('class', 'sidebar');
+    }
+
+    return html.tag('div', attributes, content);
+  },
+};

--- a/src/content/dependencies/generatePageSidebarBox.js
+++ b/src/content/dependencies/generatePageSidebarBox.js
@@ -1,0 +1,20 @@
+export default {
+  extraDependencies: ['html'],
+
+  slots: {
+    content: {
+      type: 'html',
+      mutable: false,
+    },
+
+    attributes: {
+      type: 'attributes',
+      mutable: false,
+    },
+  },
+
+  generate: (slots, {html}) =>
+    html.tag('div', {class: 'sidebar'},
+      slots.attributes,
+      slots.content),
+};

--- a/src/content/dependencies/generatePageSidebarConjoinedBox.js
+++ b/src/content/dependencies/generatePageSidebarConjoinedBox.js
@@ -1,0 +1,42 @@
+// This component is kind of unfortunately magical. It reads the content of
+// various boxes and joins them together, discarding the boxes' attributes.
+// Since it requires access to the actual box *templates* (rather than those
+// templates' resolved content), take care when slotting into this.
+
+export default {
+  contentDependencies: ['generatePageSidebarBox'],
+  extraDependencies: ['html'],
+
+  relations: (relation) => ({
+    box:
+      relation('generatePageSidebarBox'),
+  }),
+
+  slots: {
+    attributes: {
+      type: 'attributes',
+      mutable: false,
+    },
+
+    boxes: {
+      validate: v => v.looseArrayOf(v.isTemplate),
+    },
+  },
+
+  generate: (relations, slots, {html}) =>
+    relations.box.slots({
+      attributes: slots.attributes,
+      content:
+        slots.boxes.slice()
+          .map(box => box.getSlotValue('content'))
+          .map((content, index, {length}) => [
+            content,
+            index < length - 1 &&
+              html.tag('hr', {
+                style:
+                  `border-color: var(--primary-color); ` +
+                  `border-style: none none dotted none`,
+              }),
+          ]),
+    }),
+};

--- a/src/content/dependencies/generateTrackInfoPage.js
+++ b/src/content/dependencies/generateTrackInfoPage.js
@@ -595,7 +595,7 @@ export default {
             ],
           }),
 
-        ...relations.sidebar,
+        leftSidebar: relations.sidebar,
 
         socialEmbed: relations.socialEmbed,
       });

--- a/src/content/dependencies/generateWikiHomeNewsBox.js
+++ b/src/content/dependencies/generateWikiHomeNewsBox.js
@@ -1,48 +1,51 @@
 import {empty, stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: ['linkNewsEntry', 'transformContent'],
+  contentDependencies: [
+    'generatePageSidebarBox',
+    'linkNewsEntry',
+    'transformContent',
+  ],
+
   extraDependencies: ['html', 'language', 'wikiData'],
 
-  sprawl({newsData}) {
-    return {
-      entries: newsData.slice(0, 3),
-    };
-  },
+  sprawl: ({newsData}) => ({
+    entries:
+      newsData.slice(0, 3),
+  }),
 
-  relations(relation, sprawl) {
-    return {
-      entryContents:
-        sprawl.entries
-          .map(entry => relation('transformContent', entry.contentShort)),
+  relations: (relation, sprawl) => ({
+    box:
+      relation('generatePageSidebarBox'),
 
-      entryMainLinks:
-        sprawl.entries
-          .map(entry => relation('linkNewsEntry', entry)),
+    entryContents:
+      sprawl.entries
+        .map(entry => relation('transformContent', entry.contentShort)),
 
-      entryReadMoreLinks:
-        sprawl.entries
-          .map(entry =>
-            entry.contentShort !== entry.content &&
-              relation('linkNewsEntry', entry)),
-    };
-  },
+    entryMainLinks:
+      sprawl.entries
+        .map(entry => relation('linkNewsEntry', entry)),
 
-  data(sprawl) {
-    return {
-      entryDates:
-        sprawl.entries
-          .map(entry => entry.date),
-    }
-  },
+    entryReadMoreLinks:
+      sprawl.entries
+        .map(entry =>
+          entry.contentShort !== entry.content &&
+            relation('linkNewsEntry', entry)),
+  }),
+
+  data: (sprawl) => ({
+    entryDates:
+      sprawl.entries
+        .map(entry => entry.date),
+  }),
 
   generate(data, relations, {html, language}) {
     if (empty(relations.entryContents)) {
       return html.blank();
     }
 
-    return {
-      class: 'latest-news-sidebar-box',
+    return relations.box.slots({
+      attributes: {class: 'latest-news-sidebar-box'},
       content: [
         html.tag('h1', language.$('homepage.news.title')),
 
@@ -77,6 +80,6 @@ export default {
                     })),
               ])),
       ],
-    };
+    });
   },
 };

--- a/src/content/dependencies/generateWikiHomePage.js
+++ b/src/content/dependencies/generateWikiHomePage.js
@@ -1,6 +1,8 @@
 export default {
   contentDependencies: [
     'generatePageLayout',
+    'generatePageSidebar',
+    'generatePageSidebarBox',
     'generateWikiHomeAlbumsRow',
     'generateWikiHomeNewsBox',
     'transformContent',
@@ -22,7 +24,13 @@ export default {
     relations.layout =
       relation('generatePageLayout');
 
+    relations.sidebar =
+      relation('generatePageSidebar');
+
     if (homepageLayout.sidebarContent) {
+      relations.customSidebarBox =
+        relation('generatePageSidebarBox');
+
       relations.customSidebarContent =
         relation('transformContent', homepageLayout.sidebarContent);
     }
@@ -69,21 +77,23 @@ export default {
         relations.contentRows,
       ],
 
-      leftSidebarCollapse: false,
-      leftSidebarWide: true,
+      leftSidebar:
+        relations.sidebar.slots({
+          collapse: false,
+          wide: true,
 
-      leftSidebarMultiple: [
-        (relations.customSidebarContent
-          ? {
-              class: 'custom-content-sidebar-box',
-              content:
-                relations.customSidebarContent
-                  .slot('mode', 'multiline'),
-            }
-          : null),
+          boxes: [
+            relations.customSidebarContent &&
+              relations.customSidebarBox.slots({
+                attributes: {class: 'custom-content-sidebar-box'},
+                content:
+                  relations.customSidebarContent
+                    .slot('mode', 'multiline'),
+              }),
 
-        relations.newsSidebarBox ?? null,
-      ],
+            relations.newsSidebarBox,
+          ],
+        }),
 
       navLinkStyle: 'index',
       navLinks: [

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -994,6 +994,12 @@ export class Attributes {
     }
   }
 
+  with(...args) {
+    const clone = this.clone();
+    clone.add(...args);
+    return clone;
+  }
+
   #addMultipleAttributes(attributes) {
     const flatInputAttributes =
       [attributes].flat(Infinity).filter(Boolean);

--- a/tap-snapshots/test/snapshot/generateAlbumSidebarGroupBox.js.test.cjs
+++ b/tap-snapshots/test/snapshot/generateAlbumSidebarGroupBox.js.test.cjs
@@ -6,20 +6,26 @@
  */
 'use strict'
 exports[`test/snapshot/generateAlbumSidebarGroupBox.js > TAP > generateAlbumSidebarGroupBox (snapshot) > basic behavior, mode: album 1`] = `
-<h1><a href="group/vcg/">VCG</a></h1>
-Very cool group.
-<p>Visit on <a href="https://vcg.bandcamp.com/" class="nowrap">Bandcamp</a> or <a href="https://youtube.com/@vcg" class="nowrap">YouTube</a>.</p>
-<p class="group-chronology-link">Next: <a href="album/last/">Last</a></p>
-<p class="group-chronology-link">Previous: <a href="album/first/">First</a></p>
+<div class="sidebar individual-group-sidebar-box">
+    <h1><a href="group/vcg/">VCG</a></h1>
+    Very cool group.
+    <p>Visit on <a class="external-link" href="https://vcg.bandcamp.com/">Bandcamp</a> or <a class="external-link" href="https://youtube.com/@vcg">YouTube</a>.</p>
+    <p class="group-chronology-link">Next: <a href="album/last/">Last</a></p>
+    <p class="group-chronology-link">Previous: <a href="album/first/">First</a></p>
+</div>
 `
 
 exports[`test/snapshot/generateAlbumSidebarGroupBox.js > TAP > generateAlbumSidebarGroupBox (snapshot) > basic behavior, mode: track 1`] = `
-<h1><a href="group/vcg/">VCG</a></h1>
-<p>Visit on <a href="https://vcg.bandcamp.com/" class="nowrap">Bandcamp</a> or <a href="https://youtube.com/@vcg" class="nowrap">YouTube</a>.</p>
+<div class="sidebar individual-group-sidebar-box">
+    <h1><a href="group/vcg/">VCG</a></h1>
+    <p>Visit on <a class="external-link" href="https://vcg.bandcamp.com/">Bandcamp</a> or <a class="external-link" href="https://youtube.com/@vcg">YouTube</a>.</p>
+</div>
 `
 
 exports[`test/snapshot/generateAlbumSidebarGroupBox.js > TAP > generateAlbumSidebarGroupBox (snapshot) > dateless album in mixed group 1`] = `
-<h1><a href="group/vcg/">VCG</a></h1>
-Very cool group.
-<p>Visit on <a href="https://vcg.bandcamp.com/" class="nowrap">Bandcamp</a> or <a href="https://youtube.com/@vcg" class="nowrap">YouTube</a>.</p>
+<div class="sidebar individual-group-sidebar-box">
+    <h1><a href="group/vcg/">VCG</a></h1>
+    Very cool group.
+    <p>Visit on <a class="external-link" href="https://vcg.bandcamp.com/">Bandcamp</a> or <a class="external-link" href="https://youtube.com/@vcg">YouTube</a>.</p>
+</div>
 `

--- a/test/snapshot/generateAlbumSidebarGroupBox.js
+++ b/test/snapshot/generateAlbumSidebarGroupBox.js
@@ -11,6 +11,8 @@ testContentFunctions(t, 'generateAlbumSidebarGroupBox (snapshot)', async (t, eva
   let album, group;
 
   album = {
+    name: 'Middle',
+    directory: 'middle',
     date: new Date('2010-04-13'),
   };
 


### PR DESCRIPTION
This pull request makes some serious refactoring for sidebars!

* We added a new `generatePageSidebar` component (eventually alongside `generatePageSidebarBox`), and incrementally added support for it across pages — in `generatePageLayout`, we wrote a layer to transfer the old slot format into entries on sidebar components! (We removed this at the end, once all the updating was finished.)
* We updated lots of more complex sidebar components to piece themselves together from simpler components! The album sidebar now uses `generateAlbumSidebarGroupBox` in conjunction with `generatePageSidebarConjoinedBox`, and a chunk of its logic is now in `generateAlbumSidebarTrackListBox`. And the flash act sidebar (following up #453) is similarly split in separate components `generateFlashActSidebarCurrentActBox` and `generateFlashActSidebarSideMapBox`!
* We updated all the simpler sidebars to use the new `generatePageSidebar` component, too, of course!

Apart from being a bunch of nice-to-have code cleanup and refactoring, this PR lays groundworks for doing more interesting and complex things with sidebars in general — like making the client JS automatically slot stuff into a box that shows up on all or most pages, for example. So this work is leading into the search frontend, but refactoring will make sidebars more consistent to work with and expand on in general, too!