### PR TITLE
Transform content in additional file descriptions

### DIFF
--- a/src/content/dependencies/generateAdditionalFilesListChunk.js
+++ b/src/content/dependencies/generateAdditionalFilesListChunk.js
@@ -18,29 +18,28 @@ export default {
   },
 
   generate(slots, {html, language}) {
-    const titleParts = ['releaseInfo.additionalFiles.entry'];
-    const titleOptions = {
-      title:
-        html.tag('span', {class: 'group-name'},
-          slots.title),
-    };
-
-    if (!html.isBlank(slots.description)) {
-      titleParts.push('withDescription');
-      titleOptions.description = slots.description;
-    }
-
     const summary =
       html.tag('summary',
         html.tag('span',
-          language.$(...titleParts, titleOptions)));
+          language.$('releaseInfo.additionalFiles.entry', {
+            title:
+              html.tag('span', {class: 'group-name'},
+                slots.title),
+          })));
+
+    const description =
+      html.tag('li', {class: 'entry-description'},
+        {[html.onlyIfContent]: true},
+        slots.description);
+
+    const items =
+      (html.isBlank(slots.items)
+        ? html.tag('li',
+            language.$('releaseInfo.additionalFiles.entry.noFilesAvailable'))
+        : slots.items);
 
     const content =
-      html.tag('ul',
-        (html.isBlank(slots.items)
-          ? html.tag('li',
-              language.$('releaseInfo.additionalFiles.entry.noFilesAvailable'))
-          : slots.items));
+      html.tag('ul', [description, items]);
 
     const details =
       html.tag('details',

--- a/src/content/dependencies/generateAlbumAdditionalFilesList.js
+++ b/src/content/dependencies/generateAlbumAdditionalFilesList.js
@@ -6,6 +6,7 @@ export default {
     'generateAdditionalFilesListChunk',
     'generateAdditionalFilesListChunkItem',
     'linkAlbumAdditionalFile',
+    'transformContent',
   ],
 
   extraDependencies: ['getSizeOfAdditionalFile', 'html', 'urls'],
@@ -17,6 +18,13 @@ export default {
     chunks:
       additionalFiles
         .map(() => relation('generateAdditionalFilesListChunk')),
+
+    chunkDescriptions:
+      additionalFiles
+        .map(({description}) =>
+          (description
+            ? relation('transformContent', description)
+            : null)),
 
     chunkItems:
       additionalFiles
@@ -38,10 +46,6 @@ export default {
       additionalFiles
         .map(({title}) => title),
 
-    chunkDescriptions:
-      additionalFiles
-        .map(({description}) => description ?? null),
-
     chunkItemLocations:
       additionalFiles
         .map(({files}) => files ?? []),
@@ -56,10 +60,13 @@ export default {
       chunks:
         stitchArrays({
           chunk: relations.chunks,
+          description: relations.chunkDescriptions,
           title: data.chunkTitles,
-          description: data.chunkDescriptions,
         }).map(({chunk, title, description}) =>
-            chunk.slots({title, description})),
+            chunk.slots({
+              title,
+              description: description.slot('mode', 'inline'),
+            })),
 
       chunkItems:
         stitchArrays({

--- a/src/content/dependencies/generateAlbumAdditionalFilesList.js
+++ b/src/content/dependencies/generateAlbumAdditionalFilesList.js
@@ -65,7 +65,10 @@ export default {
         }).map(({chunk, title, description}) =>
             chunk.slots({
               title,
-              description: description.slot('mode', 'inline'),
+              description:
+                (description
+                  ? description.slot('mode', 'inline')
+                  : null),
             })),
 
       chunkItems:

--- a/src/data/checks.js
+++ b/src/data/checks.js
@@ -469,6 +469,10 @@ export class ContentNodeError extends Error {
 export function reportContentTextErrors(wikiData, {
   bindFind,
 }) {
+  const additionalFileShape = {
+    description: 'description',
+  };
+
   const commentaryShape = {
     body: 'commentary body',
     artistDisplayText: 'commentary artist display text',
@@ -477,6 +481,7 @@ export function reportContentTextErrors(wikiData, {
 
   const contentTextSpec = [
     ['albumData', {
+      additionalFiles: additionalFileShape,
       commentary: commentaryShape,
     }],
 
@@ -509,8 +514,11 @@ export function reportContentTextErrors(wikiData, {
     }],
 
     ['trackData', {
+      additionalFiles: additionalFileShape,
       commentary: commentaryShape,
       lyrics: '_content',
+      midiProjectFiles: additionalFileShape,
+      sheetMusicFiles: additionalFileShape,
     }],
 
     ['wikiInfo', {

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -1095,6 +1095,16 @@ li > ul {
   margin-bottom: 10px;
 }
 
+.additional-files-list .entry-description {
+  list-style-type: none;
+  max-width: 540px;
+
+  /* This should be margin-bottom, but cascading rules
+   * cause some awkwardness - `#content li` takes precedence.
+   */
+  padding-bottom: 3px;
+}
+
 .group-contributions-table {
   display: inline-block;
 }

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -325,7 +325,7 @@ releaseInfo:
 
     entry:
       _: "{TITLE}"
-      withDescription: "{TITLE}: {DESCRIPTION}"
+
       noFilesAvailable: >-
         There are no files available or listed for this entry.
 

--- a/tap-snapshots/test/snapshot/generateAlbumAdditionalFilesList.js.test.cjs
+++ b/tap-snapshots/test/snapshot/generateAlbumAdditionalFilesList.js.test.cjs
@@ -19,8 +19,9 @@ exports[`test/snapshot/generateAlbumAdditionalFilesList.js > TAP > generateAlbum
     </li>
     <li>
         <details>
-            <summary><span><span class="group-name">Fake Section</span>: No sizes for these files</span></summary>
+            <summary><span><span class="group-name">Fake Section</span></span></summary>
             <ul>
+                <li class="entry-description">No sizes for these files</li>
                 <li><a href="media/album-additional/exciting-album/oops.mp3">oops.mp3</a></li>
                 <li><a href="media/album-additional/exciting-album/Internet%20Explorer.gif">Internet Explorer.gif</a></li>
                 <li><a href="media/album-additional/exciting-album/daisy.mp3">daisy.mp3</a></li>
@@ -29,14 +30,18 @@ exports[`test/snapshot/generateAlbumAdditionalFilesList.js > TAP > generateAlbum
     </li>
     <li>
         <details open>
-            <summary><span><span class="group-name">Empty Section</span>: These files haven&apos;t been made available.</span></summary>
-            <ul><li>There are no files available or listed for this entry.</li></ul>
+            <summary><span><span class="group-name">Empty Section</span></span></summary>
+            <ul>
+                <li class="entry-description">These files haven&#39;t been made available.</li>
+                <li>There are no files available or listed for this entry.</li>
+            </ul>
         </details>
     </li>
     <li>
         <details>
-            <summary><span><span class="group-name">Alternate Covers</span>: This is just an example description.</span></summary>
+            <summary><span><span class="group-name">Alternate Covers</span></span></summary>
             <ul>
+                <li class="entry-description">This is just an example description.</li>
                 <li><a href="media/album-additional/exciting-album/Homestuck_Vol4_alt1.jpg">Homestuck_Vol4_alt1.jpg</a></li>
                 <li><a href="media/album-additional/exciting-album/Homestuck_Vol4_alt2.jpg">Homestuck_Vol4_alt2.jpg</a></li>
                 <li><a href="media/album-additional/exciting-album/Homestuck_Vol4_alt3.jpg">Homestuck_Vol4_alt3.jpg</a></li>

--- a/test/snapshot/generateAlbumAdditionalFilesList.js
+++ b/test/snapshot/generateAlbumAdditionalFilesList.js
@@ -23,7 +23,11 @@ testContentFunctions(t, 'generateAlbumAdditionalFilesList (snapshot)', async (t,
         ?.at(1) ?? null,
   };
 
-  await evaluate.load();
+  await evaluate.load({
+    mock: {
+      image: evaluate.stubContentFunction('image'),
+    },
+  });
 
   const album = new Album();
   album.directory = 'exciting-album';


### PR DESCRIPTION
Couple of user-visible tweaks here for additional file entry descriptions:

* Descriptions are no longer inline with the entry's title; instead, the description is displayed as a `<li>` at the top of the file list. It's styled *without* a bullet (to just look like indented/aligned text), so that it's easier to visually parse the actual file links. It also gets a little bit of extra margin to separate itself from the file list below.
* Descriptions are now treated as proper (inline) content, so content links and such work inside them properly. (These are interactive, so necessitated separating the description from the `<summary>`.)
* Descriptions are also automatically checked for content errors. This conveniently makes use of the same built-in customizable parsing that lets us parse various parts of commentary entries, so no new logic here. Snazzy!
* We *didn't* need to change the validator, which already used `isContentString` here, despite descriptions not otherwise being treated as content!