### PR TITLE
Flash commentary!

### DIFF
--- a/src/content/dependencies/generateFlashInfoPage.js
+++ b/src/content/dependencies/generateFlashInfoPage.js
@@ -2,6 +2,7 @@ import {empty} from '#sugar';
 
 export default {
   contentDependencies: [
+    'generateCommentarySection',
     'generateContentHeading',
     'generateContributionList',
     'generateFlashActSidebar',
@@ -89,6 +90,13 @@ export default {
         relation('generateContributionList', flash.contributorContribs);
     }
 
+    // Section: Artist commentary
+
+    if (flash.commentary) {
+      sections.artistCommentary =
+        relation('generateCommentarySection', flash.commentary);
+    }
+
     return relations;
   },
 
@@ -136,6 +144,19 @@ export default {
                     .map(link => link.slot('context', 'flash'))),
             })),
 
+        html.tag('p',
+          {[html.onlyIfContent]: true},
+          {[html.joinChildren]: html.tag('br')},
+
+          [
+            sec.artistCommentary &&
+              language.$('releaseInfo.readCommentary', {
+                link: html.tag('a',
+                  {href: '#artist-commentary'},
+                  language.$('releaseInfo.readCommentary.link')),
+              }),
+          ]),
+
         sec.featuredTracks && [
           sec.featuredTracks.heading
             .slots({
@@ -158,6 +179,8 @@ export default {
 
           sec.contributors.list,
         ],
+
+        sec.artistCommentary,
       ],
 
       navLinkStyle: 'hierarchical',

--- a/src/data/checks.js
+++ b/src/data/checks.js
@@ -166,6 +166,10 @@ export function filterReferenceErrors(wikiData, {
       commentary: '_commentary',
     }],
 
+    ['flashData', {
+      commentary: '_commentary',
+    }],
+
     ['groupCategoryData', {
       groups: 'group',
     }],
@@ -487,6 +491,10 @@ export function reportContentTextErrors(wikiData, {
 
     ['artistData', {
       contextNotes: '_content',
+    }],
+
+    ['flashData', {
+      commentary: commentaryShape,
     }],
 
     ['flashActData', {

--- a/src/data/things/artist.js
+++ b/src/data/things/artist.js
@@ -220,6 +220,11 @@ export class Artist extends Thing {
       data: 'flashData',
       list: input.value('contributorContribs'),
     }),
+
+    flashesAsCommentator: reverseReferenceList({
+      data: 'flashData',
+      list: input.value('commentatorArtists'),
+    }),
   });
 
   static [Thing.getSerializeDescriptors] = ({

--- a/src/data/things/flash.js
+++ b/src/data/things/flash.js
@@ -20,6 +20,8 @@ import {
 
 import {
   color,
+  commentary,
+  commentatorArtists,
   contentString,
   contributionList,
   directory,
@@ -97,6 +99,8 @@ export class Flash extends Thing {
 
     urls: urls(),
 
+    commentary: commentary(),
+
     // Update only
 
     artistData: wikiData({
@@ -112,6 +116,8 @@ export class Flash extends Thing {
     }),
 
     // Expose only
+
+    commentatorArtists: commentatorArtists(),
 
     act: [
       withFlashAct(),
@@ -166,10 +172,13 @@ export class Flash extends Thing {
       'Cover Art File Extension': {property: 'coverArtFileExtension'},
 
       'Featured Tracks': {property: 'featuredTracks'},
+
       'Contributors': {
         property: 'contributorContribs',
         transform: parseContributors,
       },
+
+      'Commentary': {property: 'commentary'},
 
       'Review Points': {ignore: true},
     },


### PR DESCRIPTION
Adds support for commentary on flashes, which works exactly as you'd expect.

Doesn't add commentary for flash acts — this is a thing we *could* do, but right now flash acts don't have info pages, so there's nowhere to put it just yet.

Lots of cleanup in `generateArtistInfoPageCommentaryChunkedList`, but the essential form and function are basically the same. It was fairly well-suited to adapt to including flashes!

Note that in order to combine albums and flashes, we now run a `sortByDate` as the final pass (to interweave flashes into `sortAlbumsTracksChronologically`-sorted albums and tracks). This is OK because sorting by date is the last step of `sortAlbumsTracksChronologically` anyway, so we aren't altering its resultant sort — but we fundamentally have to make sure we're using compatible kinds of dates. We need to be aware of this if we later make use of `getDate` (e.g. to get the date of a commentary entry rather than the thing itself).