### PR TITLE
Show platform tooltip for images with links in content

### DIFF
--- a/src/content/dependencies/transformContent.js
+++ b/src/content/dependencies/transformContent.js
@@ -266,12 +266,21 @@ export default {
                     {class: 'pixelate'});
 
               if (link) {
-                // TODO: Would be nice to use an external link component here,
-                // just for the title text (ex. "YouTube (opens in new tab)")
                 content =
                   html.tag('a',
                     {href: link},
                     {target: '_blank'},
+
+                    {title:
+                      language.$('misc.external.opensInNewTab', {
+                        link:
+                          language.formatExternalLink(link, {
+                            style: 'platform',
+                          }),
+
+                        annotation:
+                          language.$('misc.external.opensInNewTab.annotation'),
+                      }).toString()},
 
                     content);
               }


### PR DESCRIPTION
Within content like commentary, makes `<img link="https://youtube.com/watch?v=etc">`-type image links display "YouTube (opens in new tab)"-type browser tooltips.
