### PR TITLE
Filter out & warn about mismatched string options

### DIFF
--- a/src/data/things/language.js
+++ b/src/data/things/language.js
@@ -17,6 +17,8 @@ import {
 
 import {externalFunction, flag, name} from '#composite/wiki-properties';
 
+export const languageOptionRegex = /{(?<name>[A-Z0-9_]+)}/g;
+
 export class Language extends Thing {
   static [Thing.getPropertyDescriptors] = () => ({
     // Update & expose
@@ -201,7 +203,7 @@ export class Language extends Thing {
     const output = this.#iterateOverTemplate({
       template: this.strings[key],
 
-      match: /{(?<name>[A-Z0-9_]+)}/g,
+      match: languageOptionRegex,
 
       insert: ({name: optionName}, canceledForming) => {
         if (optionsMap.has(optionName)) {


### PR DESCRIPTION
Development:

* Resolves #438.

Shows a brief warning message when `strings` is computed, if any of the provided values have options which don't line up with inherited strings:

```
Not using es string releaseInfo.listenOn.noLinks:
- Missing options: NAME
Not using fake-lang string releaseInfo.by:
- Missing options: ARTISTS
- Unexpected options: ARTISTSSSS
```

These are consequently filtered out of the returned `strings`, and the corresponding inherited strings are used instead.

Notes:

* If the inherited template is falsy (including if it doesn't exist at all), the provided string is treated as valid no matter its inputs.
* The main way to trigger this is the first time a page in the desired non-default language is loaded, after a language has been loaded or updated. We don't diff changes or anything—all errors will be printed each time on each build, but only for the first page load of a given language (before it's updated).
* Also, if the wiki's default language (English if not customized) *also* has a custom language file, and other languages inherit their strings from that. In this case the default language's strings will be validated — against `strings-default.yaml` — as soon as the build starts. If a string doesn't match *here,* then the built-in `strings-default.yaml` string is what corresponding strings in *other* (non-default) languages will be validated against, too.
  * This ensures custom languages' options always line up with the built-in `strings-default.yaml` language's options.
  * If a custom default language specifies totally new strings, other custom languages are validated against this, so their options will also line up.

Without these changes, mismatched options *in language files* would cause the wiki software to outright fail to generate particular pages, which isn't ideal. (E.g, it prevented making a complete static-build until all string options were up to date.)

Now, this kind of error is preemptively detected and avoided, and a warning shows as soon as any page is loaded in that language. It's not spammy, but it is in your face when it counts! And gets out of your way, otherwise: relevant pages will continue to generate, just with inherited strings used instead.
