### PR TITLE
Cover art dimensions!

### DIFF
--- a/src/content/dependencies/generateAlbumCoverArtwork.js
+++ b/src/content/dependencies/generateAlbumCoverArtwork.js
@@ -12,11 +12,15 @@ export default {
 
     color:
       album.color,
+
+    dimensions:
+      album.coverArtDimensions,
   }),
 
   generate: (data, relations) =>
     relations.coverArtwork.slots({
       path: data.path,
       color: data.color,
+      dimensions: data.dimensions,
     }),
 };

--- a/src/content/dependencies/generateAlbumGalleryPage.js
+++ b/src/content/dependencies/generateAlbumGalleryPage.js
@@ -145,6 +145,18 @@ export default {
             : null)),
     ];
 
+    data.dimensions = [
+      (album.hasCoverArt
+        ? album.coverArtDimensions
+        : null),
+
+      ...
+        album.tracks.map(track =>
+          (track.hasUniqueCoverArt
+            ? track.coverArtDimensions
+            : null)),
+    ];
+
     return data;
   },
 
@@ -175,10 +187,12 @@ export default {
                 stitchArrays({
                   image: relations.images,
                   path: data.paths,
+                  dimensions: data.dimensions,
                   name: data.names,
-                }).map(({image, path, name}) =>
+                }).map(({image, path, dimensions, name}) =>
                     image.slots({
                       path,
+                      dimensions,
                       missingSourceContent:
                         language.$('misc.albumGalleryGrid.noCoverArt', {name}),
                     })),

--- a/src/content/dependencies/generateArtTagGalleryPage.js
+++ b/src/content/dependencies/generateArtTagGalleryPage.js
@@ -74,6 +74,9 @@ export default {
           ? ['media.trackCover', thing.album.directory, thing.directory, thing.coverArtFileExtension]
           : ['media.albumCover', thing.directory, thing.coverArtFileExtension]));
 
+    data.dimensions =
+      query.things.map(thing => thing.coverArtDimensions);
+
     data.coverArtists =
       query.things.map(thing =>
         thing.coverArtistContribs
@@ -111,8 +114,12 @@ export default {
                 stitchArrays({
                   image: relations.images,
                   path: data.paths,
-                }).map(({image, path}) =>
-                    image.slot('path', path)),
+                  dimensions: data.dimensions,
+                }).map(({image, path, dimensions}) =>
+                    image.slots({
+                      path,
+                      dimensions,
+                    })),
 
               info:
                 data.coverArtists.map(names =>

--- a/src/content/dependencies/generateArtistGalleryPage.js
+++ b/src/content/dependencies/generateArtistGalleryPage.js
@@ -68,6 +68,9 @@ export default {
           ? ['media.trackCover', thing.album.directory, thing.directory, thing.coverArtFileExtension]
           : ['media.albumCover', thing.directory, thing.coverArtFileExtension]));
 
+    data.dimensions =
+      query.things.map(thing => thing.coverArtDimensions);
+
     data.otherCoverArtists =
       query.things.map(thing =>
         (thing.coverArtistContribs.length > 1
@@ -107,8 +110,12 @@ export default {
                 stitchArrays({
                   image: relations.images,
                   path: data.paths,
-                }).map(({image, path}) =>
-                    image.slot('path', path)),
+                  dimensions: data.dimensions,
+                }).map(({image, path, dimensions}) =>
+                    image.slots({
+                      path,
+                      dimensions,
+                    })),
 
               info:
                 data.otherCoverArtists.map(names =>

--- a/src/content/dependencies/generateCoverArtwork.js
+++ b/src/content/dependencies/generateCoverArtwork.js
@@ -59,9 +59,23 @@ export default {
       validate: v => v.is('primary', 'thumbnail', 'commentary'),
       default: 'primary',
     },
+
+    dimensions: {
+      validate: v => v.isDimensions,
+    },
   },
 
   generate(data, relations, slots, {html}) {
+    const square =
+      (slots.dimensions
+        ? slots.dimensions[0] === slots.dimensions[1]
+        : true);
+
+    const sizeSlots =
+      (square
+        ? {square: true}
+        : {width: slots.dimensions[0], height: slots.dimensions[1]});
+
     switch (slots.mode) {
       case 'primary':
         return html.tags([
@@ -72,7 +86,7 @@ export default {
             thumb: 'medium',
             reveal: true,
             link: true,
-            square: true,
+            ...sizeSlots,
           }),
 
           !empty(relations.tagLinks) &&
@@ -93,7 +107,7 @@ export default {
           thumb: 'small',
           reveal: false,
           link: false,
-          square: true,
+          ...sizeSlots,
         });
 
       case 'commentary':
@@ -104,8 +118,8 @@ export default {
           thumb: 'medium',
           reveal: true,
           link: true,
-          square: true,
           lazy: true,
+          ...sizeSlots,
 
           attributes:
             {class: 'commentary-art'},

--- a/src/content/dependencies/generateCoverArtwork.js
+++ b/src/content/dependencies/generateCoverArtwork.js
@@ -74,7 +74,7 @@ export default {
     const sizeSlots =
       (square
         ? {square: true}
-        : {width: slots.dimensions[0], height: slots.dimensions[1]});
+        : {dimensions: slots.dimensions});
 
     switch (slots.mode) {
       case 'primary':

--- a/src/content/dependencies/generateTrackCoverArtwork.js
+++ b/src/content/dependencies/generateTrackCoverArtwork.js
@@ -17,12 +17,18 @@ export default {
 
     color:
       track.color,
+
+    dimensions:
+      (track.hasUniqueCoverArt
+        ? track.coverArtDimensions
+        : track.album.coverArtDimensions),
   }),
 
   generate: (data, relations) =>
     relations.coverArtwork.slots({
       path: data.path,
       color: data.color,
+      dimensions: data.dimensions,
     }),
 };
 

--- a/src/content/dependencies/image.js
+++ b/src/content/dependencies/image.js
@@ -69,8 +69,6 @@ export default {
     },
 
     alt: {type: 'string'},
-    width: {type: 'number'},
-    height: {type: 'number'},
 
     attributes: {
       type: 'attributes',
@@ -139,8 +137,13 @@ export default {
       !isMissingImageFile &&
       !empty(contentWarnings);
 
+    const hasBothDimensions =
+      !!(slots.dimensions &&
+         slots.dimensions[0] !== null &&
+         slots.dimensions[1] !== null);
+
     const willSquare =
-      (slots.dimensions
+      (hasBothDimensions
         ? slots.dimensions[0] === slots.dimensions[1]
         : slots.square);
 
@@ -148,8 +151,12 @@ export default {
       {class: 'image'},
 
       slots.alt && {alt: slots.alt},
-      slots.width && {width: slots.width},
-      slots.height && {height: slots.height},
+
+      slots.dimensions?.[0] &&
+        {width: slots.dimensions[0]},
+
+      slots.dimensions?.[1] &&
+        {width: slots.dimensions[1]},
     ]);
 
     const isPlaceholder =

--- a/src/content/dependencies/image.js
+++ b/src/content/dependencies/image.js
@@ -235,11 +235,9 @@ export default {
           to('thumb.path', mediaSrcJpeg);
       }
 
-      const dimensions = getDimensionsOfImagePath(mediaSrc);
-      const availableThumbs = getThumbnailsAvailableForDimensions(dimensions);
-
-      const [width, height] = dimensions;
-      const originalLength = Math.max(width, height)
+      const originalDimensions = getDimensionsOfImagePath(mediaSrc);
+      const availableThumbs = getThumbnailsAvailableForDimensions(originalDimensions);
+      const originalLength = Math.max(originalDimensions[0], originalDimensions[1]);
 
       const fileSize =
         (willLink && mediaSrc

--- a/src/content/dependencies/image.js
+++ b/src/content/dependencies/image.js
@@ -61,7 +61,12 @@ export default {
 
     reveal: {type: 'boolean', default: true},
     lazy: {type: 'boolean', default: false},
+
     square: {type: 'boolean', default: false},
+
+    dimensions: {
+      validate: v => v.isDimensions,
+    },
 
     alt: {type: 'string'},
     width: {type: 'number'},
@@ -134,7 +139,10 @@ export default {
       !isMissingImageFile &&
       !empty(contentWarnings);
 
-    const willSquare = slots.square;
+    const willSquare =
+      (slots.dimensions
+        ? slots.dimensions[0] === slots.dimensions[1]
+        : slots.square);
 
     const imgAttributes = html.attributes([
       {class: 'image'},

--- a/src/content/dependencies/transformContent.js
+++ b/src/content/dependencies/transformContent.js
@@ -294,6 +294,25 @@ export default {
 
             const image = relations.images[imageIndex++];
 
+            image.setSlots({
+              src,
+
+              link: link ?? true,
+              warnings: warnings ?? null,
+              thumb: slots.thumb,
+            });
+
+            if (width || height) {
+              image.setSlot('dimensions', [width ?? null, height ?? null]);
+            }
+
+            image.setSlot('attributes', [
+              {class: 'content-image'},
+
+              pixelate &&
+                {class: 'pixelate'},
+            ]);
+
             return {
               type: 'processed-image',
               inline: false,
@@ -302,22 +321,7 @@ export default {
                   align === 'center' &&
                     {class: 'align-center'},
 
-                  image.slots({
-                    src,
-
-                    link: link ?? true,
-                    width: width ?? null,
-                    height: height ?? null,
-                    warnings: warnings ?? null,
-                    thumb: slots.thumb,
-
-                    attributes: [
-                      {class: 'content-image'},
-
-                      pixelate &&
-                        {class: 'pixelate'},
-                    ],
-                  })),
+                  image),
             };
           }
 

--- a/src/data/things/album.js
+++ b/src/data/things/album.js
@@ -92,6 +92,11 @@ export class Album extends Thing {
       simpleString(),
     ],
 
+    coverArtDimensions: [
+      exitWithoutContribs({contribs: 'coverArtistContribs'}),
+      dimensions(),
+    ],
+
     bannerDimensions: [
       exitWithoutContribs({contribs: 'bannerArtistContribs'}),
       dimensions(),
@@ -260,6 +265,11 @@ export class Album extends Thing {
 
       'Cover Art File Extension': {property: 'coverArtFileExtension'},
       'Track Art File Extension': {property: 'trackCoverArtFileExtension'},
+
+      'Cover Art Dimensions': {
+        property: 'coverArtDimensions',
+        transform: parseDimensions,
+      },
 
       'Wallpaper Artists': {
         property: 'wallpaperArtistContribs',

--- a/src/data/things/track.js
+++ b/src/data/things/track.js
@@ -13,6 +13,7 @@ import {
   parseAdditionalNames,
   parseContributors,
   parseDate,
+  parseDimensions,
   parseDuration,
 } from '#yaml';
 
@@ -34,6 +35,7 @@ import {
   commentatorArtists,
   contentString,
   contributionList,
+  dimensions,
   directory,
   duration,
   flag,
@@ -156,6 +158,11 @@ export class Track extends Thing {
       }),
 
       exposeDependency({dependency: '#album.trackArtDate'}),
+    ],
+
+    coverArtDimensions: [
+      exitWithoutUniqueCoverArt(),
+      dimensions(),
     ],
 
     commentary: commentary(),
@@ -388,6 +395,11 @@ export class Track extends Thing {
       },
 
       'Cover Art File Extension': {property: 'coverArtFileExtension'},
+
+      'Cover Art Dimensions': {
+        property: 'coverArtDimensions',
+        transform: parseDimensions,
+      },
 
       'Has Cover Art': {
         property: 'disableUniqueCoverArt',

--- a/src/data/validators.js
+++ b/src/data/validators.js
@@ -643,10 +643,15 @@ export function isDimensions(dimensions) {
 
   if (dimensions.length !== 2) throw new TypeError(`Expected 2 item array`);
 
-  isPositive(dimensions[0]);
-  isInteger(dimensions[0]);
-  isPositive(dimensions[1]);
-  isInteger(dimensions[1]);
+  if (dimensions[0] !== null) {
+    isPositive(dimensions[0]);
+    isInteger(dimensions[0]);
+  }
+
+  if (dimensions[1] !== null) {
+    isPositive(dimensions[1]);
+    isInteger(dimensions[1]);
+  }
 
   return true;
 }


### PR DESCRIPTION
Adds support for presenting cover art as a rectangle instead of a square, by using a new field `Cover Art Dimensions`. This is opt-in: we *don't* process the dimensions of actual image files (nor consider the dimensions saved in the thumbnail cache), and we *don't* alter the behavior for any rectangle source images which aren't yet associated with `Cover Art Dimensions`.

Looks like you'd expect!

<img width="829" alt="Album page for Jade Tower, with a wide rectangular cover art—it's effectively shorter than a square cover art would be here. Tags are displayed beneath the artwork as usual." src="https://github.com/hsmusic/hsmusic-wiki/assets/9948030/cfd7abee-d4ac-4c2a-a4f3-3e049764f359">

Generally supported in the various gallery pages, `image`, and `generateCoverArtwork`.