### PR TITLE
Show secondary nav bar on track info page

### DIFF
--- a/src/content/dependencies/generateAlbumSecondaryNav.js
+++ b/src/content/dependencies/generateAlbumSecondaryNav.js
@@ -102,7 +102,7 @@ export default {
   generate(relations, slots, {html, language}) {
     const navLinksShouldShowPreviousNext =
       (slots.mode === 'track'
-        ? Array.from(relations.previousNextLinks, () => false)
+        ? Array.from(relations.previousNextLinks ?? [], () => false)
         : stitchArrays({
             previousAlbumLink: relations.previousAlbumLinks ?? null,
             nextAlbumLink: relations.nextAlbumLinks ?? null,

--- a/src/content/dependencies/generateAlbumSecondaryNav.js
+++ b/src/content/dependencies/generateAlbumSecondaryNav.js
@@ -59,11 +59,11 @@ export default {
       relation('generateSecondaryNav');
 
     relations.groupLinks =
-      album.groups
+      query.groups
         .map(group => relation('linkGroup', group));
 
     relations.colorStyles =
-      album.groups
+      query.groups
         .map(group => relation('generateColorStyleAttribute', group.color));
 
     if (album.date) {

--- a/src/content/dependencies/generateTrackInfoPage.js
+++ b/src/content/dependencies/generateTrackInfoPage.js
@@ -10,6 +10,7 @@ export default {
     'generateAdditionalFilesShortcut',
     'generateAlbumAdditionalFilesList',
     'generateAlbumNavAccent',
+    'generateAlbumSecondaryNav',
     'generateAlbumSidebar',
     'generateAlbumStyleRules',
     'generateChronologyLinks',
@@ -111,6 +112,9 @@ export default {
 
     relations.chronologyLinks =
       relation('generateChronologyLinks');
+
+    relations.secondaryNav =
+      relation('generateAlbumSecondaryNav', track.album);
 
     relations.sidebar =
       relation('generateAlbumSidebar', track.album, track);
@@ -594,6 +598,10 @@ export default {
               },
             ],
           }),
+
+        secondaryNav:
+          relations.secondaryNav
+            .slot('mode', 'track'),
 
         leftSidebar: relations.sidebar,
 


### PR DESCRIPTION
Well this is overdue.

Cherry-picked from #457 with some clean-up. Includes a couple bug fixes, and adds the album secondary nav to track info pages. (This has been supported, but unused, since the start: 073d9377d63eebf5eafbee41a8097f0bb94b13ef)