### PR TITLE
Add isThing/validateThing, and miscellaneous related

### DIFF
--- a/src/data/thing.js
+++ b/src/data/thing.js
@@ -17,6 +17,22 @@ export default class Thing extends CacheableObject {
   static yamlDocumentSpec = Symbol.for('Thing.yamlDocumentSpec');
   static getYamlLoadingSpec = Symbol.for('Thing.getYamlLoadingSpec');
 
+  static isThingConstructor = Symbol.for('Thing.isThingConstructor');
+  static isThing = Symbol.for('Thing.isThing');
+
+  // To detect:
+  // Symbol.for('Thing.isThingConstructor') in constructor
+  static [Symbol.for('Thing.isThingConstructor')] = NaN;
+
+  static [CacheableObject.propertyDescriptors] = {
+    // To detect:
+    // Object.hasOwn(object, Symbol.for('Thing.isThing'))
+    [Symbol.for('Thing.isThing')]: {
+      flags: {expose: true},
+      expose: {compute: () => NaN},
+    },
+  };
+
   // Default custom inspect function, which may be overridden by Thing
   // subclasses. This will be used when displaying aggregate errors and other
   // command-line logging - it's the place to provide information useful in

--- a/src/data/things/index.js
+++ b/src/data/things/index.js
@@ -2,10 +2,10 @@ import * as path from 'node:path';
 import {fileURLToPath} from 'node:url';
 
 import {openAggregate, showAggregate} from '#aggregate';
+import CacheableObject from '#cacheable-object';
 import {logError} from '#cli';
 import {compositeFrom} from '#composite';
 import * as serialize from '#serialize';
-
 import Thing from '#thing';
 
 import * as albumClasses from './album.js';
@@ -142,7 +142,7 @@ function evaluatePropertyDescriptors() {
         }
       }
 
-      constructor.propertyDescriptors = results;
+      constructor[CacheableObject.propertyDescriptors] = results;
     },
 
     showFailedClasses(failedClasses) {

--- a/src/data/things/index.js
+++ b/src/data/things/index.js
@@ -142,7 +142,10 @@ function evaluatePropertyDescriptors() {
         }
       }
 
-      constructor[CacheableObject.propertyDescriptors] = results;
+      constructor[CacheableObject.propertyDescriptors] = {
+        ...constructor[CacheableObject.propertyDescriptors] ?? {},
+        ...results,
+      };
     },
 
     showFailedClasses(failedClasses) {

--- a/src/data/validators.js
+++ b/src/data/validators.js
@@ -745,12 +745,31 @@ export function validateReferenceList(type = '') {
   return validateArrayItems(validateReference(type));
 }
 
+export function validateThing({
+  referenceType: expectedReferenceType = '',
+} = {}) {
+  return (thing) => {
+    isThing(thing);
+
+    if (expectedReferenceType) {
+      const {[Symbol.for('Thing.referenceType')]: referenceType} =
+        thing.constructor;
+
+      if (referenceType !== expectedReferenceType) {
+        throw new TypeError(`Expected only ${expectedReferenceType}, got other type: ${referenceType}`);
+      }
+    }
+
+    return true;
+  };
+}
+
 const validateWikiData_cache = {};
 
 export function validateWikiData({
   referenceType = '',
   allowMixedTypes = false,
-}) {
+} = {}) {
   if (referenceType && allowMixedTypes) {
     throw new TypeError(`Don't specify both referenceType and allowMixedTypes`);
   }

--- a/src/data/validators.js
+++ b/src/data/validators.js
@@ -613,6 +613,17 @@ export function isThingClass(thingClass) {
   return true;
 }
 
+export function isThing(thing) {
+  isObject(thing);
+  isFunction(thing.constructor);
+
+  if (!Object.hasOwn(thing.constructor, Symbol.for('Thing.referenceType'))) {
+    throw new TypeError(`Expected a Thing, constructor missing Thing.referenceType`);
+  }
+
+  return true;
+}
+
 export const isContribution = validateProperties({
   artist: isArtistRef,
   annotation: optional(isStringNonEmpty),

--- a/test/unit/data/things/track.js
+++ b/test/unit/data/things/track.js
@@ -248,6 +248,7 @@ t.test(`Track.color`, t => {
   track.albumData = [
     {
       constructor: {[Thing.referenceType]: 'album'},
+      [Thing.isThing]: true,
       color: '#abcdef',
       tracks: [track],
       trackSections: [


### PR DESCRIPTION
Towards #431. Includes a few groundwork changes:

* CacheableObject now supports symbols for property descriptor keys.
* "Plain" property descriptors—the ones which aren't computed in `[Thing.getPropertyDescriptors]`—are now namespaced on a `CacheableObject` symbol.
* "Plain" property descriptors are retained and merged with the computed ones, if specified.
* The basic `Thing` class comes with a default "plain" property descriptor, `[Thing.isThing]`, whose *own-property* presence indicates that a thing is in fact a thing. This is automatically present as an own-property on every instance of every Thing subclass, but only because those subclasses don't override `[CacheableObject.propertyDescriptors]`—if they did, they'd need to explicitly inherit from `Thing[CacheableObject.propertyDescriptors]`.
  * We intend on making property descriptor inheritance (the normal computed ones, rather than "plain" ones) totally automatic, i.e. it'll walk up the prototype chain to merge property descriptors together for an arbitrarily descendant subclass. That's out of scope for this PR, though.

Ostensibly this PR includes "optimizations" for `validateWikiData` based on the above, but they appear to make no difference (they should only affect data linking, which is instant both before and after). We're still filing this because this is the internal interface we'd rather use for identifying whether a thing is a thing; some things don't have reference types, and wouldn't be accepted in `validateWikiData` before (or `validateThing` otherwise).