### PR TITLE
Add input.thisProperty, cacheable object property self-reflection

### DIFF
--- a/src/data/cacheable-object.js
+++ b/src/data/cacheable-object.js
@@ -255,7 +255,8 @@ export default class CacheableObject {
 
     if (expose.dependencies?.length > 0) {
       const dependencyKeys = expose.dependencies.slice();
-      const shouldReflect = dependencyKeys.includes('this');
+      const shouldReflectObject = dependencyKeys.includes('this');
+      const shouldReflectProperty = dependencyKeys.includes('thisProperty');
 
       getAllDependencies = () => {
         const dependencies = Object.create(null);
@@ -264,8 +265,12 @@ export default class CacheableObject {
           dependencies[key] = this.#propertyUpdateValues[key];
         }
 
-        if (shouldReflect) {
+        if (shouldReflectObject) {
           dependencies.this = this;
+        }
+
+        if (shouldReflectProperty) {
+          dependencies.thisProperty = property;
         }
 
         return dependencies;

--- a/src/data/composite.js
+++ b/src/data/composite.js
@@ -29,6 +29,7 @@ input.value = _valueIntoToken('input.value');
 input.dependency = _valueIntoToken('input.dependency');
 
 input.myself = () => Symbol.for(`hsmusic.composite.input.myself`);
+input.thisProperty = () => Symbol.for('hsmusic.composite.input.thisProperty');
 
 input.updateValue = _valueIntoToken('input.updateValue');
 
@@ -284,6 +285,7 @@ export function templateCompositeFrom(description) {
               'input.value',
               'input.dependency',
               'input.myself',
+              'input.thisProperty',
               'input.updateValue',
             ].includes(tokenShape)) {
               expectedValueProvidingTokenInputNames.push(name);
@@ -567,6 +569,8 @@ export function compositeFrom(description) {
             return token;
           case 'input.myself':
             return 'this';
+          case 'input.thisProperty':
+            return 'thisProperty';
           default:
             return null;
         }
@@ -721,6 +725,8 @@ export function compositeFrom(description) {
               return (tokenValue.startsWith('#') ? null : tokenValue);
             case 'input.myself':
               return 'this';
+            case 'input.thisProperty':
+              return 'thisProperty';
             default:
               return null;
           }
@@ -877,6 +883,8 @@ export function compositeFrom(description) {
               return valueSoFar;
             case 'input.myself':
               return initialDependencies['this'];
+            case 'input.thisProperty':
+              return initialDependencies['thisProperty'];
             case 'input':
               return initialDependencies[token];
             default:
@@ -969,6 +977,7 @@ export function compositeFrom(description) {
             ? {[input.updateValue()]: valueSoFar}
             : {}),
         [input.myself()]: initialDependencies?.['this'] ?? null,
+        [input.thisProperty()]: initialDependencies?.['thisProperty'] ?? null,
       };
 
       const selectDependencies =
@@ -983,6 +992,8 @@ export function compositeFrom(description) {
               return dependency;
             case 'input.myself':
               return input.myself();
+            case 'input.thisProperty':
+              return input.thisProperty();
             case 'input.dependency':
               return tokenValue;
             case 'input.updateValue':

--- a/src/data/composite/things/track/index.js
+++ b/src/data/composite/things/track/index.js
@@ -9,3 +9,4 @@ export {default as withContainingTrackSection} from './withContainingTrackSectio
 export {default as withHasUniqueCoverArt} from './withHasUniqueCoverArt.js';
 export {default as withOtherReleases} from './withOtherReleases.js';
 export {default as withPropertyFromAlbum} from './withPropertyFromAlbum.js';
+export {default as withPropertyFromOriginalRelease} from './withPropertyFromOriginalRelease.js';

--- a/src/data/composite/things/track/withPropertyFromOriginalRelease.js
+++ b/src/data/composite/things/track/withPropertyFromOriginalRelease.js
@@ -1,0 +1,86 @@
+// Provides a value inherited from the original release, if applicable, and a
+// flag indicating if this track is a rerelase or not.
+//
+// Like withOriginalRelease, this will early exit (with notFoundValue) if the
+// original release is specified by reference and that reference doesn't
+// resolve to anything.
+
+import {input, templateCompositeFrom} from '#composite';
+
+import {withResultOfAvailabilityCheck} from '#composite/control-flow';
+import {withPropertyFromObject} from '#composite/data';
+
+import withOriginalRelease from './withOriginalRelease.js';
+
+export default templateCompositeFrom({
+  annotation: `inheritFromOriginalRelease`,
+
+  inputs: {
+    property: input({type: 'string'}),
+
+    notFoundValue: input({
+      defaultValue: null,
+    }),
+  },
+
+  outputs: ({
+    [input.staticValue('property')]: property,
+  }) =>
+    ['#isRerelease'].concat(
+      (property
+        ? ['#original.' + property]
+        : ['#originalValue'])),
+
+  steps: () => [
+    withOriginalRelease({
+      notFoundValue: input('notFoundValue'),
+    }),
+
+    withResultOfAvailabilityCheck({
+      from: '#originalRelease',
+    }),
+
+    {
+      dependencies: [
+        '#availability',
+        input.staticValue('property'),
+      ],
+
+      compute: (continuation, {
+        ['#availability']: availability,
+        [input.staticValue('property')]: property,
+      }) =>
+        (availability
+          ? continuation()
+          : continuation.raiseOutput(
+              Object.assign(
+                {'#isRerelease': false},
+                (property
+                  ? {['#original.' + property]: null}
+                  : {'#originalValue': null})))),
+    },
+
+    withPropertyFromObject({
+      object: '#originalRelease',
+      property: input('property'),
+    }),
+
+    {
+      dependencies: [
+        '#value',
+        input.staticValue('property'),
+      ],
+
+      compute: (continuation, {
+        ['#value']: value,
+        [input.staticValue('property')]: property,
+      }) =>
+        continuation.raiseOutput(
+          Object.assign(
+            {'#isRerelease': true},
+            (property
+              ? {['#original.' + property]: value}
+              : {'#originalValue': value}))),
+    },
+  ],
+});

--- a/src/data/things/track.js
+++ b/src/data/things/track.js
@@ -168,10 +168,7 @@ export class Track extends Thing {
     commentary: commentary(),
 
     lyrics: [
-      inheritFromOriginalRelease({
-        property: input.value('lyrics'),
-      }),
-
+      inheritFromOriginalRelease(),
       contentString(),
     ],
 
@@ -196,7 +193,6 @@ export class Track extends Thing {
 
     artistContribs: [
       inheritFromOriginalRelease({
-        property: input.value('artistContribs'),
         notFoundValue: input.value([]),
       }),
 
@@ -220,7 +216,6 @@ export class Track extends Thing {
 
     contributorContribs: [
       inheritFromOriginalRelease({
-        property: input.value('contributorContribs'),
         notFoundValue: input.value([]),
       }),
 
@@ -255,7 +250,6 @@ export class Track extends Thing {
 
     referencedTracks: [
       inheritFromOriginalRelease({
-        property: input.value('referencedTracks'),
         notFoundValue: input.value([]),
       }),
 
@@ -268,7 +262,6 @@ export class Track extends Thing {
 
     sampledTracks: [
       inheritFromOriginalRelease({
-        property: input.value('sampledTracks'),
         notFoundValue: input.value([]),
       }),
 


### PR DESCRIPTION
Towards #431. Adds support for `input.thisProperty()`, corresponding to cacheable-object dependency `'thisProperty'`, which reflects the key for the current property descriptor, no matter what context it's used in. (For example, a compositional step nested fourteen layers deep will still have `input.thisProperty()` reflect the property which, in total, the composition is going to expose its final value on.)

This is made use of in a couple places—mainly `inheritFromOriginalRelease`, in this PR, which no longer needs a `property` manually specified at all. If the step is present, this property inherits from the same property on the original release—that's all there is to it!
