### PR TITLE
Various updates to make tests pass again

### DIFF
--- a/src/content/dependencies/generateAlbumSecondaryNav.js
+++ b/src/content/dependencies/generateAlbumSecondaryNav.js
@@ -151,11 +151,8 @@ export default {
       stitchArrays({
         content: navLinkContents,
         colorStyle: relations.colorStyles,
-      }).map(({content, colorStyle}, index) =>
+      }).map(({content, colorStyle}) =>
           html.tag('span', {class: 'nav-link'},
-            index > 0 &&
-              {class: 'has-divider'},
-
             colorStyle.slot('context', 'primary-only'),
 
             content));

--- a/src/content/dependencies/generatePageLayout.js
+++ b/src/content/dependencies/generatePageLayout.js
@@ -348,9 +348,6 @@ export default {
                     showAsCurrent &&
                       {class: 'current'},
 
-                    i > 0 &&
-                      {class: 'has-divider'},
-
                     [
                       html.tag('span', {class: 'nav-link-content'},
                         // Use inline-block styling on the content span,

--- a/src/content/dependencies/image.js
+++ b/src/content/dependencies/image.js
@@ -1,4 +1,4 @@
-import {logInfo, logWarn} from '#cli';
+import {logWarn} from '#cli';
 import {empty} from '#sugar';
 
 export default {
@@ -118,10 +118,6 @@ export default {
 
     const isMissingImageFile =
       missingImagePaths.includes(mediaSrc);
-
-    if (isMissingImageFile) {
-      logInfo`No image file for ${mediaSrc} - build again for list of missing images.`;
-    }
 
     const willLink =
       !isMissingImageFile &&

--- a/src/data/composite/wiki-data/withReverseContributionList.js
+++ b/src/data/composite/wiki-data/withReverseContributionList.js
@@ -11,7 +11,8 @@
 
 import {input, templateCompositeFrom} from '#composite';
 
-import {exitWithoutDependency} from '#composite/control-flow';
+import {exitWithoutDependency, raiseOutputWithoutDependency}
+  from '#composite/control-flow';
 
 import inputWikiData from './inputWikiData.js';
 
@@ -32,10 +33,17 @@ export default templateCompositeFrom({
   outputs: ['#reverseContributionList'],
 
   steps: () => [
+    // Early exit with an empty array if the data list isn't available.
     exitWithoutDependency({
       dependency: input('data'),
       value: input.value([]),
+    }),
+
+    // Raise an empty array (don't early exit) if the data list is empty.
+    raiseOutputWithoutDependency({
+      dependency: input('data'),
       mode: input.value('empty'),
+      output: input.value({'#reverseContributionList': []}),
     }),
 
     {

--- a/src/data/composite/wiki-data/withReverseReferenceList.js
+++ b/src/data/composite/wiki-data/withReverseReferenceList.js
@@ -13,7 +13,8 @@
 
 import {input, templateCompositeFrom} from '#composite';
 
-import {exitWithoutDependency} from '#composite/control-flow';
+import {exitWithoutDependency, raiseOutputWithoutDependency}
+  from '#composite/control-flow';
 
 import inputWikiData from './inputWikiData.js';
 
@@ -34,10 +35,17 @@ export default templateCompositeFrom({
   outputs: ['#reverseReferenceList'],
 
   steps: () => [
+    // Early exit with an empty array if the data list isn't available.
     exitWithoutDependency({
       dependency: input('data'),
       value: input.value([]),
+    }),
+
+    // Raise an empty array (don't early exit) if the data list is empty.
+    raiseOutputWithoutDependency({
+      dependency: input('data'),
       mode: input.value('empty'),
+      output: input.value({'#reverseReferenceList': []}),
     }),
 
     {

--- a/src/data/composite/wiki-data/withUniqueReferencingThing.js
+++ b/src/data/composite/wiki-data/withUniqueReferencingThing.js
@@ -21,11 +21,10 @@ export default templateCompositeFrom({
   outputs: ['#uniqueReferencingThing'],
 
   steps: () => [
-    // withReverseRefernceList does this check too, but it early exits with
-    // an empty array. That's no good here!
+    // Early exit with null (not an empty array) if the data list
+    // isn't available.
     exitWithoutDependency({
       dependency: input('data'),
-      mode: input.value('empty'),
     }),
 
     withReverseReferenceList({

--- a/src/data/validators.js
+++ b/src/data/validators.js
@@ -443,24 +443,23 @@ for (const entry of illegalContentSpec) {
   }
 }
 
-const illegalContentRegexp =
-  new RegExp(
-    illegalContentSpec
-      .map(entry => entry.illegal)
-      .map(illegal => `${illegal}+`)
-      .join('|'),
-    'g');
-
-const illegalCharactersInContent =
+const illegalSequencesInContent =
   illegalContentSpec
     .map(entry => entry.illegal)
-    .join('');
+    .map(illegal =>
+      (illegal.length === 1
+        ? `${illegal}+`
+        : `(?:${illegal})+`))
+    .join('|');
+
+const illegalContentRegexp =
+  new RegExp(illegalSequencesInContent, 'g');
 
 const legalContentNearEndRegexp =
-  new RegExp(`[^\n${illegalCharactersInContent}]+$`);
+  new RegExp(`(?<=^|${illegalSequencesInContent})(?:(?!${illegalSequencesInContent}).)+$`);
 
 const legalContentNearStartRegexp =
-  new RegExp(`^[^\n${illegalCharactersInContent}]+`);
+  new RegExp(`^(?:(?!${illegalSequencesInContent}).)+`);
 
 const trimWhitespaceNearBothSidesRegexp =
   /^ +| +$/gm;

--- a/src/static/site6.css
+++ b/src/static/site6.css
@@ -488,13 +488,13 @@ a:not([href]):hover {
   display: inline-block;
 }
 
-.nav-links-index .nav-link.has-divider::before,
-.nav-links-groups .nav-link.has-divider::before {
+.nav-links-index .nav-link:not(:first-child)::before,
+.nav-links-groups .nav-link:not(:first-child)::before {
   content: "\0020\00b7\0020";
   font-weight: 800;
 }
 
-.nav-links-hierarchical .nav-link.has-divider::before {
+.nav-links-hierarchical .nav-link:not(:first-child)::before {
   content: "\0020/\0020";
 }
 

--- a/tap-snapshots/test/snapshot/generateAlbumCoverArtwork.js.test.cjs
+++ b/tap-snapshots/test/snapshot/generateAlbumCoverArtwork.js.test.cjs
@@ -15,7 +15,7 @@ exports[`test/snapshot/generateAlbumCoverArtwork.js > TAP > generateAlbumCoverAr
      { name: 'creepy crawlies', isContentWarning: true }
    ]
  ]
- slots: { path: [ 'media.albumCover', 'bee-forus-seatbelt-safebee', 'png' ], color: '#f28514', thumb: 'medium', reveal: true, link: true, square: true }]
+ slots: { path: [ 'media.albumCover', 'bee-forus-seatbelt-safebee', 'png' ], color: '#f28514', thumb: 'medium', reveal: true, link: true, dimensions: [ 400, 300 ] }]
 <ul class="image-details">
     <li><a href="tag/damara/">Damara</a></li>
     <li><a href="tag/cronus/">Cronus</a></li>
@@ -33,5 +33,5 @@ exports[`test/snapshot/generateAlbumCoverArtwork.js > TAP > generateAlbumCoverAr
      { name: 'creepy crawlies', isContentWarning: true }
    ]
  ]
- slots: { path: [ 'media.albumCover', 'bee-forus-seatbelt-safebee', 'png' ], color: '#f28514', thumb: 'small', reveal: false, link: false, square: true }]
+ slots: { path: [ 'media.albumCover', 'bee-forus-seatbelt-safebee', 'png' ], color: '#f28514', thumb: 'small', reveal: false, link: false, dimensions: [ 400, 300 ] }]
 `

--- a/tap-snapshots/test/snapshot/generateAlbumReleaseInfo.js.test.cjs
+++ b/tap-snapshots/test/snapshot/generateAlbumReleaseInfo.js.test.cjs
@@ -10,7 +10,7 @@ exports[`test/snapshot/generateAlbumReleaseInfo.js > TAP > generateAlbumReleaseI
     By <span class="contribution nowrap"><a href="artist/toby-fox/">Toby Fox</a> (music probably)</span> and <span class="contribution nowrap"><span class="text-with-tooltip"><span class="hoverable"><a class="text-with-tooltip-interaction-cue" href="artist/tensei/">Tensei</a></span><span class="tooltip icons icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://tenseimusic.bandcamp.com/">
                         <svg><use href="static/icons.svg#icon-bandcamp"></use></svg>
                         <span class="icon-text">tenseimusic</span>
-                    </a></span></span></span> (hot jams)</span>.
+                    </a><span class="icon-platform">Bandcamp</span></span></span></span> (hot jams)</span>.
     <br>
     Cover art by <a href="artist/hb/">Hanni Brosh</a>.
     <br>
@@ -24,7 +24,7 @@ exports[`test/snapshot/generateAlbumReleaseInfo.js > TAP > generateAlbumReleaseI
     <br>
     Duration: ~10:25.
 </p>
-<p>Listen on <a href="https://homestuck.bandcamp.com/album/alterniabound-with-alternia" class="nowrap">Bandcamp</a>, <a href="https://www.youtube.com/playlist?list=PLnVpmehyaOFZWO9QOZmD6A3TIK0wZ6xE2" class="nowrap">YouTube (playlist)</a>, or <a href="https://www.youtube.com/watch?v=HO5V2uogkYc" class="nowrap">YouTube (full album)</a>.</p>
+<p>Listen on <a class="external-link" href="https://homestuck.bandcamp.com/album/alterniabound-with-alternia">Bandcamp</a>, <a class="external-link" href="https://www.youtube.com/playlist?list=PLnVpmehyaOFZWO9QOZmD6A3TIK0wZ6xE2">YouTube (playlist)</a>, or <a class="external-link" href="https://www.youtube.com/watch?v=HO5V2uogkYc">YouTube (full album)</a>.</p>
 `
 
 exports[`test/snapshot/generateAlbumReleaseInfo.js > TAP > generateAlbumReleaseInfo (snapshot) > equal cover art date 1`] = `
@@ -36,5 +36,5 @@ exports[`test/snapshot/generateAlbumReleaseInfo.js > TAP > generateAlbumReleaseI
 `
 
 exports[`test/snapshot/generateAlbumReleaseInfo.js > TAP > generateAlbumReleaseInfo (snapshot) > URLs only 1`] = `
-<p>Listen on <a href="https://homestuck.bandcamp.com/foo" class="nowrap">Bandcamp</a> or <a href="https://soundcloud.com/bar" class="nowrap">SoundCloud</a>.</p>
+<p>Listen on <a class="external-link" href="https://homestuck.bandcamp.com/foo">Bandcamp</a> or <a class="external-link" href="https://soundcloud.com/bar">SoundCloud</a>.</p>
 `

--- a/tap-snapshots/test/snapshot/generateAlbumSecondaryNav.js.test.cjs
+++ b/tap-snapshots/test/snapshot/generateAlbumSecondaryNav.js.test.cjs
@@ -7,11 +7,11 @@
 'use strict'
 exports[`test/snapshot/generateAlbumSecondaryNav.js > TAP > generateAlbumSecondaryNav (snapshot) > basic behavior, mode: album 1`] = `
 <nav id="secondary-nav" class="nav-links-groups">
-    <span style="--primary-color: #abcdef">
+    <span class="nav-link" style="--primary-color: #abcdef">
         <a href="group/vcg/">VCG</a>
         (<a title="First" href="album/first/">Previous</a>, <a title="Last" href="album/last/">Next</a>)
     </span>
-    <span style="--primary-color: #123456">
+    <span class="nav-link" style="--primary-color: #123456">
         <a href="group/bepis/">Bepis</a>
         (<a title="Second" href="album/second/">Next</a>)
     </span>
@@ -20,14 +20,14 @@ exports[`test/snapshot/generateAlbumSecondaryNav.js > TAP > generateAlbumSeconda
 
 exports[`test/snapshot/generateAlbumSecondaryNav.js > TAP > generateAlbumSecondaryNav (snapshot) > basic behavior, mode: track 1`] = `
 <nav id="secondary-nav" class="nav-links-groups">
-    <a style="--primary-color: #abcdef" href="group/vcg/">VCG</a>
-    <a style="--primary-color: #123456" href="group/bepis/">Bepis</a>
+    <span class="nav-link" style="--primary-color: #abcdef"><a href="group/vcg/">VCG</a></span>
+    <span class="nav-link" style="--primary-color: #123456"><a href="group/bepis/">Bepis</a></span>
 </nav>
 `
 
 exports[`test/snapshot/generateAlbumSecondaryNav.js > TAP > generateAlbumSecondaryNav (snapshot) > dateless album in mixed group 1`] = `
 <nav id="secondary-nav" class="nav-links-groups">
-    <a style="--primary-color: #abcdef" href="group/vcg/">VCG</a>
-    <a style="--primary-color: #123456" href="group/bepis/">Bepis</a>
+    <span class="nav-link" style="--primary-color: #abcdef"><a href="group/vcg/">VCG</a></span>
+    <span class="nav-link" style="--primary-color: #123456"><a href="group/bepis/">Bepis</a></span>
 </nav>
 `

--- a/tap-snapshots/test/snapshot/generateAlbumTrackList.js.test.cjs
+++ b/tap-snapshots/test/snapshot/generateAlbumTrackList.js.test.cjs
@@ -10,7 +10,7 @@ exports[`test/snapshot/generateAlbumTrackList.js > TAP > generateAlbumTrackList 
     <li>(0:20) <a href="track/t1/">Track 1</a></li>
     <li>[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t2/">Track 2</a></li>
     <li>(0:40) <a href="track/t3/">Track 3</a></li>
-    <li style="--primary-color: #ea2e83">[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t4/">Track 4</a> <span class="by">by <a href="artist/apricot/">Apricot</a> and <a href="artist/peach/">Peach</a></span></li>
+    <li style="--primary-color: #ea2e83">[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t4/">Track 4</a> <span class="by"><span class="chunkwrap">by <a href="artist/apricot/">Apricot</a>,</span> <span class="chunkwrap"><a href="artist/peach/">Peach</a>,</span> <span class="chunkwrap">and <a href="artist/cerise/">Cerise</a></span></span></li>
 </ul>
 `
 
@@ -25,7 +25,7 @@ exports[`test/snapshot/generateAlbumTrackList.js > TAP > generateAlbumTrackList 
         </ul>
     </dd>
     <dt class="content-heading" tabindex="0"><span class="content-heading-main-title">Second section:</span></dt>
-    <dd><ul><li style="--primary-color: #ea2e83">[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t4/">Track 4</a> <span class="by">by <a href="artist/apricot/">Apricot</a> and <a href="artist/peach/">Peach</a></span></li></ul></dd>
+    <dd><ul><li style="--primary-color: #ea2e83">[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t4/">Track 4</a> <span class="by"><span class="chunkwrap">by <a href="artist/apricot/">Apricot</a>,</span> <span class="chunkwrap"><a href="artist/peach/">Peach</a>,</span> <span class="chunkwrap">and <a href="artist/cerise/">Cerise</a></span></span></li></ul></dd>
 </dl>
 `
 
@@ -40,17 +40,17 @@ exports[`test/snapshot/generateAlbumTrackList.js > TAP > generateAlbumTrackList 
         </ul>
     </dd>
     <dt class="content-heading" tabindex="0"><span class="content-heading-main-title">Second section:</span></dt>
-    <dd><ul><li style="--primary-color: #ea2e83">[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t4/">Track 4</a> <span class="by">by <a href="artist/apricot/">Apricot</a> and <a href="artist/peach/">Peach</a></span></li></ul></dd>
+    <dd><ul><li style="--primary-color: #ea2e83">[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t4/">Track 4</a> <span class="by"><span class="chunkwrap">by <a href="artist/apricot/">Apricot</a>,</span> <span class="chunkwrap"><a href="artist/peach/">Peach</a>,</span> <span class="chunkwrap">and <a href="artist/cerise/">Cerise</a></span></span></li></ul></dd>
 </dl>
 <ul>
     <li>(0:20) <a href="track/t1/">Track 1</a></li>
     <li>[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t2/">Track 2</a></li>
     <li>(0:40) <a href="track/t3/">Track 3</a></li>
-    <li style="--primary-color: #ea2e83">[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t4/">Track 4</a> <span class="by">by <a href="artist/apricot/">Apricot</a> and <a href="artist/peach/">Peach</a></span></li>
+    <li style="--primary-color: #ea2e83">[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t4/">Track 4</a> <span class="by"><span class="chunkwrap">by <a href="artist/apricot/">Apricot</a>,</span> <span class="chunkwrap"><a href="artist/peach/">Peach</a>,</span> <span class="chunkwrap">and <a href="artist/cerise/">Cerise</a></span></span></li>
 </ul>
 <ul>
     <li><a href="track/t2/">Track 2</a></li>
-    <li style="--primary-color: #ea2e83"><a href="track/t4/">Track 4</a> <span class="by">by <a href="artist/apricot/">Apricot</a> and <a href="artist/peach/">Peach</a></span></li>
+    <li style="--primary-color: #ea2e83"><a href="track/t4/">Track 4</a> <span class="by"><span class="chunkwrap">by <a href="artist/apricot/">Apricot</a>,</span> <span class="chunkwrap"><a href="artist/peach/">Peach</a>,</span> <span class="chunkwrap">and <a href="artist/cerise/">Cerise</a></span></span></li>
 </ul>
 `
 
@@ -65,17 +65,17 @@ exports[`test/snapshot/generateAlbumTrackList.js > TAP > generateAlbumTrackList 
         </ul>
     </dd>
     <dt class="content-heading" tabindex="0"><span class="content-heading-main-title">Second section:</span></dt>
-    <dd><ul><li style="--primary-color: #ea2e83">[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t4/">Track 4</a> <span class="by">by <a href="artist/apricot/">Apricot</a> and <a href="artist/peach/">Peach</a></span></li></ul></dd>
+    <dd><ul><li style="--primary-color: #ea2e83">[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t4/">Track 4</a> <span class="by"><span class="chunkwrap">by <a href="artist/apricot/">Apricot</a>,</span> <span class="chunkwrap"><a href="artist/peach/">Peach</a>,</span> <span class="chunkwrap">and <a href="artist/cerise/">Cerise</a></span></span></li></ul></dd>
 </dl>
 <ul>
     <li>(0:20) <a href="track/t1/">Track 1</a></li>
     <li>[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t2/">Track 2</a></li>
     <li>(0:40) <a href="track/t3/">Track 3</a></li>
-    <li style="--primary-color: #ea2e83">[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t4/">Track 4</a> <span class="by">by <a href="artist/apricot/">Apricot</a> and <a href="artist/peach/">Peach</a></span></li>
+    <li style="--primary-color: #ea2e83">[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t4/">Track 4</a> <span class="by"><span class="chunkwrap">by <a href="artist/apricot/">Apricot</a>,</span> <span class="chunkwrap"><a href="artist/peach/">Peach</a>,</span> <span class="chunkwrap">and <a href="artist/cerise/">Cerise</a></span></span></li>
 </ul>
 <ul>
     <li>[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t2/">Track 2</a></li>
-    <li style="--primary-color: #ea2e83">[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t4/">Track 4</a> <span class="by">by <a href="artist/apricot/">Apricot</a> and <a href="artist/peach/">Peach</a></span></li>
+    <li style="--primary-color: #ea2e83">[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t4/">Track 4</a> <span class="by"><span class="chunkwrap">by <a href="artist/apricot/">Apricot</a>,</span> <span class="chunkwrap"><a href="artist/peach/">Peach</a>,</span> <span class="chunkwrap">and <a href="artist/cerise/">Cerise</a></span></span></li>
 </ul>
 `
 
@@ -90,17 +90,17 @@ exports[`test/snapshot/generateAlbumTrackList.js > TAP > generateAlbumTrackList 
         </ul>
     </dd>
     <dt class="content-heading" tabindex="0"><span class="content-heading-main-title">Second section:</span></dt>
-    <dd><ul><li style="--primary-color: #ea2e83"><a href="track/t4/">Track 4</a> <span class="by">by <a href="artist/apricot/">Apricot</a> and <a href="artist/peach/">Peach</a></span></li></ul></dd>
+    <dd><ul><li style="--primary-color: #ea2e83"><a href="track/t4/">Track 4</a> <span class="by"><span class="chunkwrap">by <a href="artist/apricot/">Apricot</a>,</span> <span class="chunkwrap"><a href="artist/peach/">Peach</a>,</span> <span class="chunkwrap">and <a href="artist/cerise/">Cerise</a></span></span></li></ul></dd>
 </dl>
 <ul>
     <li>(0:20) <a href="track/t1/">Track 1</a></li>
     <li>[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t2/">Track 2</a></li>
     <li>(0:40) <a href="track/t3/">Track 3</a></li>
-    <li style="--primary-color: #ea2e83">[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t4/">Track 4</a> <span class="by">by <a href="artist/apricot/">Apricot</a> and <a href="artist/peach/">Peach</a></span></li>
+    <li style="--primary-color: #ea2e83">[mocked: generateAlbumTrackListMissingDuration - slots: {}] <a href="track/t4/">Track 4</a> <span class="by"><span class="chunkwrap">by <a href="artist/apricot/">Apricot</a>,</span> <span class="chunkwrap"><a href="artist/peach/">Peach</a>,</span> <span class="chunkwrap">and <a href="artist/cerise/">Cerise</a></span></span></li>
 </ul>
 <ul>
     <li><a href="track/t2/">Track 2</a></li>
-    <li style="--primary-color: #ea2e83"><a href="track/t4/">Track 4</a> <span class="by">by <a href="artist/apricot/">Apricot</a> and <a href="artist/peach/">Peach</a></span></li>
+    <li style="--primary-color: #ea2e83"><a href="track/t4/">Track 4</a> <span class="by"><span class="chunkwrap">by <a href="artist/apricot/">Apricot</a>,</span> <span class="chunkwrap"><a href="artist/peach/">Peach</a>,</span> <span class="chunkwrap">and <a href="artist/cerise/">Cerise</a></span></span></li>
 </ul>
 `
 
@@ -115,16 +115,16 @@ exports[`test/snapshot/generateAlbumTrackList.js > TAP > generateAlbumTrackList 
         </ul>
     </dd>
     <dt class="content-heading" tabindex="0"><span class="content-heading-main-title">Second section:</span></dt>
-    <dd><ul><li style="--primary-color: #ea2e83"><a href="track/t4/">Track 4</a> <span class="by">by <a href="artist/apricot/">Apricot</a> and <a href="artist/peach/">Peach</a></span></li></ul></dd>
+    <dd><ul><li style="--primary-color: #ea2e83"><a href="track/t4/">Track 4</a> <span class="by"><span class="chunkwrap">by <a href="artist/apricot/">Apricot</a>,</span> <span class="chunkwrap"><a href="artist/peach/">Peach</a>,</span> <span class="chunkwrap">and <a href="artist/cerise/">Cerise</a></span></span></li></ul></dd>
 </dl>
 <ul>
     <li>(0:20) <a href="track/t1/">Track 1</a></li>
     <li><a href="track/t2/">Track 2</a></li>
     <li>(0:40) <a href="track/t3/">Track 3</a></li>
-    <li style="--primary-color: #ea2e83"><a href="track/t4/">Track 4</a> <span class="by">by <a href="artist/apricot/">Apricot</a> and <a href="artist/peach/">Peach</a></span></li>
+    <li style="--primary-color: #ea2e83"><a href="track/t4/">Track 4</a> <span class="by"><span class="chunkwrap">by <a href="artist/apricot/">Apricot</a>,</span> <span class="chunkwrap"><a href="artist/peach/">Peach</a>,</span> <span class="chunkwrap">and <a href="artist/cerise/">Cerise</a></span></span></li>
 </ul>
 <ul>
     <li><a href="track/t2/">Track 2</a></li>
-    <li style="--primary-color: #ea2e83"><a href="track/t4/">Track 4</a> <span class="by">by <a href="artist/apricot/">Apricot</a> and <a href="artist/peach/">Peach</a></span></li>
+    <li style="--primary-color: #ea2e83"><a href="track/t4/">Track 4</a> <span class="by"><span class="chunkwrap">by <a href="artist/apricot/">Apricot</a>,</span> <span class="chunkwrap"><a href="artist/peach/">Peach</a>,</span> <span class="chunkwrap">and <a href="artist/cerise/">Cerise</a></span></span></li>
 </ul>
 `

--- a/tap-snapshots/test/snapshot/generateTrackCoverArtwork.js.test.cjs
+++ b/tap-snapshots/test/snapshot/generateTrackCoverArtwork.js.test.cjs
@@ -15,7 +15,7 @@ exports[`test/snapshot/generateTrackCoverArtwork.js > TAP > generateTrackCoverAr
      { name: 'creepy crawlies', isContentWarning: true }
    ]
  ]
- slots: { path: [ 'media.albumCover', 'bee-forus-seatbelt-safebee', 'png' ], color: '#abcdef', thumb: 'medium', reveal: true, link: true, square: true }]
+ slots: { path: [ 'media.albumCover', 'bee-forus-seatbelt-safebee', 'png' ], color: '#abcdef', thumb: 'medium', reveal: true, link: true, dimensions: [ 400, 300 ] }]
 <ul class="image-details">
     <li><a href="tag/damara/">Damara</a></li>
     <li><a href="tag/cronus/">Cronus</a></li>
@@ -40,7 +40,7 @@ exports[`test/snapshot/generateTrackCoverArtwork.js > TAP > generateTrackCoverAr
      { name: 'creepy crawlies', isContentWarning: true }
    ]
  ]
- slots: { path: [ 'media.albumCover', 'bee-forus-seatbelt-safebee', 'png' ], color: '#abcdef', thumb: 'small', reveal: false, link: false, square: true }]
+ slots: { path: [ 'media.albumCover', 'bee-forus-seatbelt-safebee', 'png' ], color: '#abcdef', thumb: 'small', reveal: false, link: false, dimensions: [ 400, 300 ] }]
 `
 
 exports[`test/snapshot/generateTrackCoverArtwork.js > TAP > generateTrackCoverArtwork (snapshot) > display: thumbnail - unique art 1`] = `

--- a/tap-snapshots/test/snapshot/generateTrackReleaseInfo.js.test.cjs
+++ b/tap-snapshots/test/snapshot/generateTrackReleaseInfo.js.test.cjs
@@ -13,7 +13,7 @@ exports[`test/snapshot/generateTrackReleaseInfo.js > TAP > generateTrackReleaseI
     <br>
     Duration: 0:58.
 </p>
-<p>Listen on <a href="https://soundcloud.com/foo" class="nowrap">SoundCloud</a> or <a href="https://youtube.com/watch?v=bar" class="nowrap">YouTube</a>.</p>
+<p>Listen on <a class="external-link" href="https://soundcloud.com/foo">SoundCloud</a> or <a class="external-link" href="https://youtube.com/watch?v=bar">YouTube</a>.</p>
 `
 
 exports[`test/snapshot/generateTrackReleaseInfo.js > TAP > generateTrackReleaseInfo (snapshot) > cover artist contribs, non-unique 1`] = `

--- a/tap-snapshots/test/snapshot/image.js.test.cjs
+++ b/tap-snapshots/test/snapshot/image.js.test.cjs
@@ -24,6 +24,14 @@ exports[`test/snapshot/image.js > TAP > image (snapshot) > content warnings via 
 </div>
 `
 
+exports[`test/snapshot/image.js > TAP > image (snapshot) > dimensions 1`] = `
+<div class="image-container"><div class="image-outer-area"><div class="image-inner-area"><img class="image" width="400" src="foobar"></div></div></div>
+`
+
+exports[`test/snapshot/image.js > TAP > image (snapshot) > dimensions with square 1`] = `
+<div class="image-container"><div class="image-outer-area"><div class="image-inner-area"><img class="image" width="400" src="foobar"></div></div></div>
+`
+
 exports[`test/snapshot/image.js > TAP > image (snapshot) > lazy with square 1`] = `
 <noscript><div class="image-container square"><div class="image-outer-area square-content"><div class="image-inner-area"><img class="image" src="foobar"></div></div></div></noscript>
 <div class="image-container square js-hide"><div class="image-outer-area square-content"><div class="image-inner-area"><img class="image lazy" data-original="foobar"></div></div></div>
@@ -63,8 +71,4 @@ exports[`test/snapshot/image.js > TAP > image (snapshot) > thumb requested but s
 
 exports[`test/snapshot/image.js > TAP > image (snapshot) > thumbnail details 1`] = `
 <div class="image-container"><div class="image-outer-area"><div class="image-inner-area"><img class="image" data-original-length="1200" data-thumbs="voluminous:1200 middling:900 petite:20" src="thumb/album-art/beyond-canon/cover.voluminous.jpg"></div></div></div>
-`
-
-exports[`test/snapshot/image.js > TAP > image (snapshot) > width & height 1`] = `
-<div class="image-container"><div class="image-outer-area"><div class="image-inner-area"><img class="image" width="600" height="400" src="foobar"></div></div></div>
 `

--- a/tap-snapshots/test/snapshot/linkContribution.js.test.cjs
+++ b/tap-snapshots/test/snapshot/linkContribution.js.test.cjs
@@ -8,22 +8,22 @@
 exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) > loads of links (inline) 1`] = `
 <span class="contribution nowrap"><a href="artist/lorem-ipsum-lover/">Lorem Ipsum Lover</a> (<span class="icons icons-inline"><a class="icon" href="https://loremipsum.io">
             <svg>
-                <title>External (loremipsum.io)</title>
+                <title>loremipsum.io</title>
                 <use href="static/icons.svg#icon-globe"></use>
             </svg>
         </a>, <a class="icon" href="https://loremipsum.io/generator/">
             <svg>
-                <title>External (loremipsum.io)</title>
+                <title>loremipsum.io</title>
                 <use href="static/icons.svg#icon-globe"></use>
             </svg>
         </a>, <a class="icon" href="https://loremipsum.io/#meaning">
             <svg>
-                <title>External (loremipsum.io)</title>
+                <title>loremipsum.io</title>
                 <use href="static/icons.svg#icon-globe"></use>
             </svg>
         </a>, <a class="icon" href="https://loremipsum.io/#usage-and-examples">
             <svg>
-                <title>External (loremipsum.io)</title>
+                <title>loremipsum.io</title>
                 <use href="static/icons.svg#icon-globe"></use>
             </svg>
         </a></span>)</span>
@@ -33,28 +33,28 @@ exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) >
 <span class="contribution"><span class="text-with-tooltip"><span class="hoverable"><a class="text-with-tooltip-interaction-cue" href="artist/lorem-ipsum-lover/">Lorem Ipsum Lover</a></span><span class="tooltip icons icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://loremipsum.io">
                     <svg><use href="static/icons.svg#icon-globe"></use></svg>
                     <span class="icon-text">loremipsum.io</span>
-                </a><a class="icon has-text" href="https://loremipsum.io/generator/">
+                </a><span class="icon-platform">Other</span><a class="icon has-text" href="https://loremipsum.io/generator/">
                     <svg><use href="static/icons.svg#icon-globe"></use></svg>
                     <span class="icon-text">loremipsum.io</span>
-                </a><a class="icon has-text" href="https://loremipsum.io/#meaning">
+                </a><span class="icon-platform">Other</span><a class="icon has-text" href="https://loremipsum.io/#meaning">
                     <svg><use href="static/icons.svg#icon-globe"></use></svg>
                     <span class="icon-text">loremipsum.io</span>
-                </a><a class="icon has-text" href="https://loremipsum.io/#usage-and-examples">
+                </a><span class="icon-platform">Other</span><a class="icon has-text" href="https://loremipsum.io/#usage-and-examples">
                     <svg><use href="static/icons.svg#icon-globe"></use></svg>
                     <span class="icon-text">loremipsum.io</span>
-                </a><a class="icon has-text" href="https://loremipsum.io/#controversy">
+                </a><span class="icon-platform">Other</span><a class="icon has-text" href="https://loremipsum.io/#controversy">
                     <svg><use href="static/icons.svg#icon-globe"></use></svg>
                     <span class="icon-text">loremipsum.io</span>
-                </a><a class="icon has-text" href="https://loremipsum.io/#when-to-use-lorem-ipsum">
+                </a><span class="icon-platform">Other</span><a class="icon has-text" href="https://loremipsum.io/#when-to-use-lorem-ipsum">
                     <svg><use href="static/icons.svg#icon-globe"></use></svg>
                     <span class="icon-text">loremipsum.io</span>
-                </a><a class="icon has-text" href="https://loremipsum.io/#lorem-ipsum-all-the-things">
+                </a><span class="icon-platform">Other</span><a class="icon has-text" href="https://loremipsum.io/#lorem-ipsum-all-the-things">
                     <svg><use href="static/icons.svg#icon-globe"></use></svg>
                     <span class="icon-text">loremipsum.io</span>
-                </a><a class="icon has-text" href="https://loremipsum.io/#original-source">
+                </a><span class="icon-platform">Other</span><a class="icon has-text" href="https://loremipsum.io/#original-source">
                     <svg><use href="static/icons.svg#icon-globe"></use></svg>
                     <span class="icon-text">loremipsum.io</span>
-                </a></span></span></span></span>
+                </a><span class="icon-platform">Other</span></span></span></span></span>
 `
 
 exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) > no accents 1`] = `
@@ -78,7 +78,7 @@ exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) >
             </svg>
         </a>, <a class="icon" href="https://toby.fox/">
             <svg>
-                <title>External (toby.fox)</title>
+                <title>toby.fox</title>
                 <use href="static/icons.svg#icon-globe"></use>
             </svg>
         </a></span>)</span>
@@ -105,7 +105,7 @@ exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) >
             </svg>
         </a>, <a class="icon" href="https://toby.fox/">
             <svg>
-                <title>External (toby.fox)</title>
+                <title>toby.fox</title>
                 <use href="static/icons.svg#icon-globe"></use>
             </svg>
         </a></span>)</span>
@@ -115,15 +115,15 @@ exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) >
 <span class="contribution"><span class="text-with-tooltip"><span class="hoverable"><a class="text-with-tooltip-interaction-cue" href="artist/clark-powell/">Clark Powell</a></span><span class="tooltip icons icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://soundcloud.com/plazmataz">
                     <svg><use href="static/icons.svg#icon-soundcloud"></use></svg>
                     <span class="icon-text">plazmataz</span>
-                </a></span></span></span></span>
+                </a><span class="icon-platform">SoundCloud</span></span></span></span></span>
 <span class="contribution nowrap"><a href="artist/the-big-baddies/">Grounder &amp; Scratch</a> (Snooping)</span>
 <span class="contribution nowrap"><span class="text-with-tooltip"><span class="hoverable"><a class="text-with-tooltip-interaction-cue" href="artist/toby-fox/">Toby Fox</a></span><span class="tooltip icons icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://tobyfox.bandcamp.com/">
                     <svg><use href="static/icons.svg#icon-bandcamp"></use></svg>
                     <span class="icon-text">tobyfox</span>
-                </a><a class="icon has-text" href="https://toby.fox/">
+                </a><span class="icon-platform">Bandcamp</span><a class="icon has-text" href="https://toby.fox/">
                     <svg><use href="static/icons.svg#icon-globe"></use></svg>
                     <span class="icon-text">toby.fox</span>
-                </a></span></span></span> (Arrangement)</span>
+                </a><span class="icon-platform">Other</span></span></span></span> (Arrangement)</span>
 `
 
 exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) > showContribution & showIcons (inline) 1`] = `
@@ -141,7 +141,7 @@ exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) >
             </svg>
         </a>, <a class="icon" href="https://toby.fox/">
             <svg>
-                <title>External (toby.fox)</title>
+                <title>toby.fox</title>
                 <use href="static/icons.svg#icon-globe"></use>
             </svg>
         </a></span>)</span>
@@ -151,13 +151,13 @@ exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) >
 <span class="contribution"><span class="text-with-tooltip"><span class="hoverable"><a class="text-with-tooltip-interaction-cue" href="artist/clark-powell/">Clark Powell</a></span><span class="tooltip icons icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://soundcloud.com/plazmataz">
                     <svg><use href="static/icons.svg#icon-soundcloud"></use></svg>
                     <span class="icon-text">plazmataz</span>
-                </a></span></span></span></span>
+                </a><span class="icon-platform">SoundCloud</span></span></span></span></span>
 <span class="contribution nowrap"><a href="artist/the-big-baddies/">Grounder &amp; Scratch</a> (Snooping)</span>
 <span class="contribution nowrap"><span class="text-with-tooltip"><span class="hoverable"><a class="text-with-tooltip-interaction-cue" href="artist/toby-fox/">Toby Fox</a></span><span class="tooltip icons icons-tooltip"><span class="tooltip-content"><a class="icon has-text" href="https://tobyfox.bandcamp.com/">
                     <svg><use href="static/icons.svg#icon-bandcamp"></use></svg>
                     <span class="icon-text">tobyfox</span>
-                </a><a class="icon has-text" href="https://toby.fox/">
+                </a><span class="icon-platform">Bandcamp</span><a class="icon has-text" href="https://toby.fox/">
                     <svg><use href="static/icons.svg#icon-globe"></use></svg>
                     <span class="icon-text">toby.fox</span>
-                </a></span></span></span> (Arrangement)</span>
+                </a><span class="icon-platform">Other</span></span></span></span> (Arrangement)</span>
 `

--- a/test/snapshot/generateAlbumCoverArtwork.js
+++ b/test/snapshot/generateAlbumCoverArtwork.js
@@ -13,6 +13,7 @@ testContentFunctions(t, 'generateAlbumCoverArtwork (snapshot)', async (t, evalua
   const album = {
     directory: 'bee-forus-seatbelt-safebee',
     coverArtFileExtension: 'png',
+    coverArtDimensions: [400, 300],
     color: '#f28514',
     artTags: [
       {name: 'Damara', directory: 'damara', isContentWarning: false},

--- a/test/snapshot/generateAlbumSecondaryNav.js
+++ b/test/snapshot/generateAlbumSecondaryNav.js
@@ -10,6 +10,8 @@ testContentFunctions(t, 'generateAlbumSecondaryNav (snapshot)', async (t, evalua
   group2 = {name: 'Bepis', directory: 'bepis', color: '#123456'};
 
   album = {
+    name: 'Album',
+    directory: 'album',
     date: new Date('2010-04-13'),
     groups: [group1, group2],
   };

--- a/test/snapshot/generateAlbumTrackList.js
+++ b/test/snapshot/generateAlbumTrackList.js
@@ -16,6 +16,7 @@ testContentFunctions(t, 'generateAlbumTrackList (snapshot)', async (t, evaluate)
   const contribs2 = [
     {artist: {name: 'Apricot', directory: 'apricot', urls: null}},
     {artist: {name: 'Peach', directory: 'peach', urls: ['https://peach.bandcamp.com/']}},
+    {artist: {name: 'Cerise', directory: 'cerise', urls: null}},
   ];
 
   const color1 = '#fb07ff';

--- a/test/snapshot/generateTrackCoverArtwork.js
+++ b/test/snapshot/generateTrackCoverArtwork.js
@@ -11,6 +11,7 @@ testContentFunctions(t, 'generateTrackCoverArtwork (snapshot)', async (t, evalua
   const album = {
     directory: 'bee-forus-seatbelt-safebee',
     coverArtFileExtension: 'png',
+    coverArtDimensions: [400, 300],
     artTags: [
       {name: 'Damara', directory: 'damara', isContentWarning: false},
       {name: 'Cronus', directory: 'cronus', isContentWarning: false},
@@ -23,6 +24,7 @@ testContentFunctions(t, 'generateTrackCoverArtwork (snapshot)', async (t, evalua
     directory: 'beesmp3',
     hasUniqueCoverArt: true,
     coverArtFileExtension: 'jpg',
+    coverArtDimensions: null,
     color: '#f28514',
     artTags: [{name: 'Bees', directory: 'bees', isContentWarning: false}],
     album,

--- a/test/snapshot/image.js
+++ b/test/snapshot/image.js
@@ -38,17 +38,24 @@ testContentFunctions(t, 'image (snapshot)', async (t, evaluate) => {
     },
   });
 
-  quickSnapshot('width & height', {
+  quickSnapshot('dimensions', {
     slots: {
       src: 'foobar',
-      width: 600,
-      height: 400,
+      dimensions: [600, 400],
     },
   });
 
   quickSnapshot('square', {
     slots: {
       src: 'foobar',
+      square: true,
+    },
+  });
+
+  quickSnapshot('dimensions with square', {
+    slots: {
+      src: 'foobar',
+      dimensions: [600, 400],
       square: true,
     },
   });

--- a/test/unit/data/cacheable-object.js
+++ b/test/unit/data/cacheable-object.js
@@ -4,7 +4,7 @@ import CacheableObject from '#cacheable-object';
 
 function newCacheableObject(PD) {
   return new (class extends CacheableObject {
-    static propertyDescriptors = PD;
+    static [CacheableObject.propertyDescriptors] = PD;
   });
 }
 

--- a/test/unit/data/composite/things/track/withAlbum.js
+++ b/test/unit/data/composite/things/track/withAlbum.js
@@ -2,6 +2,8 @@ import t from 'tap';
 
 import '#import-heck';
 
+import Thing from '#thing';
+
 import {compositeFrom, input} from '#composite';
 import {exposeConstant, exposeDependency} from '#composite/control-flow';
 import {withAlbum} from '#composite/things/track';
@@ -23,9 +25,21 @@ t.test(`withAlbum: basic behavior`, t => {
     },
   });
 
-  const fakeTrack1 = {directory: 'foo'};
-  const fakeTrack2 = {directory: 'bar'};
-  const fakeAlbum = {directory: 'baz', tracks: [fakeTrack1]};
+  const fakeTrack1 = {
+    [Thing.isThing]: true,
+    directory: 'foo',
+  };
+
+  const fakeTrack2 = {
+    [Thing.isThing]: true,
+    directory: 'bar',
+  };
+
+  const fakeAlbum = {
+    [Thing.isThing]: true,
+    directory: 'baz',
+    tracks: [fakeTrack1],
+  };
 
   t.equal(
     composite.expose.compute({
@@ -55,9 +69,21 @@ t.test(`withAlbum: early exit conditions`, t => {
     ],
   });
 
-  const fakeTrack1 = {directory: 'foo'};
-  const fakeTrack2 = {directory: 'bar'};
-  const fakeAlbum = {directory: 'baz', tracks: [fakeTrack1]};
+  const fakeTrack1 = {
+    [Thing.isThing]: true,
+    directory: 'foo',
+  };
+
+  const fakeTrack2 = {
+    [Thing.isThing]: true,
+    directory: 'bar',
+  };
+
+  const fakeAlbum = {
+    [Thing.isThing]: true,
+    directory: 'baz',
+    tracks: [fakeTrack1],
+  };
 
   t.equal(
     composite.expose.compute({


### PR DESCRIPTION
This is absolutely how unit testing is supposed to work.

Changes that affect code outside the tests:

* No more `has-divider` class on `.nav-link` — we just query `:not(:first-child)` in CSS.
* No more "no image file for (this media file) - build again for list of missing images" message from `image`. You get the full list every build anyway, and it's pretty bright and obvious; detailed notices are just logger noise.
* Fixes (via some regex hell) to how `isContentString` looks for nearby valid content when it's indicating the lcoation of invalid content, which weren't an issue until #449 banished `<a href` (a multiple-character sequence made up of characters that are individually very common).
* Changes `withReverseReferenceList` and `withReverseContributionList` (and thus `withUniqueReferencingThing`, so `withFlashAct`, `withFlashSide`, and `withAlbum`) to not early exit if the wiki-data array is provided but empty (meaning no match can possibly be found). This is restoring the behavior that was already expected from `withAlbum`, but the fix impacts more code paths than before, most likely. Didn't appear to break anything though!
