### PR TITLE
Client-side session storage

### DIFF
--- a/src/static/client3.js
+++ b/src/static/client3.js
@@ -18,7 +18,7 @@ const clientSteps = {
   addPageListeners: [],
 };
 
-function initInfo(key, description) {
+function initInfo(infoKey, description) {
   const object = {...description};
 
   for (const obj of [
@@ -31,7 +31,47 @@ function initInfo(key, description) {
     Object.preventExtensions(obj);
   }
 
-  clientInfo[key] = object;
+  if (object.session) {
+    const sessionDefaults = object.session;
+
+    object.session = {};
+
+    for (const [key, defaultValue] of Object.entries(sessionDefaults)) {
+      const storageKey = `hsmusic.${infoKey}.${key}`;
+
+      let fallbackValue = defaultValue;
+
+      Object.defineProperty(object.session, key, {
+        get: () => {
+          try {
+            return sessionStorage.getItem(storageKey) ?? defaultValue;
+          } catch (error) {
+            if (error instanceof DOMException) {
+              return fallbackValue;
+            } else {
+              throw error;
+            }
+          }
+        },
+
+        set: (value) => {
+          try {
+            sessionStorage.setItem(storageKey, value);
+          } catch (error) {
+            if (error instanceof DOMException) {
+              fallbackValue = value;
+            } else {
+              throw error;
+            }
+          }
+        },
+      });
+    }
+
+    Object.preventExtensions(object.session);
+  }
+
+  clientInfo[infoKey] = object;
 
   return object;
 }


### PR DESCRIPTION
Extracts a commit from #470 so other features can be built off it. The description, from that PR:

Totally new infrastructure in client-side JS to support hooking into `sessionStorage` nicely. Session info is part of `clientInfo` (the specified values are the defaults on a new session), and accessed via ordinary getters/setters. If session storage is completely disabled or denied (by the browser), then the getters/setters still work—they just don't save the value anywhere except the current page's memory. This is trivial to use and should support various interesting features in the future.
