### PR TITLE
Refactor & improve YAML processing

### DIFF
--- a/src/data/checks.js
+++ b/src/data/checks.js
@@ -37,7 +37,9 @@ export function reportDuplicateDirectories(wikiData, {
 
     const directoryPlaces = Object.create(null);
     const duplicateDirectories = new Set();
+
     const thingData = wikiData[findSpec.bindTo];
+    if (!thingData) continue;
 
     for (const thing of thingData) {
       if (findSpec.include && !findSpec.include(thing)) {

--- a/src/upd8.js
+++ b/src/upd8.js
@@ -1107,7 +1107,11 @@ async function main() {
       logInfo`Loaded data and processed objects:`;
       logThings('albumData', 'albums');
       logThings('trackData', 'tracks');
-      logThings(wikiData.artistData.filter(artist => !artist.isAlias), 'artists');
+      logThings(
+        (wikiData.artistData
+          ? wikiData.artistData.filter(artist => !artist.isAlias)
+          : null),
+        'artists');
       if (wikiData.flashData) {
         logThings('flashData', 'flashes');
         logThings('flashActData', 'flash acts');

--- a/src/upd8.js
+++ b/src/upd8.js
@@ -51,8 +51,6 @@ import {sortByName} from '#sort';
 import {empty, withEntries} from '#sugar';
 import {generateURLs, urlSpec} from '#urls';
 import {identifyAllWebRoutes} from '#web-routes';
-import {linkWikiDataArrays, loadAndProcessDataDocuments, sortWikiDataArrays}
-  from '#yaml';
 
 import {
   colors,
@@ -79,6 +77,13 @@ import genThumbs, {
   migrateThumbsIntoDedicatedCacheDirectory,
   verifyImagePaths,
 } from '#thumbs';
+
+import {
+  getAllDataSteps,
+  linkWikiDataArrays,
+  loadAndProcessDataDocuments,
+  sortWikiDataArrays,
+} from '#yaml';
 
 import FileSizePreloader from './file-size-preloader.js';
 import {listingSpec, listingTargetSpec} from './listing-spec.js';
@@ -1066,9 +1071,11 @@ async function main() {
 
   let processDataAggregate, wikiDataResult;
 
+  const yamlDataSteps = getAllDataSteps();
+
   try {
     ({aggregate: processDataAggregate, result: wikiDataResult} =
-        await loadAndProcessDataDocuments({dataPath}));
+        await loadAndProcessDataDocuments(yamlDataSteps, {dataPath}));
   } catch (error) {
     console.error(error);
 
@@ -1351,7 +1358,7 @@ async function main() {
     timeStart: Date.now(),
   });
 
-  sortWikiDataArrays(wikiData);
+  sortWikiDataArrays(yamlDataSteps, wikiData);
 
   Object.assign(stepStatusSummary.sortWikiDataArrays, {
     status: STATUS_DONE_CLEAN,

--- a/src/util/aggregate.js
+++ b/src/util/aggregate.js
@@ -93,10 +93,27 @@ export function openAggregate({
 
   aggregate.receive = (results) => {
     if (!Array.isArray(results)) {
-      throw new Error(`Expected an array`);
+      if (typeof results === 'object' && results.aggregate) {
+        const {aggregate, result} = results;
+
+        try {
+          aggregate.close();
+        } catch (error) {
+          errors.push(error);
+        }
+
+        return result;
+      }
+
+      throw new Error(`Expected an array or {aggregate, result} object`);
     }
 
     return results.map(({aggregate, result}) => {
+      if (!aggregate) {
+        console.log('nope:', results);
+        throw new Error(`Expected an array of {aggregate, result} objects`);
+      }
+
       try {
         aggregate.close();
       } catch (error) {

--- a/src/util/aggregate.js
+++ b/src/util/aggregate.js
@@ -124,6 +124,13 @@ export function openAggregate({
     });
   };
 
+  aggregate.contain = (results) => {
+    return {
+      aggregate,
+      result: aggregate.receive(results),
+    };
+  };
+
   aggregate.map = (...args) => {
     const parent = aggregate;
     const {result, aggregate: child} = mapAggregate(...args);

--- a/src/util/aggregate.js
+++ b/src/util/aggregate.js
@@ -136,15 +136,15 @@ export function aggregateThrows(errorClass) {
   return {[openAggregate.errorClassSymbol]: errorClass};
 }
 
-// Helper function for allowing both (fn, aggregateOpts) and (aggregateOpts, fn)
-// in aggregate utilities.
-function _reorganizeAggregateArguments(arg1, arg2) {
-  if (typeof arg1 === 'function') {
-    return {fn: arg1, opts: arg2 ?? {}};
-  } else if (typeof arg2 === 'function') {
-    return {fn: arg2, opts: arg1 ?? {}};
+// Helper function for allowing both (fn, opts) and (opts, fn) in aggregate
+// utilities (or other shapes besides functions).
+function _reorganizeAggregateArguments(arg1, arg2, desire = v => typeof v === 'function') {
+  if (desire(arg1)) {
+    return [arg1, arg2 ?? {}];
+  } else if (desire(arg2)) {
+    return [arg2, arg1];
   } else {
-    throw new Error(`Expected a function`);
+    return [undefined, undefined];
   }
 }
 
@@ -158,12 +158,20 @@ function _reorganizeAggregateArguments(arg1, arg2) {
 // use aggregate.close() to throw the error. (This aggregate may be passed to a
 // parent aggregate: `parent.call(aggregate.close)`!)
 export function mapAggregate(array, arg1, arg2) {
-  const {fn, opts} = _reorganizeAggregateArguments(arg1, arg2);
+  const [fn, opts] = _reorganizeAggregateArguments(arg1, arg2);
+  if (!fn) {
+    throw new Error(`Expected a function`);
+  }
+
   return _mapAggregate('sync', null, array, fn, opts);
 }
 
 export function mapAggregateAsync(array, arg1, arg2) {
-  const {fn, opts} = _reorganizeAggregateArguments(arg1, arg2);
+  const [fn, opts] = _reorganizeAggregateArguments(arg1, arg2);
+  if (!fn) {
+    throw new Error(`Expected a function`);
+  }
+
   const {promiseAll = Promise.all.bind(Promise), ...remainingOpts} = opts;
   return _mapAggregate('async', promiseAll, array, fn, remainingOpts);
 }
@@ -200,12 +208,20 @@ export function _mapAggregate(mode, promiseAll, array, fn, aggregateOpts) {
 //
 // As with mapAggregate, the returned aggregate property is not yet closed.
 export function filterAggregate(array, arg1, arg2) {
-  const {fn, opts} = _reorganizeAggregateArguments(arg1, arg2);
+  const [fn, opts] = _reorganizeAggregateArguments(arg1, arg2);
+  if (!fn) {
+    throw new Error(`Expected a function`);
+  }
+
   return _filterAggregate('sync', null, array, fn, opts);
 }
 
 export async function filterAggregateAsync(array, arg1, arg2) {
-  const {fn, opts} = _reorganizeAggregateArguments(arg1, arg2);
+  const [fn, opts] = _reorganizeAggregateArguments(arg1, arg2);
+  if (!fn) {
+    throw new Error(`Expected a function`);
+  }
+
   const {promiseAll = Promise.all.bind(Promise), ...remainingOpts} = opts;
   return _filterAggregate('async', promiseAll, array, fn, remainingOpts);
 }
@@ -268,12 +284,20 @@ function _filterAggregate(mode, promiseAll, array, fn, aggregateOpts) {
 // function with it, then closing the function and returning the result (if
 // there's no throw).
 export function withAggregate(arg1, arg2) {
-  const {fn, opts} = _reorganizeAggregateArguments(arg1, arg2);
+  const [fn, opts] = _reorganizeAggregateArguments(arg1, arg2);
+  if (!fn) {
+    throw new Error(`Expected a function`);
+  }
+
   return _withAggregate('sync', opts, fn);
 }
 
 export function withAggregateAsync(arg1, arg2) {
-  const {fn, opts} = _reorganizeAggregateArguments(arg1, arg2);
+  const [fn, opts] = _reorganizeAggregateArguments(arg1, arg2);
+  if (!fn) {
+    throw new Error(`Expected a function`);
+  }
+
   return _withAggregate('async', opts, fn);
 }
 


### PR DESCRIPTION
Spiritually succeeds #302, #317, and #386.

This pull request broadly aims to improve the way the wiki loads and process YAML documents. The biggest changes here are internal: we've attempted to divide the monolithic `loadAndProcessDataDocuments` function into a variety of smaller, mostly composable functions. We've also tried to improve the general code flow surrounding error reporting, because it was getting difficult to keep track of; a new `aggregate.receive()` utility aids this effort.

Specifically, we've got:

* Broken-down, composable internal functions
  * `getAllDataSteps`: renamed from `getDataSteps`, in line with `getAllFindSpecs`, but otherwise the same.
  * `getFilesFromDataStep`: Per-document-mode behavior for computing the files which a given data step will load data from.
  * `loadYAMLDocumentsFromFile`: Generic function for reading and parsing YAML files from a file path. This reports errors in two ways - as an aggregate returned alongside results, or as a fatal, directly thrown error - but for now, we report them into the same "errors loading YAML documents" aggregate. (This means "blank document" errors are now fatal. Sorry! We'll get badgered to change this one day.)
  * `processThingsFromDataStep`: Perform the usual steps for converting documents into things. Only behavior adjustment is that we now reuse the result from `makeProcessDocument`, but the code is generally nicer here.
  * `saveThingsFromDataStep`: Perform a data step's save function with a list of lists of things (one list for each file) and return the results.
* Useful top-level functions for breaking the overall process into just a series of stages
  * `loadYAMLDocumentsFromDataSteps`: Compute all the data steps files and read YAML documents from those files.
  * `processThingsFromDataSteps`: Convert documents into things for all data steps.
  * `saveThingsFromDataSteps`: Flatten actual thing results into a single `wikiData` object.
* Standard "quick" functions like normal
  * `loadAndProcessDataDocuments`: Takes a list of `dataSteps` now, but otherwise externally unchanged. This is the main reference for coding your own loading steps from, so internally it's now extremely simple and just composes the stage functions above.
  * `quickLoadAllFromYAML`: Externally unchanged, computes `dataSteps` on its own.

Performance isn't substantially altered; "load and process data files" may be 2-4% faster (about 0.03-0.05s difference on M2).

However, this makes an important change for anyone working with data - but especially us, rebasing and handling merge conflicts on the regular: upd8.js now early exits if there are any errors opening, reading, or parsing data files as YAML. This exit happens *before* processing field contents, and certainly before hopelessly processing reference errors. Previously there was no early exit, and files which failed to read would just be skipped — excluded from data!

This makes for easier data work and is in line with changes from #50 and #300.