### PR TITLE
"Always Reference Tracks By Directory" shorthand field

### DIFF
--- a/src/data/things/album.js
+++ b/src/data/things/album.js
@@ -48,6 +48,8 @@ export class Album extends Thing {
     directory: directory(),
     urls: urls(),
 
+    alwaysReferenceTracksByDirectory: flag(false),
+
     bandcampAlbumIdentifier: simpleString(),
     bandcampArtworkIdentifier: simpleString(),
 
@@ -225,6 +227,10 @@ export class Album extends Thing {
     fields: {
       'Album': {property: 'name'},
       'Directory': {property: 'directory'},
+
+      'Always Reference Tracks By Directory': {
+        property: 'alwaysReferenceTracksByDirectory',
+      },
 
       'Bandcamp Album ID': {
         property: 'bandcampAlbumIdentifier',

--- a/test/unit/data/things/track.js
+++ b/test/unit/data/things/track.js
@@ -122,6 +122,61 @@ t.test(`Track.album`, t => {
     `album #6: is null when album's trackSections don't match track`);
 });
 
+t.test(`Track.alwaysReferenceByDirectory`, t => {
+  t.plan(7);
+
+  const {track: originalTrack, album: originalAlbum} =
+    stubTrackAndAlbum('original-track', 'original-album');
+
+  const {track: rereleaseTrack, album: rereleaseAlbum} =
+    stubTrackAndAlbum('rerelease-track', 'rerelease-album');
+
+  originalTrack.name = 'Cowabunga';
+  rereleaseTrack.name = 'Cowabunga';
+
+  originalTrack.dataSourceAlbum = 'album:original-album';
+  rereleaseTrack.dataSourceAlbum = 'album:rerelease-album';
+
+  rereleaseTrack.originalReleaseTrack = 'track:original-track';
+
+  const {XXX_decacheWikiData} = linkAndBindWikiData({
+    albumData: [originalAlbum, rereleaseAlbum],
+    trackData: [originalTrack, rereleaseTrack],
+  });
+
+  t.equal(originalTrack.alwaysReferenceByDirectory, false,
+    `alwaysReferenceByDirectory #1: defaults to false`);
+
+  t.equal(rereleaseTrack.alwaysReferenceByDirectory, true,
+    `alwaysReferenceByDirectory #2: is true if rerelease name matches original`);
+
+  rereleaseTrack.name = 'Foo Dog!';
+
+  t.equal(rereleaseTrack.alwaysReferenceByDirectory, false,
+    `alwaysReferenceByDirectory #3: is false if rerelease name doesn't match original`);
+
+  rereleaseTrack.name = `COWabunga`;
+
+  t.equal(rereleaseTrack.alwaysReferenceByDirectory, false,
+    `alwaysReferenceByDirectory #4: is false if rerelease name doesn't match original exactly`);
+
+  rereleaseAlbum.alwaysReferenceTracksByDirectory = true;
+  XXX_decacheWikiData();
+
+  t.equal(rereleaseTrack.alwaysReferenceByDirectory, true,
+    `alwaysReferenceByDirectory #5: is true if album's alwaysReferenceTracksByDirectory is true`);
+
+  rereleaseTrack.alwaysReferenceByDirectory = false;
+
+  t.equal(rereleaseTrack.alwaysReferenceByDirectory, false,
+    `alwaysReferenceByDirectory #6: doesn't inherit from album if set to false`);
+
+  rereleaseTrack.name = 'Cowabunga';
+
+  t.equal(rereleaseTrack.alwaysReferenceByDirectory, false,
+    `alwaysReferenceByDirectory #7: doesn't compare original release name if set to false`);
+});
+
 t.test(`Track.artTags`, t => {
   t.plan(6);
 


### PR DESCRIPTION
Adds a new field to albums, `Always Reference Tracks By Directory`, which acts as the default value for `Always Reference By Directory` on tracks if set to true. There's no effect at all if this is set to false, which is also the default.

Mostly useful for compilation releases... which released the tracks under different, albeit similar names.

Tracks can individually override this inherited flag by setting `Always Reference By Directory: false`.

Includes a new unit test to confirm existing and new behavior for `Track.alwaysReferenceByDirectory`.