### PR TITLE
Add generic fetchWithProgress() client utility function

### DIFF
--- a/src/static/client4.js
+++ b/src/static/client4.js
@@ -7,6 +7,7 @@
 
 import {accumulateSum, empty, filterMultipleArrays, stitchArrays}
   from '../util/sugar.js';
+import {fetchWithProgress} from './xhr-util.js';
 
 const clientInfo = window.hsmusicClientInfo = Object.create(null);
 
@@ -2858,69 +2859,6 @@ function updateFileSizeInformation(fileSize) {
 }
 
 addImageOverlayClickHandlers();
-
-/**
- * This fetch function is adapted from a `loadImage` function
- * credited to Parziphal, Feb 13, 2017.
- * https://stackoverflow.com/a/42196770
- *
- * The callback is generally run with the loading progress as a decimal 0-1.
- * However, if it's not possible to compute the progress ration (which might
- * only become apparent after a progress amount *has* been sent!),
- * the callback will be run with the value -1.
- *
- * The return promise resolves to a manually instantiated Response object
- * which generally behaves the same as a normal fetch response; access headers,
- * text, blob, arrayBuffer as usual. Accordingly, non-200 responses do *not*
- * reject the prmoise, so be sure to check the response status yourself.
- */
-function fetchWithProgress(url, progressCallback) {
-  return new Promise(resolve => {
-    const xhr = new XMLHttpRequest();
-    let notifiedNotComputable = false;
-
-    xhr.open('GET', url, true);
-    xhr.responseType = 'arraybuffer';
-
-    xhr.onprogress = event => {
-      if (notifiedNotComputable) {
-        return;
-      }
-
-      if (!event.lengthComputable) {
-        notifiedNotComputable = true;
-        progressCallback(-1);
-        return;
-      }
-
-      progressCallback(event.loaded / event.total);
-    };
-
-    xhr.onloadend = () => {
-      const body = xhr.response;
-
-      const options = {
-        status: xhr.status,
-        headers:
-          parseResponseHeaders(xhr.getAllResponseHeaders()),
-      };
-
-      resolve(new Response(body, options));
-    };
-
-    xhr.send();
-  });
-
-  function parseResponseHeaders(headers) {
-    return (
-      Object.fromEntries(
-        headers
-          .trim()
-          .split(/[\r\n]+/)
-          .map(line => line.match(/(.+?):\s*(.+)/))
-          .map(match => [match[1], match[2]])));
-  }
-}
 
 // "Additional names" box ---------------------------------
 

--- a/src/static/client4.js
+++ b/src/static/client4.js
@@ -2922,67 +2922,6 @@ function fetchWithProgress(url, progressCallback) {
   }
 }
 
-/**
- * Credits: Parziphal, Feb 13, 2017
- * https://stackoverflow.com/a/42196770
- *
- * Loads an image with progress callback.
- *
- * The `onprogress` callback will be called by XMLHttpRequest's onprogress
- * event, and will receive the loading progress ratio as an whole number.
- * However, if it's not possible to compute the progress ratio, `onprogress`
- * will be called only once passing -1 as progress value. This is useful to,
- * for example, change the progress animation to an undefined animation.
- *
- * @param  {string}   imageUrl   The image to load
- * @param  {Function} onprogress
- * @return {Promise}
- */
-function loadImage(imageUrl, onprogress) {
-  return new Promise((resolve, reject) => {
-    var xhr = new XMLHttpRequest();
-    var notifiedNotComputable = false;
-
-    xhr.open('GET', imageUrl, true);
-    xhr.responseType = 'arraybuffer';
-
-    xhr.onprogress = function(ev) {
-      if (ev.lengthComputable) {
-        onprogress(parseInt((ev.loaded / ev.total) * 1000) / 10);
-      } else {
-        if (!notifiedNotComputable) {
-          notifiedNotComputable = true;
-          onprogress(-1);
-        }
-      }
-    }
-
-    xhr.onloadend = function() {
-      if (!xhr.status.toString().match(/^2/)) {
-        reject(xhr);
-      } else {
-        if (!notifiedNotComputable) {
-          onprogress(100);
-        }
-
-        var options = {}
-        var headers = xhr.getAllResponseHeaders();
-        var m = headers.match(/^Content-Type:\s*(.*?)$/mi);
-
-        if (m && m[1]) {
-          options.type = m[1];
-        }
-
-        var blob = new Blob([this.response], options);
-
-        resolve(window.URL.createObjectURL(blob));
-      }
-    }
-
-    xhr.send();
-  });
-}
-
 // "Additional names" box ---------------------------------
 
 const additionalNamesBoxInfo = initInfo('additionalNamesBox', {

--- a/src/static/client4.js
+++ b/src/static/client4.js
@@ -2840,6 +2840,69 @@ function updateFileSizeInformation(fileSize) {
 addImageOverlayClickHandlers();
 
 /**
+ * This fetch function is adapted from a `loadImage` function
+ * credited to Parziphal, Feb 13, 2017.
+ * https://stackoverflow.com/a/42196770
+ *
+ * The callback is generally run with the loading progress as a decimal 0-1.
+ * However, if it's not possible to compute the progress ration (which might
+ * only become apparent after a progress amount *has* been sent!),
+ * the callback will be run with the value -1.
+ *
+ * The return promise resolves to a manually instantiated Response object
+ * which generally behaves the same as a normal fetch response; access headers,
+ * text, blob, arrayBuffer as usual. Accordingly, non-200 responses do *not*
+ * reject the prmoise, so be sure to check the response status yourself.
+ */
+function fetchWithProgress(url, progressCallback) {
+  return new Promise(resolve => {
+    const xhr = new XMLHttpRequest();
+    let notifiedNotComputable = false;
+
+    xhr.open('GET', url, true);
+    xhr.responseType = 'arraybuffer';
+
+    xhr.onprogress = event => {
+      if (notifiedNotComputable) {
+        return;
+      }
+
+      if (!event.lengthComputable) {
+        notifiedNotComputable = true;
+        progressCallback(-1);
+        return;
+      }
+
+      progressCallback(event.loaded / event.total);
+    };
+
+    xhr.onloadend = () => {
+      const body = xhr.response;
+
+      const options = {
+        status: xhr.status,
+        headers:
+          parseResponseHeaders(xhr.getAllResponseHeaders()),
+      };
+
+      resolve(new Response(body, options));
+    };
+
+    xhr.send();
+  });
+
+  function parseResponseHeaders(headers) {
+    return (
+      Object.fromEntries(
+        headers
+          .trim()
+          .split(/[\r\n]+/)
+          .map(line => line.match(/(.+?):\s*(.+)/))
+          .map(match => [match[1], match[2]])));
+  }
+}
+
+/**
  * Credits: Parziphal, Feb 13, 2017
  * https://stackoverflow.com/a/42196770
  *

--- a/src/static/xhr-util.js
+++ b/src/static/xhr-util.js
@@ -1,0 +1,62 @@
+/**
+ * This fetch function is adapted from a `loadImage` function
+ * credited to Parziphal, Feb 13, 2017.
+ * https://stackoverflow.com/a/42196770
+ *
+ * The callback is generally run with the loading progress as a decimal 0-1.
+ * However, if it's not possible to compute the progress ration (which might
+ * only become apparent after a progress amount *has* been sent!),
+ * the callback will be run with the value -1.
+ *
+ * The return promise resolves to a manually instantiated Response object
+ * which generally behaves the same as a normal fetch response; access headers,
+ * text, blob, arrayBuffer as usual. Accordingly, non-200 responses do *not*
+ * reject the prmoise, so be sure to check the response status yourself.
+ */
+export function fetchWithProgress(url, progressCallback) {
+  return new Promise(resolve => {
+    const xhr = new XMLHttpRequest();
+    let notifiedNotComputable = false;
+
+    xhr.open('GET', url, true);
+    xhr.responseType = 'arraybuffer';
+
+    xhr.onprogress = event => {
+      if (notifiedNotComputable) {
+        return;
+      }
+
+      if (!event.lengthComputable) {
+        notifiedNotComputable = true;
+        progressCallback(-1);
+        return;
+      }
+
+      progressCallback(event.loaded / event.total);
+    };
+
+    xhr.onloadend = () => {
+      const body = xhr.response;
+
+      const options = {
+        status: xhr.status,
+        headers:
+          parseResponseHeaders(xhr.getAllResponseHeaders()),
+      };
+
+      resolve(new Response(body, options));
+    };
+
+    xhr.send();
+  });
+
+  function parseResponseHeaders(headers) {
+    return (
+      Object.fromEntries(
+        headers
+          .trim()
+          .split(/[\r\n]+/)
+          .map(line => line.match(/(.+?):\s*(.+)/))
+          .map(match => [match[1], match[2]])));
+  }
+}


### PR DESCRIPTION
This is basically an updated version of the existing `loadImage` function we used, which was pulled basically one for one from Parziphal on Stack Overflow: https://stackoverflow.com/a/42196770

The new function's biggest difference is that the resolved value is an ordinary fetch `Response` object, manually instantiated from an XHR's results, which supports the usual body-access functions. We get blob MIME type detection [for free](https://fetch.spec.whatwg.org/#dom-body-blob), though we have to manually parse [the XHR's headers](https://xhr.spec.whatwg.org/#dom-xmlhttprequest-getallresponseheaders).

In the future, the guts of this function can probably be rewritten to report progress from a real `fetch` call and return its response object verbatim! For now all that matters to us is being able to choose whether we want a blob or array buffer out of the response, and building off XHR works fine for that.