### PR TITLE
Improvements for live-dev-server responses

### DIFF
--- a/src/write/build-modes/live-dev-server.js
+++ b/src/write/build-modes/live-dev-server.js
@@ -302,10 +302,10 @@ export async function go({
       try {
         const {size} = await stat(filePath);
         const buffer = await readFile(filePath)
-        response.writeHead(200, contentType ? {
-          'Content-Type': contentType,
+        response.writeHead(200, {
+          ...contentType ? {'Content-Type': contentType} : {},
           'Content-Length': size,
-        } : {});
+        });
         response.end(buffer);
         if (loudResponses) console.log(`${requestHead} [200] ${pathname}`);
       } catch (error) {

--- a/src/write/build-modes/live-dev-server.js
+++ b/src/write/build-modes/live-dev-server.js
@@ -312,12 +312,13 @@ export async function go({
         if (error.code === 'EISDIR') {
           response.writeHead(404, contentTypePlain);
           response.end(`File not found for: ${safePath}`);
+          console.error(`${requestHead} [404] ${pathname} (is directory)`);
         } else {
           response.writeHead(500, contentTypePlain);
           response.end(`Failed during file-to-response pipeline`);
+          console.error(`${requestHead} [500] ${pathname}`);
+          showError(error);
         }
-        console.error(`${requestHead} [500] ${pathname}`);
-        showError(error);
       }
       return;
     }

--- a/src/write/build-modes/live-dev-server.js
+++ b/src/write/build-modes/live-dev-server.js
@@ -5,7 +5,7 @@ import * as path from 'node:path';
 import {pipeline} from 'node:stream/promises';
 import {inspect as nodeInspect} from 'node:util';
 
-import {ENABLE_COLOR, logInfo, logWarn, progressCallAll} from '#cli';
+import {ENABLE_COLOR, colors, logInfo, logWarn, progressCallAll} from '#cli';
 import {watchContentDependencies} from '#content-dependencies';
 import {quickEvaluate} from '#content-function';
 import * as html from '#html';
@@ -214,7 +214,7 @@ export async function go({
 
         response.writeHead(200, contentTypeJSON);
         response.end(json);
-        if (loudResponses) console.log(`${requestHead} [200] ${pathname}`);
+        if (loudResponses) console.log(`${requestHead} [200] ${pathname} (${colors.yellow(`special`)})`);
       } catch (error) {
         response.writeHead(500, contentTypeJSON);
         response.end(`Internal error serializing wiki JSON`);
@@ -325,7 +325,7 @@ export async function go({
 
       await pipeline(fd.createReadStream(), response);
 
-      if (loudResponses) console.log(`${requestHead} [200] ${pathname}`);
+      if (loudResponses) console.log(`${requestHead} [200] ${pathname} (${colors.magenta(`web route`)})`);
 
       return;
     }
@@ -433,9 +433,9 @@ export async function go({
             ? `${(timeDelta / 1000).toFixed(2)}s`
             : `${timeDelta}ms`);
 
-        console.log(`${requestHead} [200, ${timeString}] ${pathname}`);
+        console.log(`${requestHead} [200, ${timeString}] ${pathname} (${colors.blue(`page`)})`);
       } else if (loudResponses) {
-        console.log(`${requestHead} [200] ${pathname}`);
+        console.log(`${requestHead} [200] ${pathname} (${colors.blue(`page`)})`);
       }
 
       response.writeHead(200, contentTypeHTML);


### PR DESCRIPTION
Bundles various semi-related changes to how live-dev-server sends responses, mainly for sending files from the file system (i.e. web routes):

* Always send the content-length header, instead of only when we guess a MIME type! This was just a bug earlier, but it stumped us for a while, trying to figure out why the search corpuses didn't seem to have a readable progress bar (due to the unusual `.json.msgpack` extension).
* Use `fd = fs.open(...)` and `pipeline(fd.createReadStream(), ...)`, so we can send the content-length header before actually reading the file, and provide more synchronized progress info.
* Fix a mistaken [500] log message when we actually sent 404.
* When using `--loud-responses`, add a colored accent to each [200] log message ("page" or "web route").