### PR TITLE
Fix group contributions info sort switcher showing when not applicable

### DIFF
--- a/src/content/dependencies/generateArtistGroupContributionsInfo.js
+++ b/src/content/dependencies/generateArtistGroupContributionsInfo.js
@@ -161,9 +161,15 @@ export default {
       slots.visible && 'visible',
     ];
 
+    // TODO: It feels pretty awkward that this component is the only one that
+    // has enough knowledge to decide if the sort button is even applicable...
+    const switchingSortPossible =
+      !empty(relations.groupLinksSortedByCount) &&
+      !empty(relations.groupLinksSortedByDuration);
+
     return html.tags([
       html.tag('dt', {class: topLevelClasses},
-        (slots.showSortButton
+        (switchingSortPossible && slots.showSortButton
           ? language.$('artistPage.groupContributions.title.withSortButton', {
               title: slots.title,
               sort:


### PR DESCRIPTION
Just a quick fix for the artist info page's group contributions info part! This makes sure the default "Sorting by count" button, for switching to duration, doesn't show up if there *is* no by-duration info to display.

This also fixes JavaScript flat-out not working on those pages. (It does not fix group contributions setup still being outside `clientSteps` lol.)

There's probably some general cleanup to be done for how group contributions info is structured, but that'll be best off as part of #309.