### PR TITLE
Improve appearance of dates in commentary entries

### DIFF
--- a/src/content/dependencies/generateCommentaryEntry.js
+++ b/src/content/dependencies/generateCommentaryEntry.js
@@ -61,19 +61,14 @@ export default {
         relations.annotationContent.slot('mode', 'inline');
     }
 
-    if (data.date) {
-      accentParts.push('withDate');
-      accentOptions.date =
-        language.formatDate(data.date);
-    }
-
     const accent =
       (accentParts.length > 1
         ? html.tag('span', {class: 'commentary-entry-accent'},
             language.$(...accentParts, accentOptions))
         : null);
 
-    const titleParts = ['misc.artistCommentary.entry.title'];
+    const titlePrefix = 'misc.artistCommentary.entry.title';
+    const titleParts = [titlePrefix];
     const titleOptions = {artists: artistsSpan};
 
     if (accent) {
@@ -88,7 +83,16 @@ export default {
     return html.tags([
       html.tag('p', {class: 'commentary-entry-heading'},
         style,
-        language.$(...titleParts, titleOptions)),
+        [
+          data.date &&
+            html.tag('time',
+              language.$(titlePrefix, 'date', {
+                date:
+                  language.formatDate(data.date),
+              })),
+
+          language.$(...titleParts, titleOptions)
+        ]),
 
       html.tag('blockquote', {class: 'commentary-entry-body'},
         style,

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -1108,6 +1108,10 @@ ul.image-details li {
   font-style: oblique;
 }
 
+.commentary-entry-heading time {
+  float: right;
+}
+
 .commentary-art {
   float: right;
   width: 30%;

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -430,12 +430,15 @@ misc:
     entry:
       title:
         _: "{ARTISTS}:"
+
         noArtists: "Unknown artist"
+
         withAccent: "{ARTISTS}: {ACCENT}"
+
         accent:
           withAnnotation: "({ANNOTATION})"
-          withDate: ({DATE})"
-          withAnnotation.withDate: "({ANNOTATION}, {DATE})"
+
+        date: "{DATE}"
 
       seeOriginalRelease: "See {ORIGINAL}!"
 


### PR DESCRIPTION
Makes commentary entries float to the right, instead of sitting inline.

<img width="659" alt="Two commentary entries with dates, shown as part of the entry accent. They are not aligned with each other so it's not super easy to tell if they're different or the same." src="https://github.com/hsmusic/hsmusic-wiki/assets/9948030/b3c0d49b-d0a1-4bc1-8248-84cb6d103d49">

<img width="653" alt="Same two entries, but the dates are removed from the accent and now float by the right edge of the heading. They're aligned, so it's easy to tell the second entry is from the day after the first." src="https://github.com/hsmusic/hsmusic-wiki/assets/9948030/6e8293df-7d74-49ee-9ec6-d11708bbed22">
