### PR TITLE
Review dependencies accessed by compositional steps on first run (etc)

### DIFF
--- a/src/data/composite.js
+++ b/src/data/composite.js
@@ -1124,7 +1124,7 @@ export function compositeFrom(description) {
                 reason = true;
               }
 
-              if (!filterableDependencies[dependency]) {
+              if (filterableDependencies[dependency] === undefined) {
                 subAggregate.push(
                   new Error(
                     `Not available` +

--- a/src/data/composite/things/track/withContainingTrackSection.js
+++ b/src/data/composite/things/track/withContainingTrackSection.js
@@ -30,7 +30,6 @@ export default templateCompositeFrom({
 
       compute: (continuation, {
         [input.myself()]: track,
-        [input('notFoundMode')]: notFoundMode,
         ['#album.trackSections']: trackSections,
       }) => continuation({
         ['#trackSection']:


### PR DESCRIPTION
This PR performs some runtime observations to flag possible issues with accessed dependencies before they have a greater impact.

* The review is only performed once per written compositional step respective to a call to `compositeFrom`. Practically speaking, this refers to each property on a Thing-subclass-level `[Thing.getPropertyDescriptors]()` call. So, each step will only be reviewed once per usage on a property per kind of thing.
* When reviewing, a proxy is passed to `compute`/`transform` capturing property accesses on `filteredDependencies`. This proxy keeps track of which properties are accessed and some relevant observations.
  * *Unavailable dependencies* are flagged, and these are defined as any accessed dependency whose value is `undefined`. The reporter makes a best effort to identify the cause, but even if it fails, it will *always* flag an unavailable dependency.
    * A dependency may be unavailable because it's not listed on the step's `dependencies`.
    * A dependency may be unavailable because it's a local (`#`-prefixed) dependency and no previous step provided it.
    * A dependency may be unavailable because it's an object property dependency and the cacheable object doesn't have that property.
    * A dependency may be unavailable because it's an input that the composition doesn't declare.
    * Any and all of the above are reported as applicable.
  * *Expressed, but never-accessed dependencies* are flagged. These are dependencies specified on the step's `dependencies` but not accessed.
  * If errors were found above, the list of all accessed dependencies is also included for reference.
* When reviewing, a function is prepared to report the above results (observed via proxy). This reporting function, if present, is conditionally called based on how the step itself evaluated.
* The dependency access error report is shown in aggregate with any other errors while evaluating the step. We previously experimented with only showing the dependency (discarding the internally thrown error), since you generally want to address a property access issue first, but figured this might be unreliable and not always applicable.
* In general, errors thrown from compositional steps now chain up to the top. This can probably make for some long chains, but should improve clarity, especially as multiple errors can now come from a single step at once.
