### PR TITLE
Add [html.onlyIfSiblings] and [language.onlyIfOptions]!

### DIFF
--- a/src/content/dependencies/generateAlbumCommentaryPage.js
+++ b/src/content/dependencies/generateAlbumCommentaryPage.js
@@ -1,4 +1,4 @@
-import {empty, stitchArrays} from '#sugar';
+import {stitchArrays} from '#sugar';
 
 export default {
   contentDependencies: [
@@ -167,16 +167,16 @@ export default {
                 }),
 
               accent:
-                !empty(relations.albumCommentaryListeningLinks) &&
-                  language.$('albumCommentaryPage.entry.title.albumCommentary.accent', {
-                    listeningLinks:
-                      language.formatUnitList(
-                        relations.albumCommentaryListeningLinks
-                          .map(link => link.slots({
-                            context: 'album',
-                            tab: 'separate',
-                          }))),
-                  }),
+                language.$('albumCommentaryPage.entry.title.albumCommentary.accent', {
+                  [language.onlyIfOptions]: ['listeningLinks'],
+                  listeningLinks:
+                    language.formatUnitList(
+                      relations.albumCommentaryListeningLinks
+                        .map(link => link.slots({
+                          context: 'album',
+                          tab: 'separate',
+                        }))),
+                }),
             }),
 
             relations.albumCommentaryCover
@@ -213,13 +213,13 @@ export default {
                   }),
 
                 accent:
-                  !empty(listeningLinks) &&
-                    language.$('albumCommentaryPage.entry.title.trackCommentary.accent', {
-                      listeningLinks:
-                        language.formatUnitList(
-                          listeningLinks.map(link =>
-                            link.slot('tab', 'separate'))),
-                    }),
+                  language.$('albumCommentaryPage.entry.title.trackCommentary.accent', {
+                    [language.onlyIfOptions]: ['listeningLinks'],
+                    listeningLinks:
+                      language.formatUnitList(
+                        listeningLinks.map(link =>
+                          link.slot('tab', 'separate'))),
+                  }),
               }),
 
               cover?.slots({mode: 'commentary'}),

--- a/src/content/dependencies/generateAlbumInfoPage.js
+++ b/src/content/dependencies/generateAlbumInfoPage.js
@@ -213,10 +213,10 @@ export default {
             {[html.joinChildren]: html.tag('br')},
 
             [
-              data.dateAddedToWiki &&
-                language.$('releaseInfo.addedToWiki', {
-                  date: language.formatDate(data.dateAddedToWiki),
-                }),
+              language.$('releaseInfo.addedToWiki', {
+                [language.onlyIfOptions]: ['date'],
+                date: language.formatDate(data.dateAddedToWiki),
+              }),
             ]),
 
           sec.additionalFiles && [

--- a/src/content/dependencies/generateAlbumReleaseInfo.js
+++ b/src/content/dependencies/generateAlbumReleaseInfo.js
@@ -1,4 +1,4 @@
-import {accumulateSum, empty} from '#sugar';
+import {accumulateSum} from '#sugar';
 
 export default {
   contentDependencies: [
@@ -23,11 +23,9 @@ export default {
     relations.bannerArtistContributionsLine =
       relation('generateReleaseInfoContributionsLine', album.bannerArtistContribs);
 
-    if (!empty(album.urls)) {
-      relations.externalLinks =
-        album.urls.map(url =>
-          relation('linkExternal', url));
-    }
+    relations.externalLinks =
+      album.urls.map(url =>
+        relation('linkExternal', url));
 
     return relations;
   },
@@ -70,41 +68,42 @@ export default {
           relations.bannerArtistContributionsLine
             .slots({stringKey: 'releaseInfo.bannerArtBy'}),
 
-          data.date &&
-            language.$('releaseInfo.released', {
-              date: language.formatDate(data.date),
-            }),
+          language.$('releaseInfo.released', {
+            [language.onlyIfOptions]: ['date'],
+            date: language.formatDate(data.date),
+          }),
 
-          data.coverArtDate &&
-            language.$('releaseInfo.artReleased', {
-              date: language.formatDate(data.coverArtDate),
-            }),
+          language.$('releaseInfo.artReleased', {
+            [language.onlyIfOptions]: ['date'],
+            date: language.formatDate(data.coverArtDate),
+          }),
 
-          data.duration &&
-            language.$('releaseInfo.duration', {
-              duration:
-                language.formatDuration(data.duration, {
-                  approximate: data.durationApproximate,
-                }),
-            }),
+          language.$('releaseInfo.duration', {
+            [language.onlyIfOptions]: ['duration'],
+            duration:
+              language.formatDuration(data.duration, {
+                approximate: data.durationApproximate,
+              }),
+          }),
         ]),
 
-      relations.externalLinks &&
-        html.tag('p',
-          language.$('releaseInfo.listenOn', {
-            links:
-              language.formatDisjunctionList(
-                relations.externalLinks
-                  .map(link =>
-                    link.slot('context', [
-                      'album',
-                      (data.numTracks === 0
-                        ? 'albumNoTracks'
-                     : data.numTracks === 1
-                        ? 'albumOneTrack'
-                        : 'albumMultipleTracks'),
-                    ]))),
-          })),
+      html.tag('p',
+        {[html.onlyIfContent]: true},
+        language.$('releaseInfo.listenOn', {
+          [language.onlyIfOptions]: ['links'],
+          links:
+            language.formatDisjunctionList(
+              relations.externalLinks
+                .map(link =>
+                  link.slot('context', [
+                    'album',
+                    (data.numTracks === 0
+                      ? 'albumNoTracks'
+                   : data.numTracks === 1
+                      ? 'albumOneTrack'
+                      : 'albumMultipleTracks'),
+                  ]))),
+        })),
     ]);
   },
 };

--- a/src/content/dependencies/generateAlbumSidebarGroupBox.js
+++ b/src/content/dependencies/generateAlbumSidebarGroupBox.js
@@ -1,5 +1,5 @@
 import {sortChronologically} from '#sort';
-import {atOffset, empty} from '#sugar';
+import {atOffset} from '#sugar';
 
 export default {
   contentDependencies: [
@@ -89,26 +89,31 @@ export default {
           relations.description
             ?.slot('mode', 'multiline'),
 
-        !empty(relations.externalLinks) &&
-          html.tag('p',
-            language.$('releaseInfo.visitOn', {
-              links:
-                language.formatDisjunctionList(
-                  relations.externalLinks
-                    .map(link => link.slot('context', 'group'))),
-            })),
+        html.tag('p',
+          {[html.onlyIfContent]: true},
+
+          language.$('releaseInfo.visitOn', {
+            [language.onlyIfOptions]: ['links'],
+
+            links:
+              language.formatDisjunctionList(
+                relations.externalLinks
+                  .map(link => link.slot('context', 'group'))),
+          })),
 
         slots.mode === 'album' &&
-        relations.nextAlbumLink &&
           html.tag('p', {class: 'group-chronology-link'},
+            {[html.onlyIfContent]: true},
             language.$('albumSidebar.groupBox.next', {
+              [language.onlyIfOptions]: ['album'],
               album: relations.nextAlbumLink,
             })),
 
         slots.mode === 'album' &&
-        relations.previousAlbumLink &&
           html.tag('p', {class: 'group-chronology-link'},
+            {[html.onlyIfContent]: true},
             language.$('albumSidebar.groupBox.previous', {
+              [language.onlyIfOptions]: ['album'],
               album: relations.previousAlbumLink,
             })),
       ],

--- a/src/content/dependencies/generateArtistInfoPage.js
+++ b/src/content/dependencies/generateArtistInfoPage.js
@@ -153,7 +153,9 @@ export default {
 
         mainContent: [
           sec.contextNotes && [
-            html.tag('p', language.$('releaseInfo.note')),
+            html.tag('p',
+              language.$('releaseInfo.note')),
+
             html.tag('blockquote',
               sec.contextNotes.content),
           ],

--- a/src/content/dependencies/generateCommentaryEntry.js
+++ b/src/content/dependencies/generateCommentaryEntry.js
@@ -84,14 +84,14 @@ export default {
       html.tag('p', {class: 'commentary-entry-heading'},
         style,
         [
-          data.date &&
-            html.tag('time',
-              language.$(titlePrefix, 'date', {
-                date:
-                  language.formatDate(data.date),
-              })),
+          html.tag('time',
+            {[html.onlyIfContent]: true},
+            language.$(titlePrefix, 'date', {
+              [language.onlyIfOptions]: ['date'],
+              date: language.formatDate(data.date),
+            })),
 
-          language.$(...titleParts, titleOptions)
+          language.$(...titleParts, titleOptions),
         ]),
 
       html.tag('blockquote', {class: 'commentary-entry-body'},

--- a/src/content/dependencies/generateCoverArtwork.js
+++ b/src/content/dependencies/generateCoverArtwork.js
@@ -1,4 +1,4 @@
-import {empty, stitchArrays} from '#sugar';
+import {stitchArrays} from '#sugar';
 
 export default {
   contentDependencies: ['image', 'linkArtTag'],
@@ -89,14 +89,15 @@ export default {
             ...sizeSlots,
           }),
 
-          !empty(relations.tagLinks) &&
-            html.tag('ul', {class: 'image-details'},
-              stitchArrays({
-                tagLink: relations.tagLinks,
-                preferShortName: data.preferShortName,
-              }).map(({tagLink, preferShortName}) =>
-                  html.tag('li',
-                    tagLink.slot('preferShortName', preferShortName)))),
+          html.tag('ul', {class: 'image-details'},
+            {[html.onlyIfContent]: true},
+
+            stitchArrays({
+              tagLink: relations.tagLinks,
+              preferShortName: data.preferShortName,
+            }).map(({tagLink, preferShortName}) =>
+                html.tag('li',
+                  tagLink.slot('preferShortName', preferShortName)))),
         ]);
 
       case 'thumbnail':

--- a/src/content/dependencies/generateFlashIndexPage.js
+++ b/src/content/dependencies/generateFlashIndexPage.js
@@ -1,4 +1,4 @@
-import {empty, stitchArrays} from '#sugar';
+import {stitchArrays} from '#sugar';
 
 export default {
   contentDependencies: [
@@ -87,11 +87,13 @@ export default {
 
       mainClasses: ['flash-index'],
       mainContent: [
-        !empty(data.jumpLinkLabels) && [
+        html.tags([
           html.tag('p', {class: 'quick-info'},
+            {[html.onlyIfSiblings]: true},
             language.$('misc.jumpTo')),
 
           html.tag('ul', {class: 'quick-info'},
+            {[html.onlyIfContent]: true},
             stitchArrays({
               colorStyle: relations.jumpLinkColorStyles,
               anchor: data.jumpLinkAnchors,
@@ -102,7 +104,7 @@ export default {
                     {href: '#' + anchor},
                     colorStyle,
                     label)))),
-        ],
+        ]),
 
         stitchArrays({
           colorStyle: relations.actColorStyles,

--- a/src/content/dependencies/generateFlashInfoPage.js
+++ b/src/content/dependencies/generateFlashInfoPage.js
@@ -19,16 +19,14 @@ export default {
   query(flash) {
     const query = {};
 
-    if (flash.page || !empty(flash.urls)) {
-      query.urls = [];
+    query.urls = [];
 
-      if (flash.page) {
-        query.urls.push(`https://homestuck.com/story/${flash.page}`);
-      }
+    if (flash.page) {
+      query.urls.push(`https://homestuck.com/story/${flash.page}`);
+    }
 
-      if (!empty(flash.urls)) {
-        query.urls.push(...flash.urls);
-      }
+    if (!empty(flash.urls)) {
+      query.urls.push(...flash.urls);
     }
 
     return query;
@@ -44,10 +42,9 @@ export default {
     relations.sidebar =
       relation('generateFlashActSidebar', flash.act, flash);
 
-    if (query.urls) {
-      relations.externalLinks =
-        query.urls.map(url => relation('linkExternal', url));
-    }
+    relations.externalLinks =
+      query.urls
+        .map(url => relation('linkExternal', url));
 
     // TODO: Flashes always have cover art (#175)
     /* eslint-disable-next-line no-constant-condition */
@@ -135,14 +132,15 @@ export default {
             date: language.formatDate(data.date),
           })),
 
-        relations.externalLinks &&
-          html.tag('p',
-            language.$('releaseInfo.playOn', {
-              links:
-                language.formatDisjunctionList(
-                  relations.externalLinks
-                    .map(link => link.slot('context', 'flash'))),
-            })),
+        html.tag('p',
+          {[html.onlyIfContent]: true},
+          language.$('releaseInfo.playOn', {
+            [language.onlyIfOptions]: ['links'],
+            links:
+              language.formatDisjunctionList(
+                relations.externalLinks
+                  .map(link => link.slot('context', 'flash'))),
+          })),
 
         html.tag('p',
           {[html.onlyIfContent]: true},

--- a/src/content/dependencies/generateGroupInfoPage.js
+++ b/src/content/dependencies/generateGroupInfoPage.js
@@ -69,11 +69,9 @@ export default {
 
     sec.info = {};
 
-    if (!empty(group.urls)) {
-      sec.info.visitLinks =
-        group.urls
-          .map(url => relation('linkExternal', url));
-    }
+    sec.info.visitLinks =
+      group.urls
+        .map(url => relation('linkExternal', url));
 
     if (group.description) {
       sec.info.description =
@@ -131,14 +129,15 @@ export default {
         color: data.color,
 
         mainContent: [
-          sec.info.visitLinks &&
-            html.tag('p',
-              language.$('releaseInfo.visitOn', {
-                links:
-                  language.formatDisjunctionList(
-                    sec.info.visitLinks
-                      .map(link => link.slot('context', 'group'))),
-              })),
+          html.tag('p',
+            {[html.onlyIfContent]: true},
+            language.$('releaseInfo.visitOn', {
+              [language.onlyIfOptions]: ['links'],
+              links:
+                language.formatDisjunctionList(
+                  sec.info.visitLinks
+                    .map(link => link.slot('context', 'group'))),
+            })),
 
           html.tag('blockquote',
             {[html.onlyIfContent]: true},

--- a/src/content/dependencies/generateListingPage.js
+++ b/src/content/dependencies/generateListingPage.js
@@ -34,13 +34,15 @@ export default {
       relations.sameTargetListingLinks =
         listing.target.listings
           .map(listing => relation('linkListing', listing));
+    } else {
+      relations.sameTargetListingLinks = [];
     }
 
-    if (!empty(listing.seeAlso)) {
-      relations.seeAlsoLinks =
-        listing.seeAlso
-          .map(listing => relation('linkListing', listing));
-    }
+    relations.seeAlsoLinks =
+      (!empty(listing.seeAlso)
+        ? listing.seeAlso
+            .map(listing => relation('linkListing', listing))
+        : []);
 
     return relations;
   },
@@ -167,33 +169,37 @@ export default {
       headingMode: 'sticky',
 
       mainContent: [
-        relations.sameTargetListingLinks &&
-          html.tag('p',
-            language.$('listingPage.listingsFor', {
-              target:
-                language.$('listingPage.target', data.targetStringsKey),
+        html.tag('p',
+          {[html.onlyIfContent]: true},
+          language.$('listingPage.listingsFor', {
+            [language.onlyIfOptions]: ['listings'],
 
-              listings:
-                language.formatUnitList(
-                  stitchArrays({
-                    link: relations.sameTargetListingLinks,
-                    stringsKey: data.sameTargetListingStringsKeys,
-                  }).map(({link, stringsKey}, index) =>
-                      html.tag('span',
-                        index === data.sameTargetListingsCurrentIndex &&
-                          {class: 'current'},
+            target:
+              language.$('listingPage.target', data.targetStringsKey),
 
-                        link.slots({
-                          attributes: {class: 'nowrap'},
-                          content: language.$('listingPage', stringsKey, 'title.short'),
-                        })))),
-            })),
+            listings:
+              language.formatUnitList(
+                stitchArrays({
+                  link: relations.sameTargetListingLinks,
+                  stringsKey: data.sameTargetListingStringsKeys,
+                }).map(({link, stringsKey}, index) =>
+                    html.tag('span',
+                      index === data.sameTargetListingsCurrentIndex &&
+                        {class: 'current'},
 
-        relations.seeAlsoLinks &&
-          html.tag('p',
-            language.$('listingPage.seeAlso', {
-              listings: language.formatUnitList(relations.seeAlsoLinks),
-            })),
+                      link.slots({
+                        attributes: {class: 'nowrap'},
+                        content: language.$('listingPage', stringsKey, 'title.short'),
+                      })))),
+          })),
+
+        html.tag('p',
+          {[html.onlyIfContent]: true},
+          language.$('listingPage.seeAlso', {
+            [language.onlyIfOptions]: ['listings'],
+            listings:
+              language.formatUnitList(relations.seeAlsoLinks),
+          })),
 
         slots.content,
 

--- a/src/content/dependencies/generateStickyHeadingContainer.js
+++ b/src/content/dependencies/generateStickyHeadingContainer.js
@@ -22,10 +22,17 @@ export default {
         html.tag('div', {class: 'content-sticky-heading-row'}, [
           html.tag('h1', slots.title),
 
-          !html.isBlank(slots.cover) &&
-            html.tag('div', {class: 'content-sticky-heading-cover-container'},
-              html.tag('div', {class: 'content-sticky-heading-cover'},
-                slots.cover.slot('mode', 'thumbnail'))),
+          html.tag('div', {class: 'content-sticky-heading-cover-container'},
+            {[html.onlyIfContent]: true},
+
+            html.tag('div', {class: 'content-sticky-heading-cover'},
+              {[html.onlyIfContent]: true},
+
+              // TODO: We shouldn't need to do an isBlank check here,
+              // but a live blank value doesn't have a slot functions, so.
+              (html.isBlank(slots.cover)
+                ? html.blank()
+                : slots.cover.slot('mode', 'thumbnail')))),
         ]),
 
         html.tag('div', {class: 'content-sticky-subheading-row'},

--- a/src/content/dependencies/generateTrackReleaseInfo.js
+++ b/src/content/dependencies/generateTrackReleaseInfo.js
@@ -59,20 +59,20 @@ export default {
           relations.coverArtistContributionsLine
             ?.slots({stringKey: 'releaseInfo.coverArtBy'}),
 
-          data.date &&
-            language.$('releaseInfo.released', {
-              date: language.formatDate(data.date),
-            }),
+          language.$('releaseInfo.released', {
+            [language.onlyIfOptions]: ['date'],
+            date: language.formatDate(data.date),
+          }),
 
-          data.coverArtDate &&
-            language.$('releaseInfo.artReleased', {
-              date: language.formatDate(data.coverArtDate),
-            }),
+          language.$('releaseInfo.artReleased', {
+            [language.onlyIfOptions]: ['date'],
+            date: language.formatDate(data.coverArtDate),
+          }),
 
-          data.duration &&
-            language.$('releaseInfo.duration', {
-              duration: language.formatDuration(data.duration),
-            }),
+          language.$('releaseInfo.duration', {
+            [language.onlyIfOptions]: ['duration'],
+            duration: language.formatDuration(data.duration),
+          }),
         ]),
 
       html.tag('p',

--- a/src/content/dependencies/generateWikiHomeAlbumsRow.js
+++ b/src/content/dependencies/generateWikiHomeAlbumsRow.js
@@ -113,10 +113,10 @@ export default {
           image.slots({
             path,
             missingSourceContent:
-              name &&
-                language.$('misc.albumGrid.noCoverArt', {
-                  album: name,
-                }),
+              language.$('misc.albumGrid.noCoverArt', {
+                [language.onlyIfOptions]: ['album'],
+                album: name,
+              }),
             }));
 
     commonSlots.actionLinks =

--- a/src/data/things/language.js
+++ b/src/data/things/language.js
@@ -239,32 +239,37 @@ export class Language extends Thing {
       match: languageOptionRegex,
 
       insert: ({name: optionName}, canceledForming) => {
-        if (optionsMap.has(optionName)) {
-          let optionValue;
+        if (!optionsMap.has(optionName)) {
+          missingOptionNames.add(optionName);
 
-          // We'll only need the option's value if we're going to use it as
-          // part of the formed output (see below).
-          if (!canceledForming) {
-            optionValue = optionsMap.get(optionName);
-          }
-
-          // But we always have to delete expected options off the provided
-          // option map, since the leftovers are what will be used to tell
-          // which are misplaced.
-          optionsMap.delete(optionName);
-
-          if (canceledForming) {
-            return undefined;
-          } else {
-            return optionValue;
-          }
-        } else {
           // We don't need to continue forming the output if we've hit a
           // missing option name, since the end result of this formatString
           // call will be a thrown error, and formed output won't be needed.
-          missingOptionNames.add(optionName);
+          // Return undefined to mark canceledForming for the following
+          // iterations (and exit early out of this iteration).
           return undefined;
         }
+
+        let optionValue;
+
+        // We'll only need the option's value if we're going to use it as
+        // part of the formed output (see below). But, we have to do this get
+        // call now, since we'll be deleting it from optionsMap next!
+        if (!canceledForming) {
+          optionValue = optionsMap.get(optionName);
+        }
+
+        // We always have to delete expected options off the provided option
+        // map, since the leftovers are what will be used to tell which are
+        // misplaced - information you want even (or doubly so) if the string
+        // is already invalid thanks to missing options.
+        optionsMap.delete(optionName);
+
+        if (canceledForming) {
+          return undefined;
+        }
+
+        return optionValue;
       },
     });
 

--- a/src/data/things/language.js
+++ b/src/data/things/language.js
@@ -476,11 +476,32 @@ export class Language extends Thing {
   }
 
   formatDate(date) {
+    // Null or undefined date is blank content.
+    if (date === null || date === undefined) {
+      return html.blank();
+    }
+
     this.assertIntlAvailable('intl_date');
     return this.intl_date.format(date);
   }
 
   formatDateRange(startDate, endDate) {
+    // formatDateRange expects both values to be present, but if both are null
+    // or both are undefined, that's just blank content.
+    const hasStart = startDate !== null && startDate !== undefined;
+    const hasEnd = endDate !== null && endDate !== undefined;
+    if (!hasStart || !hasEnd) {
+      if (startDate === endDate) {
+        return html.blank();
+      } else if (hasStart) {
+        throw new Error(`Expected both start and end of date range, got only start`);
+      } else if (hasEnd) {
+        throw new Error(`Expected both start and end of date range, got only end`);
+      } else {
+        throw new Error(`Got mismatched ${startDate}/${endDate} for start and end`);
+      }
+    }
+
     this.assertIntlAvailable('intl_date');
     return this.intl_date.formatRange(startDate, endDate);
   }
@@ -491,6 +512,17 @@ export class Language extends Thing {
     days: numDays = 0,
     approximate = false,
   }) {
+    // Give up if any of years, months, or days is null or undefined.
+    // These default to zero, so something's gone pretty badly wrong to
+    // pass in all or partial missing values.
+    if (
+      numYears === undefined || numYears === null ||
+      numMonths === undefined || numMonths === null ||
+      numDays === undefined || numDays === null
+    ) {
+      throw new Error(`Expected values or default zero for years, months, and days`);
+    }
+
     let basis;
 
     const years = this.countYears(numYears, {unit: true});
@@ -528,6 +560,14 @@ export class Language extends Thing {
     approximate = true,
     absolute = true,
   } = {}) {
+    // Give up if current and/or reference date is null or undefined.
+    if (
+      currentDate === undefined || currentDate === null ||
+      referenceDate === undefined || referenceDate === null
+    ) {
+      throw new Error(`Expected values for currentDate and referenceDate`);
+    }
+
     const currentInstant = toTemporalInstant.apply(currentDate);
     const referenceInstant = toTemporalInstant.apply(referenceDate);
 

--- a/src/data/things/language.js
+++ b/src/data/things/language.js
@@ -738,8 +738,8 @@ export class Language extends Thing {
   }
 
   #formatListHelper(array, processFn) {
-    // Empty lists are blank content.
-    if (empty(array)) {
+    // Empty lists, null, and undefined are blank content.
+    if (empty(array) || array === null || array === undefined) {
       return html.blank();
     }
 

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -617,6 +617,8 @@ export class Tag {
     let content = '';
     let blockwrapClosers = '';
 
+    let seenSiblingIndependentContent = false;
+
     const chunkwrapSplitter =
       (this.chunkwrap
         ? this.#getAttributeString('split')
@@ -669,6 +671,10 @@ export class Tag {
 
       if (!itemContent) {
         continue;
+      }
+
+      if (!(item instanceof Tag && item.onlyIfSiblings)) {
+        seenSiblingIndependentContent = true;
       }
 
       const chunkwrapChunks =
@@ -741,6 +747,12 @@ export class Tag {
 
         content += itemContent;
       }
+    }
+
+    // If we've only seen sibling-dependent content (or just no content),
+    // then the content in total is blank.
+    if (!seenSiblingIndependentContent) {
+      return '';
     }
 
     if (chunkwrapSplitter) {


### PR DESCRIPTION
Wow! How relevant! How new! Buy it!

* Adds `[html.onlyIfSiblings]: true`, which marks that a tag should only be displayed if it has any siblings with content (and who don't have `[html.onlyIfSiblings]`). This is mostly for use inside elements with `[html.onlyIfContent]` but works in normal-parent contexts too, as well as in a plain old nested `html.tags([...])`.
* Adds `[language.onlyIfOptions]: ['opt1', 'opt2', ...]`, which goes inside `language.formatString` / `language.$` calls! This marks that particular options *might* not have a value, and if so, the whole string should be treated like `html.blank()`.
  * We made "valueless" options throw an error by default, now. These are options whose values are `null`, `undefined`, or blank HTML content (`html.isBlank()`). These were all valid before and made some pretty odd, unwanted results! ([#hsmusic-chat](https://discord.com/channels/749042497610842152/779895315750715422/1248646161200320674))
  * Valueless options are differentiated from *missing* options, which are keys that aren't even specified on the `formatString` call's options object. (And from *misplaced* options, which are ones that were specified, but unexpected.)
  * Although the default behavior is to throw, a valueless option will instead mark a flag to return `html.blank()` for the string (provided no errors) *if* it's included in the call's `[language.onlyIfOptions]` list.
* Makes basically all the formatting functions/utilities on `language` return `html.blank()` when provided `null` or `undefined`.
  * `formatDateRange` has particular errors about getting only one date, or mismatched null/undefined.
  * `formatRelativeDate` and `formatDateDuration` both give up when faced with null/undefined.
  * `formatDate`, `formatDuration`, `formatIndex`, `formatNumber`, `formatExternalLink`, `formatWordCount`, and `formatFileSize` all return blank for null/undefined.
  * All list formatting functions (through `#formatListHelper`) return blank for empty arrays, null, and undefined.

Content changes are bundled in one commit and generally as minimal as could be. There are ways to adapt existing content code's structure that would lend better to `[html.onlyIfSiblings]`! But we left larger changes out of scope, to give a focused demo of how onlyIfSiblings can be useful. 👾✨ 