### PR TITLE
Info page code cleanup!

### DIFF
--- a/src/content/dependencies/generateAdditionalFilesList.js
+++ b/src/content/dependencies/generateAdditionalFilesList.js
@@ -15,6 +15,8 @@ export default {
 
   generate: (slots, {html}) =>
     html.tag('ul', {class: 'additional-files-list'},
+      {[html.onlyIfContent]: true},
+
       stitchArrays({
         chunk: slots.chunks,
         items: slots.chunkItems,

--- a/src/content/dependencies/generateAlbumChronologyLinks.js
+++ b/src/content/dependencies/generateAlbumChronologyLinks.js
@@ -1,0 +1,53 @@
+import {sortAlbumsTracksChronologically} from '#sort';
+
+import getChronologyRelations from '../util/getChronologyRelations.js';
+
+export default {
+  contentDependencies: [
+    'generateChronologyLinks',
+    'linkAlbum',
+    'linkArtist',
+    'linkTrack',
+  ],
+
+  relations: (relation, album) => ({
+    chronologyLinks:
+      relation('generateChronologyLinks'),
+
+    coverArtistChronologyContributions:
+      getChronologyRelations(album, {
+        contributions: album.coverArtistContribs ?? [],
+
+        linkArtist: artist => relation('linkArtist', artist),
+
+        linkThing: trackOrAlbum =>
+          (trackOrAlbum.album
+            ? relation('linkTrack', trackOrAlbum)
+            : relation('linkAlbum', trackOrAlbum)),
+
+        getThings(artist) {
+          const getDate = thing => thing.coverArtDate ?? thing.date;
+
+          const things =
+            ([
+              artist.albumCoverArtistContributions,
+              artist.trackCoverArtistContributions,
+            ]).flat()
+              .map(({thing}) => thing)
+              .filter(getDate);
+
+          return sortAlbumsTracksChronologically(things, {getDate});
+        },
+      }),
+  }),
+
+  generate: (relations) =>
+    relations.chronologyLinks.slots({
+      chronologyInfoSets: [
+        {
+          headingString: 'misc.chronology.heading.coverArt',
+          contributions: relations.coverArtistChronologyContributions,
+        },
+      ],
+    }),
+}

--- a/src/content/dependencies/generateAlbumInfoPage.js
+++ b/src/content/dependencies/generateAlbumInfoPage.js
@@ -1,7 +1,4 @@
-import {sortAlbumsTracksChronologically} from '#sort';
 import {empty} from '#sugar';
-
-import getChronologyRelations from '../util/getChronologyRelations.js';
 
 export default {
   contentDependencies: [
@@ -15,14 +12,13 @@ export default {
     'generateAlbumSocialEmbed',
     'generateAlbumStyleRules',
     'generateAlbumTrackList',
-    'generateChronologyLinks',
+    'generateAlbumChronologyLinks',
     'generateCommentarySection',
     'generateContentHeading',
     'generatePageLayout',
     'linkAlbum',
     'linkAlbumCommentary',
     'linkAlbumGallery',
-    'linkArtist',
     'linkTrack',
     'transformContent',
   ],
@@ -42,37 +38,11 @@ export default {
     relations.socialEmbed =
       relation('generateAlbumSocialEmbed', album);
 
-    relations.coverArtistChronologyContributions =
-      getChronologyRelations(album, {
-        contributions: album.coverArtistContribs ?? [],
-
-        linkArtist: artist => relation('linkArtist', artist),
-
-        linkThing: trackOrAlbum =>
-          (trackOrAlbum.album
-            ? relation('linkTrack', trackOrAlbum)
-            : relation('linkAlbum', trackOrAlbum)),
-
-        getThings(artist) {
-          const getDate = thing => thing.coverArtDate ?? thing.date;
-
-          const things =
-            ([
-              artist.albumCoverArtistContributions,
-              artist.trackCoverArtistContributions,
-            ]).flat()
-              .map(({thing}) => thing)
-              .filter(getDate);
-
-          return sortAlbumsTracksChronologically(things, {getDate});
-        },
-      });
-
     relations.albumNavAccent =
       relation('generateAlbumNavAccent', album, null);
 
     relations.chronologyLinks =
-      relation('generateChronologyLinks');
+      relation('generateAlbumChronologyLinks', album);
 
     relations.secondaryNav =
       relation('generateAlbumSecondaryNav', album);
@@ -249,14 +219,7 @@ export default {
         ],
 
         navContent:
-          relations.chronologyLinks.slots({
-            chronologyInfoSets: [
-              {
-                headingString: 'misc.chronology.heading.coverArt',
-                contributions: relations.coverArtistChronologyContributions,
-              },
-            ],
-          }),
+          relations.chronologyLinks,
 
         banner: relations.banner ?? null,
         bannerPosition: 'top',

--- a/src/content/dependencies/generateArtistInfoPage.js
+++ b/src/content/dependencies/generateArtistInfoPage.js
@@ -11,309 +11,289 @@ export default {
     'generateContentHeading',
     'generateCoverArtwork',
     'generatePageLayout',
-    'linkAlbum',
     'linkArtistGallery',
     'linkExternal',
-    'linkGroup',
-    'linkTrack',
     'transformContent',
   ],
 
-  extraDependencies: ['html', 'language', 'wikiData'],
+  extraDependencies: ['html', 'language'],
 
-  sprawl({wikiInfo}) {
-    return {
-      enableFlashesAndGames: wikiInfo.enableFlashesAndGames,
-    };
-  },
-
-  query(sprawl, artist) {
-    return {
-      // Even if an artist has served as both "artist" (compositional) and
-      // "contributor" (instruments, production, etc) on the same track, that
-      // track only counts as one unique contribution in the list.
-      allTracks:
-        unique(
-          ([
-            artist.trackArtistContributions,
-            artist.trackContributorContributions,
-          ]).flat()
-            .map(({thing}) => thing)),
-
-      // Artworks are different, though. We intentionally duplicate album data
-      // objects when the artist has contributed some combination of cover art,
-      // wallpaper, and banner - these each count as a unique contribution.
-      allArtworks:
+  query: (artist) => ({
+    // Even if an artist has served as both "artist" (compositional) and
+    // "contributor" (instruments, production, etc) on the same track, that
+    // track only counts as one unique contribution in the list.
+    allTracks:
+      unique(
         ([
-          artist.albumCoverArtistContributions,
-          artist.albumWallpaperArtistContributions,
-          artist.albumBannerArtistContributions,
-          artist.trackCoverArtistContributions,
+          artist.trackArtistContributions,
+          artist.trackContributorContributions,
         ]).flat()
-          .map(({thing}) => thing),
+          .map(({thing}) => thing)),
 
-      // Banners and wallpapers don't show up in the artist gallery page, only
-      // cover art.
-      hasGallery:
-        !empty(artist.albumCoverArtistContributions) ||
-        !empty(artist.trackCoverArtistContributions),
-    };
-  },
+    // Artworks are different, though. We intentionally duplicate album data
+    // objects when the artist has contributed some combination of cover art,
+    // wallpaper, and banner - these each count as a unique contribution.
+    allArtworks:
+      ([
+        artist.albumCoverArtistContributions,
+        artist.albumWallpaperArtistContributions,
+        artist.albumBannerArtistContributions,
+        artist.trackCoverArtistContributions,
+      ]).flat()
+        .map(({thing}) => thing),
 
-  relations(relation, query, sprawl, artist) {
-    const relations = {};
-    const sections = relations.sections = {};
+    // Banners and wallpapers don't show up in the artist gallery page, only
+    // cover art.
+    hasGallery:
+      !empty(artist.albumCoverArtistContributions) ||
+      !empty(artist.trackCoverArtistContributions),
+  }),
 
-    relations.layout =
-      relation('generatePageLayout');
+  relations: (relation, query, artist) => ({
+    layout:
+      relation('generatePageLayout'),
 
-    relations.artistNavLinks =
-      relation('generateArtistNavLinks', artist);
+    artistNavLinks:
+      relation('generateArtistNavLinks', artist),
 
-    if (artist.hasAvatar) {
-      relations.cover =
-        relation('generateCoverArtwork', []);
-    }
+    cover:
+      (artist.hasAvatar
+        ? relation('generateCoverArtwork', [])
+        : null),
 
-    if (artist.contextNotes) {
-      const contextNotes = sections.contextNotes = {};
-      contextNotes.content = relation('transformContent', artist.contextNotes);
-    }
+    contentHeading:
+      relation('generateContentHeading'),
 
-    if (!empty(artist.urls)) {
-      const visit = sections.visit = {};
-      visit.externalLinks =
-        artist.urls.map(url =>
-          relation('linkExternal', url));
-    }
+    contextNotes:
+      relation('transformContent', artist.contextNotes),
 
-    if (!empty(query.allTracks)) {
-      const tracks = sections.tracks = {};
-      tracks.heading = relation('generateContentHeading');
-      tracks.list = relation('generateArtistInfoPageTracksChunkedList', artist);
-      tracks.groupInfo = relation('generateArtistGroupContributionsInfo', query.allTracks);
-    }
+    visitLinks:
+      artist.urls
+        .map(url => relation('linkExternal', url)),
 
-    if (!empty(query.allArtworks)) {
-      const artworks = sections.artworks = {};
-      artworks.heading = relation('generateContentHeading');
-      artworks.list = relation('generateArtistInfoPageArtworksChunkedList', artist);
-      artworks.groupInfo =
-        relation('generateArtistGroupContributionsInfo', query.allArtworks);
+    tracksChunkedList:
+      relation('generateArtistInfoPageTracksChunkedList', artist),
 
-      if (query.hasGallery) {
-        artworks.artistGalleryLink =
-          relation('linkArtistGallery', artist);
-      }
-    }
+    tracksGroupInfo:
+      relation('generateArtistGroupContributionsInfo', query.allTracks),
 
-    if (sprawl.enableFlashesAndGames && !empty(artist.flashContributorContributions)) {
-      const flashes = sections.flashes = {};
-      flashes.heading = relation('generateContentHeading');
-      flashes.list = relation('generateArtistInfoPageFlashesChunkedList', artist);
-    }
+    artworksChunkedList:
+      relation('generateArtistInfoPageArtworksChunkedList', artist),
 
-    if (!empty(artist.albumsAsCommentator) || !empty(artist.tracksAsCommentator)) {
-      const commentary = sections.commentary = {};
-      commentary.heading = relation('generateContentHeading');
-      commentary.list = relation('generateArtistInfoPageCommentaryChunkedList', artist);
-    }
+    artworksGroupInfo:
+      relation('generateArtistGroupContributionsInfo', query.allArtworks),
 
-    return relations;
-  },
+    artistGalleryLink:
+      (query.hasGallery
+        ? relation('linkArtistGallery', artist)
+        : null),
 
-  data(query, sprawl, artist) {
-    const data = {};
+    flashesChunkedList:
+      relation('generateArtistInfoPageFlashesChunkedList', artist),
 
-    data.name = artist.name;
-    data.directory = artist.directory;
+    commentaryChunkedList:
+      relation('generateArtistInfoPageCommentaryChunkedList', artist),
+  }),
 
-    if (artist.hasAvatar) {
-      data.avatarFileExtension = artist.avatarFileExtension;
-    }
+  data: (query, artist) => ({
+    name:
+      artist.name,
 
-    data.totalTrackCount = query.allTracks.length;
-    data.totalDuration = artist.totalDuration;
+    directory:
+      artist.directory,
 
-    return data;
-  },
+    avatarFileExtension:
+      (artist.hasAvatar
+        ? artist.avatarFileExtension
+        : null),
 
-  generate(data, relations, {html, language}) {
-    const {sections: sec} = relations;
+    totalTrackCount:
+      query.allTracks.length,
 
-    return relations.layout
-      .slots({
-        title: data.name,
-        headingMode: 'sticky',
+    totalDuration:
+      artist.totalDuration,
+  }),
 
-        cover:
-          (relations.cover
-            ? relations.cover.slots({
-                path: [
-                  'media.artistAvatar',
-                  data.directory,
-                  data.avatarFileExtension,
-                ],
-              })
-            : null),
+  generate: (data, relations, {html, language}) =>
+    relations.layout.slots({
+      title: data.name,
+      headingMode: 'sticky',
 
-        mainContent: [
-          sec.contextNotes && [
+      cover:
+        (relations.cover
+          ? relations.cover.slots({
+              path: [
+                'media.artistAvatar',
+                data.directory,
+                data.avatarFileExtension,
+              ],
+            })
+          : null),
+
+      mainContent: [
+        html.tags([
+          html.tag('p',
+            {[html.onlyIfSiblings]: true},
+            language.$('releaseInfo.note')),
+
+          html.tag('blockquote',
+            {[html.onlyIfContent]: true},
+            relations.contextNotes),
+        ]),
+
+        html.tag('p',
+          {[html.onlyIfContent]: true},
+          language.$('releaseInfo.visitOn', {
+            [language.onlyIfOptions]: ['links'],
+            links:
+              language.formatDisjunctionList(
+                relations.visitLinks
+                  .map(link => link.slot('context', 'artist'))),
+          })),
+
+        html.tag('p',
+          {[html.onlyIfContent]: true},
+          language.$('artistPage.viewArtGallery', {
+            [language.onlyIfOptions]: ['link'],
+            link:
+              relations.artistGalleryLink?.slots({
+                content: language.$('artistPage.viewArtGallery.link'),
+              }),
+          })),
+
+        html.tag('p',
+          {[html.onlyIfContent]: true},
+          language.$('misc.jumpTo.withLinks', {
+            [language.onlyIfOptions]: ['links'],
+            links:
+              language.formatUnitList([
+                !html.isBlank(relations.tracksChunkedList) &&
+                  html.tag('a',
+                    {href: '#tracks'},
+                    language.$('artistPage.trackList.title')),
+
+                !html.isBlank(relations.artworksChunkedList) &&
+                  html.tag('a',
+                    {href: '#art'},
+                    language.$('artistPage.artList.title')),
+
+                !html.isBlank(relations.flashesChunkedList) &&
+                  html.tag('a',
+                    {href: '#flashes'},
+                    language.$('artistPage.flashList.title')),
+
+                !html.isBlank(relations.commentaryChunkedList) &&
+                  html.tag('a',
+                    {href: '#commentary'},
+                    language.$('artistPage.commentaryList.title')),
+              ].filter(Boolean)),
+          })),
+
+        html.tags([
+          relations.contentHeading.clone()
+            .slots({
+              tag: 'h2',
+              attributes: {id: 'tracks'},
+              title: language.$('artistPage.trackList.title'),
+            }),
+
+          data.totalDuration > 0 &&
             html.tag('p',
-              language.$('releaseInfo.note')),
-
-            html.tag('blockquote',
-              sec.contextNotes.content),
-          ],
-
-          sec.visit &&
-            html.tag('p',
-              language.$('releaseInfo.visitOn', {
-                links:
-                  language.formatDisjunctionList(
-                    sec.visit.externalLinks
-                      .map(link => link.slot('context', 'artist'))),
+              {[html.onlyIfSiblings]: true},
+              language.$('artistPage.contributedDurationLine', {
+                artist: data.name,
+                duration:
+                  language.formatDuration(data.totalDuration, {
+                    approximate: data.totalTrackCount > 1,
+                    unit: true,
+                  }),
               })),
 
-          sec.artworks?.artistGalleryLink &&
-            html.tag('p',
-              language.$('artistPage.viewArtGallery', {
-                link: sec.artworks.artistGalleryLink.slots({
+          relations.tracksChunkedList.slots({
+            groupInfo: [
+              relations.tracksGroupInfo
+                .clone()
+                .slots({
+                  title: language.$('artistPage.groupContributions.title.music'),
+                  showSortButton: true,
+                  sort: 'count',
+                  countUnit: 'tracks',
+                  visible: true,
+                }),
+
+              relations.tracksGroupInfo
+                .clone()
+                .slots({
+                  title: language.$('artistPage.groupContributions.title.music'),
+                  showSortButton: true,
+                  sort: 'duration',
+                  countUnit: 'tracks',
+                  visible: false,
+                }),
+            ],
+          }),
+        ]),
+
+        html.tags([
+          relations.contentHeading.clone()
+            .slots({
+              tag: 'h2',
+              attributes: {id: 'art'},
+              title: language.$('artistPage.artList.title'),
+            }),
+
+          html.tag('p',
+            {[html.onlyIfContent]: true},
+            language.$('artistPage.viewArtGallery.orBrowseList', {
+              [language.onlyIfOptions]: ['link'],
+              link:
+                relations.artistGalleryLink?.slots({
                   content: language.$('artistPage.viewArtGallery.link'),
                 }),
-              })),
+            })),
 
-          (sec.tracks || sec.artworsk || sec.flashes || sec.commentary) &&
-            html.tag('p',
-              language.$('misc.jumpTo.withLinks', {
-                links: language.formatUnitList(
-                  [
-                    sec.tracks &&
-                      html.tag('a',
-                        {href: '#tracks'},
-                        language.$('artistPage.trackList.title')),
-
-                    sec.artworks &&
-                      html.tag('a',
-                        {href: '#art'},
-                        language.$('artistPage.artList.title')),
-
-                    sec.flashes &&
-                      html.tag('a',
-                        {href: '#flashes'},
-                        language.$('artistPage.flashList.title')),
-
-                    sec.commentary &&
-                      html.tag('a',
-                        {href: '#commentary'},
-                        language.$('artistPage.commentaryList.title')),
-                  ].filter(Boolean)),
-              })),
-
-          sec.tracks && [
-            sec.tracks.heading
-              .slots({
-                tag: 'h2',
-                attributes: {id: 'tracks'},
-                title: language.$('artistPage.trackList.title'),
-              }),
-
-            data.totalDuration > 0 &&
-              html.tag('p',
-                language.$('artistPage.contributedDurationLine', {
-                  artist: data.name,
-                  duration:
-                    language.formatDuration(data.totalDuration, {
-                      approximate: data.totalTrackCount > 1,
-                      unit: true,
-                    }),
-                })),
-
-            sec.tracks.list
-              .slots({
-                groupInfo: [
-                  sec.tracks.groupInfo
-                    .clone()
-                    .slots({
-                      title: language.$('artistPage.groupContributions.title.music'),
-                      showSortButton: true,
-                      sort: 'count',
-                      countUnit: 'tracks',
-                      visible: true,
-                    }),
-
-                  sec.tracks.groupInfo
-                    .clone()
-                    .slots({
-                      title: language.$('artistPage.groupContributions.title.music'),
-                      showSortButton: true,
-                      sort: 'duration',
-                      countUnit: 'tracks',
-                      visible: false,
-                    }),
-                ],
-              }),
-          ],
-
-          sec.artworks && [
-            sec.artworks.heading
-              .slots({
-                tag: 'h2',
-                attributes: {id: 'art'},
-                title: language.$('artistPage.artList.title'),
-              }),
-
-            sec.artworks.artistGalleryLink &&
-              html.tag('p',
-                language.$('artistPage.viewArtGallery.orBrowseList', {
-                  link: sec.artworks.artistGalleryLink.slots({
-                    content: language.$('artistPage.viewArtGallery.link'),
-                  }),
-                })),
-
-            sec.artworks.list
-              .slots({
-                groupInfo:
-                  sec.artworks.groupInfo
-                    .slots({
-                      title: language.$('artistPage.groupContributions.title.artworks'),
-                      showBothColumns: false,
-                      sort: 'count',
-                      countUnit: 'artworks',
-                    }),
-              }),
-          ],
-
-          sec.flashes && [
-            sec.flashes.heading
-              .slots({
-                tag: 'h2',
-                attributes: {id: 'flashes'},
-                title: language.$('artistPage.flashList.title'),
-              }),
-
-            sec.flashes.list,
-          ],
-
-          sec.commentary && [
-            sec.commentary.heading
-              .slots({
-                tag: 'h2',
-                attributes: {id: 'commentary'},
-                title: language.$('artistPage.commentaryList.title'),
-              }),
-
-            sec.commentary.list,
-          ],
-        ],
-
-        navLinkStyle: 'hierarchical',
-        navLinks:
-          relations.artistNavLinks
+          relations.artworksChunkedList
             .slots({
-              showExtraLinks: true,
-            })
-            .content,
-      });
-  },
+              groupInfo:
+                relations.artworksGroupInfo
+                  .slots({
+                    title: language.$('artistPage.groupContributions.title.artworks'),
+                    showBothColumns: false,
+                    sort: 'count',
+                    countUnit: 'artworks',
+                  }),
+            }),
+        ]),
+
+        html.tags([
+          relations.contentHeading.clone()
+            .slots({
+              tag: 'h2',
+              attributes: {id: 'flashes'},
+              title: language.$('artistPage.flashList.title'),
+            }),
+
+          relations.flashesChunkedList,
+        ]),
+
+        html.tags([
+          relations.contentHeading.clone()
+            .slots({
+              tag: 'h2',
+              attributes: {id: 'commentary'},
+              title: language.$('artistPage.commentaryList.title'),
+            }),
+
+          relations.commentaryChunkedList,
+        ]),
+      ],
+
+      navLinkStyle: 'hierarchical',
+      navLinks:
+        relations.artistNavLinks
+          .slots({
+            showExtraLinks: true,
+          })
+          .content,
+    }),
 };

--- a/src/content/dependencies/generateArtistInfoPageChunkedList.js
+++ b/src/content/dependencies/generateArtistInfoPageChunkedList.js
@@ -13,11 +13,8 @@ export default {
     },
   },
 
-  generate(slots, {html}) {
-    return (
-      html.tag('dl', [
-        slots.groupInfo,
-        slots.chunks,
-      ]));
-  },
+  generate: (slots, {html}) =>
+    html.tag('dl',
+      {[html.onlyIfContent]: true},
+      [slots.groupInfo, slots.chunks]),
 };

--- a/src/content/dependencies/generateArtistInfoPageFlashesChunkedList.js
+++ b/src/content/dependencies/generateArtistInfoPageFlashesChunkedList.js
@@ -8,12 +8,22 @@ export default {
     'generateArtistInfoPageFlashesChunk',
   ],
 
-  query(artist) {
+  extraDependencies: ['wikiData'],
+
+  sprawl: ({wikiInfo}) => ({
+    enableFlashesAndGames:
+      wikiInfo.enableFlashesAndGames,
+  }),
+
+  query(sprawl, artist) {
     const query = {};
 
-    const allContributions = [
-      ...artist.flashContributorContributions,
-    ];
+    const allContributions =
+      (sprawl.enableFlashesAndGames
+        ? [
+            ...artist.flashContributorContributions,
+          ]
+      : []);
 
     sortContributionsChronologically(
       allContributions,
@@ -33,7 +43,7 @@ export default {
     return query;
   },
 
-  relations: (relation, query, _artist) => ({
+  relations: (relation, query, _sprawl, _artist) => ({
     chunkedList:
       relation('generateArtistInfoPageChunkedList'),
 

--- a/src/content/dependencies/generateCommentarySection.js
+++ b/src/content/dependencies/generateCommentarySection.js
@@ -1,3 +1,5 @@
+import {empty} from '#sugar';
+
 export default {
   contentDependencies: [
     'transformContent',
@@ -12,15 +14,17 @@ export default {
       relation('generateContentHeading'),
 
     entries:
-      entries.map(entry =>
-        relation('generateCommentaryEntry', entry)),
+      (entries
+        ? entries.map(entry =>
+            relation('generateCommentaryEntry', entry))
+        : []),
   }),
 
   data: (entries) => ({
     firstEntryIsDated:
-      (entries[0]
-        ? !!entries[0].date
-        : null),
+      (empty(entries)
+        ? null
+        : !!entries[0].date),
   }),
 
   generate: (data, relations, {html, language}) =>

--- a/src/content/dependencies/generateContentHeading.js
+++ b/src/content/dependencies/generateContentHeading.js
@@ -38,6 +38,7 @@ export default {
   generate: (relations, slots, {html}) =>
     html.tag(slots.tag, {class: 'content-heading'},
       {tabindex: '0'},
+      {[html.onlyIfSiblings]: true},
 
       slots.attributes,
 

--- a/src/content/dependencies/generateContributionList.js
+++ b/src/content/dependencies/generateContributionList.js
@@ -2,17 +2,20 @@ export default {
   contentDependencies: ['linkContribution'],
   extraDependencies: ['html'],
 
-  relations: (relation, contributions) =>
-    ({contributionLinks:
-        contributions
-          .map(contrib => relation('linkContribution', contrib))}),
+  relations: (relation, contributions) => ({
+    contributionLinks:
+      contributions
+        .map(contrib => relation('linkContribution', contrib)),
+  }),
 
   generate: (relations, {html}) =>
     html.tag('ul',
-      relations.contributionLinks.map(contributionLink =>
-        html.tag('li',
-          contributionLink
-            .slots({
+      {[html.onlyIfContent]: true},
+
+      relations.contributionLinks
+        .map(contributionLink =>
+          html.tag('li',
+            contributionLink.slots({
               showIcons: true,
               showContribution: true,
               preventWrapping: false,

--- a/src/content/dependencies/generateGroupInfoPageAlbumsSection.js
+++ b/src/content/dependencies/generateGroupInfoPageAlbumsSection.js
@@ -1,0 +1,132 @@
+import {empty} from '#sugar';
+import {stitchArrays} from '#sugar';
+
+export default {
+  contentDependencies: [
+    'generateAbsoluteDatetimestamp',
+    'generateColorStyleAttribute',
+    'generateContentHeading',
+    'linkAlbum',
+    'linkGroupGallery',
+    'linkGroup',
+  ],
+
+  extraDependencies: ['html', 'language'],
+
+  query(group) {
+    const albums =
+      group.albums;
+
+    const albumGroups =
+      albums
+        .map(album => album.groups);
+
+    const albumOtherCategory =
+      albumGroups
+        .map(groups => groups
+          .map(group => group.category)
+          .find(category => category !== group.category));
+
+    const albumOtherGroups =
+      stitchArrays({
+        groups: albumGroups,
+        category: albumOtherCategory,
+      }).map(({groups, category}) =>
+          groups
+            .filter(group => group.category === category));
+
+    return {albums, albumOtherGroups};
+  },
+
+  relations: (relation, query, group) => ({
+    contentHeading:
+      relation('generateContentHeading'),
+
+    galleryLink:
+      relation('linkGroupGallery', group),
+
+    albumColorStyles:
+      query.albums
+        .map(album => relation('generateColorStyleAttribute', album.color)),
+
+    albumLinks:
+      query.albums
+        .map(album => relation('linkAlbum', album)),
+
+    otherGroupLinks:
+      query.albumOtherGroups
+        .map(groups => groups
+          .map(group => relation('linkGroup', group))),
+
+    datetimestamps:
+      group.albums.map(album =>
+        (album.date
+          ? relation('generateAbsoluteDatetimestamp', album.date)
+          : null)),
+  }),
+
+  generate: (relations, {html, language}) =>
+    html.tags([
+      relations.contentHeading
+        .slots({
+          tag: 'h2',
+          title: language.$('groupInfoPage.albumList.title'),
+        }),
+
+      html.tag('p',
+        {[html.onlyIfSiblings]: true},
+        language.$('groupInfoPage.viewAlbumGallery', {
+          link:
+            relations.galleryLink
+              .slot('content', language.$('groupInfoPage.viewAlbumGallery.link')),
+        })),
+
+      html.tag('ul',
+        {[html.onlyIfContent]: true},
+
+        stitchArrays({
+          albumLink: relations.albumLinks,
+          otherGroupLinks: relations.otherGroupLinks,
+          datetimestamp: relations.datetimestamps,
+          albumColorStyle: relations.albumColorStyles,
+        }).map(({
+            albumLink,
+            otherGroupLinks,
+            datetimestamp,
+            albumColorStyle,
+          }) => {
+            const prefix = 'groupInfoPage.albumList.item';
+            const parts = [prefix];
+            const options = {};
+
+            options.album =
+              albumLink.slot('color', false);
+
+            if (datetimestamp) {
+              parts.push('withYear');
+              options.yearAccent =
+                language.$(prefix, 'yearAccent', {
+                  year:
+                    datetimestamp.slots({style: 'year', tooltip: true}),
+                });
+            }
+
+            if (!empty(otherGroupLinks)) {
+              parts.push('withOtherGroup');
+              options.otherGroupAccent =
+                html.tag('span', {class: 'other-group-accent'},
+                  language.$(prefix, 'otherGroupAccent', {
+                    groups:
+                      language.formatConjunctionList(
+                        otherGroupLinks.map(groupLink =>
+                          groupLink.slot('color', false))),
+                  }));
+            }
+
+            return (
+              html.tag('li',
+                albumColorStyle,
+                language.$(...parts, options)));
+          })),
+    ]),
+};

--- a/src/content/dependencies/generateTrackInfoPage.js
+++ b/src/content/dependencies/generateTrackInfoPage.js
@@ -107,21 +107,13 @@ export default {
 
     // Section: Referenced tracks
 
-    if (!empty(track.referencedTracks)) {
-      const references = sections.references = {};
-
-      references.list =
-        relation('generateTrackList', track.referencedTracks);
-    }
+    relations.referencedTracksList =
+      relation('generateTrackList', track.referencedTracks);
 
     // Section: Sampled tracks
 
-    if (!empty(track.sampledTracks)) {
-      const samples = sections.samples = {};
-
-      samples.list =
-        relation('generateTrackList', track.sampledTracks);
-    }
+    relations.sampledTracksList =
+      relation('generateTrackList', track.sampledTracks);
 
     // Section: Tracks that reference
 
@@ -279,7 +271,7 @@ export default {
                 }),
             ]),
 
-          relations.otherReleasesList && [
+          html.tags([
             relations.contentHeading.clone()
               .slots({
                 attributes: {id: 'also-released-as'},
@@ -287,7 +279,7 @@ export default {
               }),
 
             relations.otherReleasesList,
-          ],
+          ]),
 
           sec.contributors && [
             relations.contentHeading.clone()
@@ -299,7 +291,7 @@ export default {
             sec.contributors.list,
           ],
 
-          sec.references && [
+          html.tags([
             relations.contentHeading.clone()
               .slots({
                 attributes: {id: 'references'},
@@ -313,10 +305,10 @@ export default {
                   language.$('releaseInfo.tracksReferenced.sticky'),
               }),
 
-            sec.references.list,
-          ],
+            relations.referencedTracksList,
+          ]),
 
-          sec.samples && [
+          html.tags([
             relations.contentHeading.clone()
               .slots({
                 attributes: {id: 'samples'},
@@ -330,8 +322,8 @@ export default {
                   language.$('releaseInfo.tracksSampled.sticky'),
               }),
 
-            sec.samples.list,
-          ],
+            relations.sampledTracksList,
+          ]),
 
           sec.referencedBy && [
             relations.contentHeading.clone()

--- a/src/content/dependencies/generateTrackInfoPage.js
+++ b/src/content/dependencies/generateTrackInfoPage.js
@@ -49,7 +49,7 @@ export default {
     albumNavAccent:
       relation('generateAlbumNavAccent', track.album, track),
 
-    trackChronologyLinks:
+    chronologyLinks:
       relation('generateTrackChronologyLinks', track),
 
     secondaryNav:
@@ -369,7 +369,7 @@ export default {
         }),
 
       navContent:
-        relations.trackChronologyLinks,
+        relations.chronologyLinks,
 
       secondaryNav:
         relations.secondaryNav

--- a/src/content/dependencies/generateTrackInfoPage.js
+++ b/src/content/dependencies/generateTrackInfoPage.js
@@ -83,6 +83,9 @@ export default {
         relation('generateTrackCoverArtwork', track);
     }
 
+    relations.contentHeading =
+      relation('generateContentHeading');
+
     // Section: Release info
 
     relations.releaseInfo =
@@ -92,9 +95,6 @@ export default {
 
     if (!empty(track.otherReleases)) {
       const otherReleases = sections.otherReleases = {};
-
-      otherReleases.heading =
-        relation('generateContentHeading');
 
       otherReleases.colorStyles =
         track.otherReleases
@@ -131,9 +131,6 @@ export default {
     if (!empty(track.contributorContribs)) {
       const contributors = sections.contributors = {};
 
-      contributors.heading =
-        relation('generateContentHeading');
-
       contributors.list =
         relation('generateContributionList', track.contributorContribs);
     }
@@ -142,9 +139,6 @@ export default {
 
     if (!empty(track.referencedTracks)) {
       const references = sections.references = {};
-
-      references.heading =
-        relation('generateContentHeading');
 
       references.list =
         relation('generateTrackList', track.referencedTracks);
@@ -155,9 +149,6 @@ export default {
     if (!empty(track.sampledTracks)) {
       const samples = sections.samples = {};
 
-      samples.heading =
-        relation('generateContentHeading');
-
       samples.list =
         relation('generateTrackList', track.sampledTracks);
     }
@@ -166,9 +157,6 @@ export default {
 
     if (!empty(track.referencedByTracks)) {
       const referencedBy = sections.referencedBy = {};
-
-      referencedBy.heading =
-        relation('generateContentHeading');
 
       referencedBy.list =
         relation('generateTrackListDividedByGroups',
@@ -180,9 +168,6 @@ export default {
 
     if (!empty(track.sampledByTracks)) {
       const sampledBy = sections.sampledBy = {};
-
-      sampledBy.heading =
-        relation('generateContentHeading');
 
       sampledBy.list =
         relation('generateTrackListDividedByGroups',
@@ -209,9 +194,6 @@ export default {
       if (!empty(sortedFeatures)) {
         const flashesThatFeature = sections.flashesThatFeature = {};
 
-        flashesThatFeature.heading =
-          relation('generateContentHeading');
-
         flashesThatFeature.entries =
           sortedFeatures.map(({flash, track: directlyFeaturedTrack}) =>
             (directlyFeaturedTrack === track
@@ -229,9 +211,6 @@ export default {
 
     if (track.lyrics) {
       const lyrics = sections.lyrics = {};
-
-      lyrics.heading =
-        relation('generateContentHeading');
 
       lyrics.content =
         relation('transformContent', track.lyrics);
@@ -331,7 +310,7 @@ export default {
             ]),
 
           sec.otherReleases && [
-            sec.otherReleases.heading
+            relations.contentHeading.clone()
               .slots({
                 attributes: {id: 'also-released-as'},
                 title: language.$('releaseInfo.alsoReleasedAs'),
@@ -372,7 +351,7 @@ export default {
           ],
 
           sec.contributors && [
-            sec.contributors.heading
+            relations.contentHeading.clone()
               .slots({
                 attributes: {id: 'contributors'},
                 title: language.$('releaseInfo.contributors'),
@@ -382,7 +361,7 @@ export default {
           ],
 
           sec.references && [
-            sec.references.heading
+            relations.contentHeading.clone()
               .slots({
                 attributes: {id: 'references'},
 
@@ -399,7 +378,7 @@ export default {
           ],
 
           sec.samples && [
-            sec.samples.heading
+            relations.contentHeading.clone()
               .slots({
                 attributes: {id: 'samples'},
 
@@ -416,7 +395,7 @@ export default {
           ],
 
           sec.referencedBy && [
-            sec.referencedBy.heading
+            relations.contentHeading.clone()
               .slots({
                 attributes: {id: 'referenced-by'},
 
@@ -436,7 +415,7 @@ export default {
           ],
 
           sec.sampledBy && [
-            sec.sampledBy.heading
+            relations.contentHeading.clone()
               .slots({
                 attributes: {id: 'referenced-by'},
 
@@ -456,7 +435,7 @@ export default {
           ],
 
           sec.flashesThatFeature && [
-            sec.flashesThatFeature.heading
+            relations.contentHeading.clone()
               .slots({
                 attributes: {id: 'featured-in'},
 
@@ -483,7 +462,7 @@ export default {
           ],
 
           sec.lyrics && [
-            sec.lyrics.heading
+            relations.contentHeading.clone()
               .slots({
                 attributes: {id: 'lyrics'},
                 title: language.$('releaseInfo.lyrics'),
@@ -495,7 +474,7 @@ export default {
           ],
 
           sec.sheetMusicFiles && [
-            sec.sheetMusicFiles.heading
+            relations.contentHeading.clone()
               .slots({
                 attributes: {id: 'sheet-music-files'},
                 title: language.$('releaseInfo.sheetMusicFiles.heading'),
@@ -505,7 +484,7 @@ export default {
           ],
 
           sec.midiProjectFiles && [
-            sec.midiProjectFiles.heading
+            relations.contentHeading.clone()
               .slots({
                 attributes: {id: 'midi-project-files'},
                 title: language.$('releaseInfo.midiProjectFiles.heading'),
@@ -515,7 +494,7 @@ export default {
           ],
 
           sec.additionalFiles && [
-            sec.additionalFiles.heading
+            relations.contentHeading.clone()
               .slots({
                 attributes: {id: 'additional-files'},
                 title: language.$('releaseInfo.additionalFiles.heading'),

--- a/src/content/dependencies/generateTrackInfoPage.js
+++ b/src/content/dependencies/generateTrackInfoPage.js
@@ -112,25 +112,17 @@ export default {
 
     // Section: Tracks that reference
 
-    if (!empty(track.referencedByTracks)) {
-      const referencedBy = sections.referencedBy = {};
-
-      referencedBy.list =
-        relation('generateTrackListDividedByGroups',
-          track.referencedByTracks,
-          sprawl.divideTrackListsByGroups);
-    }
+    relations.referencedByTracksList =
+      relation('generateTrackListDividedByGroups',
+        track.referencedByTracks,
+        sprawl.divideTrackListsByGroups);
 
     // Section: Tracks that sample
 
-    if (!empty(track.sampledByTracks)) {
-      const sampledBy = sections.sampledBy = {};
-
-      sampledBy.list =
-        relation('generateTrackListDividedByGroups',
-          track.sampledByTracks,
-          sprawl.divideTrackListsByGroups);
-    }
+    relations.sampledByTracksList =
+      relation('generateTrackListDividedByGroups',
+        track.sampledByTracks,
+        sprawl.divideTrackListsByGroups);
 
     // Section: Flashes that feature
 
@@ -321,7 +313,7 @@ export default {
             relations.sampledTracksList,
           ]),
 
-          sec.referencedBy && [
+          html.tags([
             relations.contentHeading.clone()
               .slots({
                 attributes: {id: 'referenced-by'},
@@ -335,16 +327,16 @@ export default {
                   language.$('releaseInfo.tracksThatReference.sticky'),
               }),
 
-            sec.referencedBy.list
+            relations.referencedByTracksList
               .slots({
                 headingString: 'releaseInfo.tracksThatReference',
               }),
-          ],
+          ]),
 
-          sec.sampledBy && [
+          html.tags([
             relations.contentHeading.clone()
               .slots({
-                attributes: {id: 'referenced-by'},
+                attributes: {id: 'sampled-by'},
 
                 title:
                   language.$('releaseInfo.tracksThatSample', {
@@ -355,11 +347,11 @@ export default {
                   language.$('releaseInfo.tracksThatSample.sticky'),
               }),
 
-            sec.sampledBy.list
+            relations.sampledByTracksList
               .slots({
                 headingString: 'releaseInfo.tracksThatSample',
               }),
-          ],
+          ]),
 
           sec.flashesThatFeature && [
             relations.contentHeading.clone()

--- a/src/content/dependencies/generateTrackInfoPage.js
+++ b/src/content/dependencies/generateTrackInfoPage.js
@@ -83,10 +83,8 @@ export default {
 
     // Section: Other releases
 
-    if (!empty(track.otherReleases)) {
-      relations.otherReleasesList =
+    relations.otherReleasesList =
         relation('generateTrackInfoPageOtherReleasesList', track);
-    }
 
     // Section: Contributors
 

--- a/src/content/dependencies/generateTrackInfoPage.js
+++ b/src/content/dependencies/generateTrackInfoPage.js
@@ -93,14 +93,8 @@ export default {
 
     // Section: Contributors
 
-    if (!empty(track.contributorContribs)) {
-      const contributors = sections.contributors = {};
-
-      contributors.list =
-        relation('generateContributionList', track.contributorContribs);
-    }
-
-    // Section: Referenced tracks
+    relations.contributorContributionList =
+      relation('generateContributionList', track.contributorContribs);
 
     relations.referencedTracksList =
       relation('generateTrackList', track.referencedTracks);
@@ -269,15 +263,15 @@ export default {
             relations.otherReleasesList,
           ]),
 
-          sec.contributors && [
+          html.tags([
             relations.contentHeading.clone()
               .slots({
                 attributes: {id: 'contributors'},
                 title: language.$('releaseInfo.contributors'),
               }),
 
-            sec.contributors.list,
-          ],
+            relations.contributorContributionList,
+          ]),
 
           html.tags([
             relations.contentHeading.clone()

--- a/src/content/dependencies/generateTrackInfoPage.js
+++ b/src/content/dependencies/generateTrackInfoPage.js
@@ -1,5 +1,3 @@
-import {empty} from '#sugar';
-
 export default {
   contentDependencies: [
     'generateAlbumAdditionalFilesList',
@@ -32,382 +30,355 @@ export default {
       wikiInfo.divideTrackListsByGroups,
   }),
 
-  relations(relation, sprawl, track) {
-    const relations = {};
-    const sections = relations.sections = {};
-    const {album} = track;
+  relations: (relation, sprawl, track) => ({
+    layout:
+      relation('generatePageLayout'),
 
-    relations.layout =
-      relation('generatePageLayout');
+    albumStyleRules:
+      relation('generateAlbumStyleRules', track.album, track),
 
-    relations.albumStyleRules =
-      relation('generateAlbumStyleRules', track.album, track);
+    socialEmbed:
+      relation('generateTrackSocialEmbed', track),
 
-    relations.socialEmbed =
-      relation('generateTrackSocialEmbed', track);
+    albumLink:
+      relation('linkAlbum', track.album),
 
-    relations.albumLink =
-      relation('linkAlbum', track.album);
+    trackLink:
+      relation('linkTrack', track),
 
-    relations.trackLink =
-      relation('linkTrack', track);
+    albumNavAccent:
+      relation('generateAlbumNavAccent', track.album, track),
 
-    relations.albumNavAccent =
-      relation('generateAlbumNavAccent', track.album, track);
+    trackChronologyLinks:
+      relation('generateTrackChronologyLinks', track),
 
-    relations.trackChronologyLinks =
-      relation('generateTrackChronologyLinks', track);
+    secondaryNav:
+      relation('generateAlbumSecondaryNav', track.album),
 
-    relations.secondaryNav =
-      relation('generateAlbumSecondaryNav', track.album);
+    sidebar:
+      relation('generateAlbumSidebar', track.album, track),
 
-    relations.sidebar =
-      relation('generateAlbumSidebar', track.album, track);
+    additionalNamesBox:
+      relation('generateTrackAdditionalNamesBox', track),
 
-    // This'll take care of itself being blank if there's nothing to show here.
-    relations.additionalNamesBox =
-      relation('generateTrackAdditionalNamesBox', track);
+    cover:
+      (track.hasUniqueCoverArt || track.album.hasCoverArt
+        ? relation('generateTrackCoverArtwork', track)
+        : null),
 
-    if (track.hasUniqueCoverArt || album.hasCoverArt) {
-      relations.cover =
-        relation('generateTrackCoverArtwork', track);
-    }
+    contentHeading:
+      relation('generateContentHeading'),
 
-    relations.contentHeading =
-      relation('generateContentHeading');
+    releaseInfo:
+      relation('generateTrackReleaseInfo', track),
 
-    // Section: Release info
+    otherReleasesList:
+        relation('generateTrackInfoPageOtherReleasesList', track),
 
-    relations.releaseInfo =
-      relation('generateTrackReleaseInfo', track);
+    contributorContributionList:
+      relation('generateContributionList', track.contributorContribs),
 
-    // Section: Other releases
+    referencedTracksList:
+      relation('generateTrackList', track.referencedTracks),
 
-    relations.otherReleasesList =
-        relation('generateTrackInfoPageOtherReleasesList', track);
+    sampledTracksList:
+      relation('generateTrackList', track.sampledTracks),
 
-    // Section: Contributors
-
-    relations.contributorContributionList =
-      relation('generateContributionList', track.contributorContribs);
-
-    relations.referencedTracksList =
-      relation('generateTrackList', track.referencedTracks);
-
-    // Section: Sampled tracks
-
-    relations.sampledTracksList =
-      relation('generateTrackList', track.sampledTracks);
-
-    // Section: Tracks that reference
-
-    relations.referencedByTracksList =
+    referencedByTracksList:
       relation('generateTrackListDividedByGroups',
         track.referencedByTracks,
-        sprawl.divideTrackListsByGroups);
+        sprawl.divideTrackListsByGroups),
 
-    // Section: Tracks that sample
-
-    relations.sampledByTracksList =
+    sampledByTracksList:
       relation('generateTrackListDividedByGroups',
         track.sampledByTracks,
-        sprawl.divideTrackListsByGroups);
+        sprawl.divideTrackListsByGroups),
 
-    // Section: Flashes that feature
+    flashesThatFeatureList:
+      relation('generateTrackInfoPageFeaturedByFlashesList', track),
 
-    relations.flashesThatFeatureList =
-      relation('generateTrackInfoPageFeaturedByFlashesList', track);
+    lyrics:
+      relation('transformContent', track.lyrics),
 
-    // Section: Lyrics
-
-    relations.lyrics =
-      relation('transformContent', track.lyrics);
-
-    // Sections: Sheet music files, MIDI/proejct files, additional files
-
-    relations.sheetMusicFilesList =
+    sheetMusicFilesList:
       relation('generateAlbumAdditionalFilesList',
-        album,
-        track.sheetMusicFiles);
+        track.album,
+        track.sheetMusicFiles),
 
-    relations.midiProjectFilesList =
+    midiProjectFilesList:
       relation('generateAlbumAdditionalFilesList',
-        album,
-        track.midiProjectFiles);
+        track.album,
+        track.midiProjectFiles),
 
-    relations.additionalFilesList =
+    additionalFilesList:
       relation('generateAlbumAdditionalFilesList',
-        album,
-        track.additionalFiles);
+        track.album,
+        track.additionalFiles),
 
-    // Section: Artist commentary
+    artistCommentarySection:
+      relation('generateCommentarySection', track.commentary),
+  }),
 
-    relations.artistCommentarySection =
-      relation('generateCommentarySection', track.commentary);
+  data: (sprawl, track) => ({
+    name:
+      track.name,
 
-    return relations;
-  },
+    color:
+      track.color,
 
-  data(sprawl, track) {
-    return {
-      name: track.name,
-      color: track.color,
+    hasTrackNumbers:
+      track.album.hasTrackNumbers,
 
-      hasTrackNumbers: track.album.hasTrackNumbers,
-      trackNumber: track.album.tracks.indexOf(track) + 1,
-    };
-  },
+    trackNumber:
+      track.album.tracks.indexOf(track) + 1,
+  }),
 
-  generate(data, relations, {html, language}) {
-    const {sections: sec} = relations;
+  generate: (data, relations, {html, language}) =>
+    relations.layout.slots({
+      title: language.$('trackPage.title', {track: data.name}),
+      headingMode: 'sticky',
 
-    return relations.layout
-      .slots({
-        title: language.$('trackPage.title', {track: data.name}),
-        headingMode: 'sticky',
+      additionalNames: relations.additionalNamesBox,
 
-        additionalNames: relations.additionalNamesBox,
+      color: data.color,
+      styleRules: [relations.albumStyleRules],
 
-        color: data.color,
-        styleRules: [relations.albumStyleRules],
+      cover:
+        (relations.cover
+          ? relations.cover.slots({
+              alt: language.$('misc.alt.trackCover'),
+            })
+          : null),
 
-        cover:
-          (relations.cover
-            ? relations.cover.slots({
-                alt: language.$('misc.alt.trackCover'),
-              })
-            : null),
+      mainContent: [
+        relations.releaseInfo,
 
-        mainContent: [
-          relations.releaseInfo,
+        html.tag('p',
+          {[html.onlyIfContent]: true},
+          {[html.joinChildren]: html.tag('br')},
 
-          html.tag('p',
+          [
+            !html.isBlank(relations.sheetMusicFilesList) &&
+              language.$('releaseInfo.sheetMusicFiles.shortcut', {
+                link: html.tag('a',
+                  {href: '#sheet-music-files'},
+                  language.$('releaseInfo.sheetMusicFiles.shortcut.link')),
+              }),
+
+            !html.isBlank(relations.midiProjectFilesList) &&
+              language.$('releaseInfo.midiProjectFiles.shortcut', {
+                link: html.tag('a',
+                  {href: '#midi-project-files'},
+                  language.$('releaseInfo.midiProjectFiles.shortcut.link')),
+              }),
+
+            !html.isBlank(relations.additionalFilesList) &&
+              language.$('releaseInfo.additionalFiles.shortcut', {
+                link: html.tag('a',
+                  {href: '#midi-project-files'},
+                  language.$('releaseInfo.additionalFiles.shortcut.link')),
+              }),
+
+            !html.isBlank(relations.artistCommentarySection) &&
+              language.$('releaseInfo.readCommentary', {
+                link: html.tag('a',
+                  {href: '#artist-commentary'},
+                  language.$('releaseInfo.readCommentary.link')),
+              }),
+          ]),
+
+        html.tags([
+          relations.contentHeading.clone()
+            .slots({
+              attributes: {id: 'also-released-as'},
+              title: language.$('releaseInfo.alsoReleasedAs'),
+            }),
+
+          relations.otherReleasesList,
+        ]),
+
+        html.tags([
+          relations.contentHeading.clone()
+            .slots({
+              attributes: {id: 'contributors'},
+              title: language.$('releaseInfo.contributors'),
+            }),
+
+          relations.contributorContributionList,
+        ]),
+
+        html.tags([
+          relations.contentHeading.clone()
+            .slots({
+              attributes: {id: 'references'},
+
+              title:
+                language.$('releaseInfo.tracksReferenced', {
+                  track: html.tag('i', data.name),
+                }),
+
+              stickyTitle:
+                language.$('releaseInfo.tracksReferenced.sticky'),
+            }),
+
+          relations.referencedTracksList,
+        ]),
+
+        html.tags([
+          relations.contentHeading.clone()
+            .slots({
+              attributes: {id: 'samples'},
+
+              title:
+                language.$('releaseInfo.tracksSampled', {
+                  track: html.tag('i', data.name),
+                }),
+
+              stickyTitle:
+                language.$('releaseInfo.tracksSampled.sticky'),
+            }),
+
+          relations.sampledTracksList,
+        ]),
+
+        html.tags([
+          relations.contentHeading.clone()
+            .slots({
+              attributes: {id: 'referenced-by'},
+
+              title:
+                language.$('releaseInfo.tracksThatReference', {
+                  track: html.tag('i', data.name),
+                }),
+
+              stickyTitle:
+                language.$('releaseInfo.tracksThatReference.sticky'),
+            }),
+
+          relations.referencedByTracksList
+            .slots({
+              headingString: 'releaseInfo.tracksThatReference',
+            }),
+        ]),
+
+        html.tags([
+          relations.contentHeading.clone()
+            .slots({
+              attributes: {id: 'sampled-by'},
+
+              title:
+                language.$('releaseInfo.tracksThatSample', {
+                  track: html.tag('i', data.name),
+                }),
+
+              stickyTitle:
+                language.$('releaseInfo.tracksThatSample.sticky'),
+            }),
+
+          relations.sampledByTracksList
+            .slots({
+              headingString: 'releaseInfo.tracksThatSample',
+            }),
+        ]),
+
+        html.tags([
+          relations.contentHeading.clone()
+            .slots({
+              attributes: {id: 'featured-in'},
+
+              title:
+                language.$('releaseInfo.flashesThatFeature', {
+                  track: html.tag('i', data.name),
+                }),
+
+              stickyTitle:
+                language.$('releaseInfo.flashesThatFeature.sticky'),
+            }),
+
+          relations.flashesThatFeatureList,
+        ]),
+
+        html.tags([
+          relations.contentHeading.clone()
+            .slots({
+              attributes: {id: 'lyrics'},
+              title: language.$('releaseInfo.lyrics'),
+            }),
+
+          html.tag('blockquote',
             {[html.onlyIfContent]: true},
-            {[html.joinChildren]: html.tag('br')},
+            relations.lyrics.slot('mode', 'lyrics')),
+        ]),
 
-            [
-              !html.isBlank(relations.sheetMusicFilesList) &&
-                language.$('releaseInfo.sheetMusicFiles.shortcut', {
-                  link: html.tag('a',
-                    {href: '#sheet-music-files'},
-                    language.$('releaseInfo.sheetMusicFiles.shortcut.link')),
-                }),
+        html.tags([
+          relations.contentHeading.clone()
+            .slots({
+              attributes: {id: 'sheet-music-files'},
+              title: language.$('releaseInfo.sheetMusicFiles.heading'),
+            }),
 
-              !html.isBlank(relations.midiProjectFilesList) &&
-                language.$('releaseInfo.midiProjectFiles.shortcut', {
-                  link: html.tag('a',
-                    {href: '#midi-project-files'},
-                    language.$('releaseInfo.midiProjectFiles.shortcut.link')),
-                }),
+          relations.sheetMusicFilesList,
+        ]),
 
-              !html.isBlank(relations.additionalFilesList) &&
-                language.$('releaseInfo.additionalFiles.shortcut', {
-                  link: html.tag('a',
-                    {href: '#midi-project-files'},
-                    language.$('releaseInfo.additionalFiles.shortcut.link')),
-                }),
+        html.tags([
+          relations.contentHeading.clone()
+            .slots({
+              attributes: {id: 'midi-project-files'},
+              title: language.$('releaseInfo.midiProjectFiles.heading'),
+            }),
 
-              !html.isBlank(relations.artistCommentarySection) &&
-                language.$('releaseInfo.readCommentary', {
-                  link: html.tag('a',
-                    {href: '#artist-commentary'},
-                    language.$('releaseInfo.readCommentary.link')),
-                }),
-            ]),
+          relations.midiProjectFilesList,
+        ]),
 
-          html.tags([
-            relations.contentHeading.clone()
-              .slots({
-                attributes: {id: 'also-released-as'},
-                title: language.$('releaseInfo.alsoReleasedAs'),
-              }),
+        html.tags([
+          relations.contentHeading.clone()
+            .slots({
+              attributes: {id: 'additional-files'},
+              title: language.$('releaseInfo.additionalFiles.heading'),
+            }),
 
-            relations.otherReleasesList,
-          ]),
+          relations.additionalFilesList,
+        ]),
 
-          html.tags([
-            relations.contentHeading.clone()
-              .slots({
-                attributes: {id: 'contributors'},
-                title: language.$('releaseInfo.contributors'),
-              }),
+        relations.artistCommentarySection,
+      ],
 
-            relations.contributorContributionList,
-          ]),
+      navLinkStyle: 'hierarchical',
+      navLinks: [
+        {auto: 'home'},
+        {html: relations.albumLink.slot('color', false)},
+        {
+          html:
+            (data.hasTrackNumbers
+              ? language.$('trackPage.nav.track.withNumber', {
+                  number: data.trackNumber,
+                  track: relations.trackLink
+                    .slot('attributes', {class: 'current'}),
+                })
+              : language.$('trackPage.nav.track', {
+                  track: relations.trackLink
+                    .slot('attributes', {class: 'current'}),
+                })),
+        },
+      ],
 
-          html.tags([
-            relations.contentHeading.clone()
-              .slots({
-                attributes: {id: 'references'},
+      navBottomRowContent:
+        relations.albumNavAccent.slots({
+          showTrackNavigation: true,
+          showExtraLinks: false,
+        }),
 
-                title:
-                  language.$('releaseInfo.tracksReferenced', {
-                    track: html.tag('i', data.name),
-                  }),
+      navContent:
+        relations.trackChronologyLinks,
 
-                stickyTitle:
-                  language.$('releaseInfo.tracksReferenced.sticky'),
-              }),
+      secondaryNav:
+        relations.secondaryNav
+          .slot('mode', 'track'),
 
-            relations.referencedTracksList,
-          ]),
+      leftSidebar: relations.sidebar,
 
-          html.tags([
-            relations.contentHeading.clone()
-              .slots({
-                attributes: {id: 'samples'},
-
-                title:
-                  language.$('releaseInfo.tracksSampled', {
-                    track: html.tag('i', data.name),
-                  }),
-
-                stickyTitle:
-                  language.$('releaseInfo.tracksSampled.sticky'),
-              }),
-
-            relations.sampledTracksList,
-          ]),
-
-          html.tags([
-            relations.contentHeading.clone()
-              .slots({
-                attributes: {id: 'referenced-by'},
-
-                title:
-                  language.$('releaseInfo.tracksThatReference', {
-                    track: html.tag('i', data.name),
-                  }),
-
-                stickyTitle:
-                  language.$('releaseInfo.tracksThatReference.sticky'),
-              }),
-
-            relations.referencedByTracksList
-              .slots({
-                headingString: 'releaseInfo.tracksThatReference',
-              }),
-          ]),
-
-          html.tags([
-            relations.contentHeading.clone()
-              .slots({
-                attributes: {id: 'sampled-by'},
-
-                title:
-                  language.$('releaseInfo.tracksThatSample', {
-                    track: html.tag('i', data.name),
-                  }),
-
-                stickyTitle:
-                  language.$('releaseInfo.tracksThatSample.sticky'),
-              }),
-
-            relations.sampledByTracksList
-              .slots({
-                headingString: 'releaseInfo.tracksThatSample',
-              }),
-          ]),
-
-          html.tags([
-            relations.contentHeading.clone()
-              .slots({
-                attributes: {id: 'featured-in'},
-
-                title:
-                  language.$('releaseInfo.flashesThatFeature', {
-                    track: html.tag('i', data.name),
-                  }),
-
-                stickyTitle:
-                  language.$('releaseInfo.flashesThatFeature.sticky'),
-              }),
-
-            relations.flashesThatFeatureList,
-          ]),
-
-          html.tags([
-            relations.contentHeading.clone()
-              .slots({
-                attributes: {id: 'lyrics'},
-                title: language.$('releaseInfo.lyrics'),
-              }),
-
-            html.tag('blockquote',
-              {[html.onlyIfContent]: true},
-              relations.lyrics.slot('mode', 'lyrics')),
-          ]),
-
-          html.tags([
-            relations.contentHeading.clone()
-              .slots({
-                attributes: {id: 'sheet-music-files'},
-                title: language.$('releaseInfo.sheetMusicFiles.heading'),
-              }),
-
-            relations.sheetMusicFilesList,
-          ]),
-
-          html.tags([
-            relations.contentHeading.clone()
-              .slots({
-                attributes: {id: 'midi-project-files'},
-                title: language.$('releaseInfo.midiProjectFiles.heading'),
-              }),
-
-            relations.midiProjectFilesList,
-          ]),
-
-          html.tags([
-            relations.contentHeading.clone()
-              .slots({
-                attributes: {id: 'additional-files'},
-                title: language.$('releaseInfo.additionalFiles.heading'),
-              }),
-
-            relations.additionalFilesList,
-          ]),
-
-          relations.artistCommentarySection,
-        ],
-
-        navLinkStyle: 'hierarchical',
-        navLinks: [
-          {auto: 'home'},
-          {html: relations.albumLink.slot('color', false)},
-          {
-            html:
-              (data.hasTrackNumbers
-                ? language.$('trackPage.nav.track.withNumber', {
-                    number: data.trackNumber,
-                    track: relations.trackLink
-                      .slot('attributes', {class: 'current'}),
-                  })
-                : language.$('trackPage.nav.track', {
-                    track: relations.trackLink
-                      .slot('attributes', {class: 'current'}),
-                  })),
-          },
-        ],
-
-        navBottomRowContent:
-          relations.albumNavAccent.slots({
-            showTrackNavigation: true,
-            showExtraLinks: false,
-          }),
-
-        navContent:
-          relations.trackChronologyLinks,
-
-        secondaryNav:
-          relations.secondaryNav
-            .slot('mode', 'track'),
-
-        leftSidebar: relations.sidebar,
-
-        socialEmbed: relations.socialEmbed,
-      });
-  },
+      socialEmbed: relations.socialEmbed,
+    }),
 };
 
 /*

--- a/src/content/dependencies/generateTrackInfoPage.js
+++ b/src/content/dependencies/generateTrackInfoPage.js
@@ -67,11 +67,6 @@ export default {
     relations.sidebar =
       relation('generateAlbumSidebar', track.album, track);
 
-    const additionalFilesSection = additionalFiles => ({
-      heading: relation('generateContentHeading'),
-      list: relation('generateAlbumAdditionalFilesList', album, additionalFiles),
-    });
-
     // This'll take care of itself being blank if there's nothing to show here.
     relations.additionalNamesBox =
       relation('generateTrackAdditionalNamesBox', track);
@@ -180,17 +175,20 @@ export default {
 
     // Sections: Sheet music files, MIDI/proejct files, additional files
 
-    if (!empty(track.sheetMusicFiles)) {
-      sections.sheetMusicFiles = additionalFilesSection(track.sheetMusicFiles);
-    }
+    relations.sheetMusicFilesList =
+      relation('generateAlbumAdditionalFilesList',
+        album,
+        track.sheetMusicFiles);
 
-    if (!empty(track.midiProjectFiles)) {
-      sections.midiProjectFiles = additionalFilesSection(track.midiProjectFiles);
-    }
+    relations.midiProjectFilesList =
+      relation('generateAlbumAdditionalFilesList',
+        album,
+        track.midiProjectFiles);
 
-    if (!empty(track.additionalFiles)) {
-      sections.additionalFiles = additionalFilesSection(track.additionalFiles);
-    }
+    relations.additionalFilesList =
+      relation('generateAlbumAdditionalFilesList',
+        album,
+        track.additionalFiles);
 
     // Section: Artist commentary
 
@@ -209,8 +207,6 @@ export default {
 
       hasTrackNumbers: track.album.hasTrackNumbers,
       trackNumber: track.album.tracks.indexOf(track) + 1,
-
-      numAdditionalFiles: track.additionalFiles.length,
     };
   },
 
@@ -242,21 +238,21 @@ export default {
             {[html.joinChildren]: html.tag('br')},
 
             [
-              sec.sheetMusicFiles &&
+              !html.isBlank(relations.sheetMusicFilesList) &&
                 language.$('releaseInfo.sheetMusicFiles.shortcut', {
                   link: html.tag('a',
                     {href: '#sheet-music-files'},
                     language.$('releaseInfo.sheetMusicFiles.shortcut.link')),
                 }),
 
-              sec.midiProjectFiles &&
+              !html.isBlank(relations.midiProjectFilesList) &&
                 language.$('releaseInfo.midiProjectFiles.shortcut', {
                   link: html.tag('a',
                     {href: '#midi-project-files'},
                     language.$('releaseInfo.midiProjectFiles.shortcut.link')),
                 }),
 
-              sec.additionalFiles &&
+              !html.isBlank(relations.additionalFilesList) &&
                 language.$('releaseInfo.additionalFiles.shortcut', {
                   link: html.tag('a',
                     {href: '#midi-project-files'},
@@ -404,35 +400,35 @@ export default {
                 .slot('mode', 'lyrics')),
           ],
 
-          sec.sheetMusicFiles && [
+          html.tags([
             relations.contentHeading.clone()
               .slots({
                 attributes: {id: 'sheet-music-files'},
                 title: language.$('releaseInfo.sheetMusicFiles.heading'),
               }),
 
-            sec.sheetMusicFiles.list,
-          ],
+            relations.sheetMusicFilesList,
+          ]),
 
-          sec.midiProjectFiles && [
+          html.tags([
             relations.contentHeading.clone()
               .slots({
                 attributes: {id: 'midi-project-files'},
                 title: language.$('releaseInfo.midiProjectFiles.heading'),
               }),
 
-            sec.midiProjectFiles.list,
-          ],
+            relations.midiProjectFilesList,
+          ]),
 
-          sec.additionalFiles && [
+          html.tags([
             relations.contentHeading.clone()
               .slots({
                 attributes: {id: 'additional-files'},
                 title: language.$('releaseInfo.additionalFiles.heading'),
               }),
 
-            sec.additionalFiles.list,
-          ],
+            relations.additionalFilesList,
+          ]),
 
           sec.artistCommentary,
         ],

--- a/src/content/dependencies/generateTrackInfoPage.js
+++ b/src/content/dependencies/generateTrackInfoPage.js
@@ -122,12 +122,8 @@ export default {
 
     // Section: Lyrics
 
-    if (track.lyrics) {
-      const lyrics = sections.lyrics = {};
-
-      lyrics.content =
-        relation('transformContent', track.lyrics);
-    }
+    relations.lyrics =
+      relation('transformContent', track.lyrics);
 
     // Sections: Sheet music files, MIDI/proejct files, additional files
 
@@ -148,10 +144,8 @@ export default {
 
     // Section: Artist commentary
 
-    if (track.commentary) {
-      sections.artistCommentary =
-        relation('generateCommentarySection', track.commentary);
-    }
+    relations.artistCommentarySection =
+      relation('generateCommentarySection', track.commentary);
 
     return relations;
   },
@@ -215,7 +209,7 @@ export default {
                     language.$('releaseInfo.additionalFiles.shortcut.link')),
                 }),
 
-              sec.artistCommentary &&
+              !html.isBlank(relations.artistCommentarySection) &&
                 language.$('releaseInfo.readCommentary', {
                   link: html.tag('a',
                     {href: '#artist-commentary'},
@@ -334,7 +328,7 @@ export default {
             relations.flashesThatFeatureList,
           ]),
 
-          sec.lyrics && [
+          html.tags([
             relations.contentHeading.clone()
               .slots({
                 attributes: {id: 'lyrics'},
@@ -342,9 +336,9 @@ export default {
               }),
 
             html.tag('blockquote',
-              sec.lyrics.content
-                .slot('mode', 'lyrics')),
-          ],
+              {[html.onlyIfContent]: true},
+              relations.lyrics.slot('mode', 'lyrics')),
+          ]),
 
           html.tags([
             relations.contentHeading.clone()
@@ -376,7 +370,7 @@ export default {
             relations.additionalFilesList,
           ]),
 
-          sec.artistCommentary,
+          relations.artistCommentarySection,
         ],
 
         navLinkStyle: 'hierarchical',

--- a/src/content/dependencies/generateTrackInfoPage.js
+++ b/src/content/dependencies/generateTrackInfoPage.js
@@ -1,23 +1,21 @@
 import {sortFlashesChronologically} from '#sort';
-import {empty, stitchArrays} from '#sugar';
+import {empty} from '#sugar';
 
 export default {
   contentDependencies: [
-    'generateAbsoluteDatetimestamp',
     'generateAlbumAdditionalFilesList',
     'generateAlbumNavAccent',
     'generateAlbumSecondaryNav',
     'generateAlbumSidebar',
     'generateAlbumStyleRules',
-    'generateColorStyleAttribute',
     'generateCommentarySection',
     'generateContentHeading',
     'generateContributionList',
     'generatePageLayout',
-    'generateRelativeDatetimestamp',
     'generateTrackAdditionalNamesBox',
     'generateTrackChronologyLinks',
     'generateTrackCoverArtwork',
+    'generateTrackInfoPageOtherReleasesList',
     'generateTrackList',
     'generateTrackListDividedByGroups',
     'generateTrackReleaseInfo',
@@ -94,36 +92,8 @@ export default {
     // Section: Other releases
 
     if (!empty(track.otherReleases)) {
-      const otherReleases = sections.otherReleases = {};
-
-      otherReleases.colorStyles =
-        track.otherReleases
-          .map(track => relation('generateColorStyleAttribute', track.color));
-
-      otherReleases.trackLinks =
-        track.otherReleases
-          .map(track => relation('linkTrack', track));
-
-      otherReleases.albumLinks =
-        track.otherReleases
-          .map(track => relation('linkAlbum', track.album));
-
-      otherReleases.datetimestamps =
-        track.otherReleases.map(track2 =>
-          (track2.date
-            ? (track.date
-                ? relation('generateRelativeDatetimestamp',
-                    track2.date,
-                    track.date)
-                : relation('generateAbsoluteDatetimestamp',
-                    track2.date))
-            : null));
-
-      otherReleases.items =
-        track.otherReleases.map(track => ({
-          trackLink: relation('linkTrack', track),
-          albumLink: relation('linkAlbum', track.album),
-        }));
+      relations.otherReleasesList =
+        relation('generateTrackInfoPageOtherReleasesList', track);
     }
 
     // Section: Contributors
@@ -309,45 +279,14 @@ export default {
                 }),
             ]),
 
-          sec.otherReleases && [
+          relations.otherReleasesList && [
             relations.contentHeading.clone()
               .slots({
                 attributes: {id: 'also-released-as'},
                 title: language.$('releaseInfo.alsoReleasedAs'),
               }),
 
-            html.tag('ul',
-              stitchArrays({
-                trackLink: sec.otherReleases.trackLinks,
-                albumLink: sec.otherReleases.albumLinks,
-                datetimestamp: sec.otherReleases.datetimestamps,
-                colorStyle: sec.otherReleases.colorStyles,
-              }).map(({
-                  trackLink,
-                  albumLink,
-                  datetimestamp,
-                  colorStyle,
-                }) => {
-                  const parts = ['releaseInfo.alsoReleasedAs.item'];
-                  const options = {};
-
-                  options.track = trackLink.slot('color', false);
-                  options.album = albumLink;
-
-                  if (datetimestamp) {
-                    parts.push('withYear');
-                    options.year =
-                      datetimestamp.slots({
-                        style: 'year',
-                        tooltip: true,
-                      });
-                  }
-
-                  return (
-                    html.tag('li',
-                      colorStyle,
-                      language.$(...parts, options)));
-                })),
+            relations.otherReleasesList,
           ],
 
           sec.contributors && [

--- a/src/content/dependencies/generateTrackInfoPageFeaturedByFlashesList.js
+++ b/src/content/dependencies/generateTrackInfoPageFeaturedByFlashesList.js
@@ -1,0 +1,62 @@
+import {sortFlashesChronologically} from '#sort';
+import {stitchArrays} from '#sugar';
+
+export default {
+  contentDependencies: ['linkFlash', 'linkTrack'],
+  extraDependencies: ['html', 'language', 'wikiData'],
+
+  sprawl: ({wikiInfo}) => ({
+    enableFlashesAndGames:
+      wikiInfo.enableFlashesAndGames,
+  }),
+
+  query: (sprawl, track) => ({
+    sortedFeatures:
+      (sprawl.enableFlashesAndGames
+        ? sortFlashesChronologically(
+            [track, ...track.otherReleases].flatMap(track =>
+              track.featuredInFlashes.map(flash => ({
+                flash,
+                track,
+
+                // These properties are only used for the sort.
+                act: flash.act,
+                date: flash.date,
+              }))))
+        : []),
+  }),
+
+  relations: (relation, query, _sprawl, track) => ({
+    flashLinks:
+      query.sortedFeatures
+        .map(({flash}) => relation('linkFlash', flash)),
+
+    trackLinks:
+      query.sortedFeatures
+        .map(({track: directlyFeaturedTrack}) =>
+          (directlyFeaturedTrack === track
+            ? null
+            : relation('linkTrack', directlyFeaturedTrack))),
+  }),
+
+  generate: (relations, {html, language}) =>
+    html.tag('ul',
+      {[html.onlyIfContent]: true},
+
+      stitchArrays({
+        flashLink: relations.flashLinks,
+        trackLink: relations.trackLinks,
+      }).map(({flashLink, trackLink}) => {
+          const attributes = html.attributes();
+          const parts = ['releaseInfo.flashesThatFeature.item'];
+          const options = {flash: flashLink};
+
+          if (trackLink) {
+            attributes.add('class', 'rerelease');
+            parts.push('asDifferentRelease');
+            options.track = trackLink;
+          }
+
+          return html.tag('li', attributes, language.$(...parts, options));
+        })),
+};

--- a/src/content/dependencies/generateTrackInfoPageOtherReleasesList.js
+++ b/src/content/dependencies/generateTrackInfoPageOtherReleasesList.js
@@ -44,6 +44,8 @@ export default {
 
   generate: (relations, {html, language}) =>
     html.tag('ul',
+      {[html.onlyIfContent]: true},
+
       stitchArrays({
         trackLink: relations.trackLinks,
         albumLink: relations.albumLinks,

--- a/src/content/dependencies/generateTrackInfoPageOtherReleasesList.js
+++ b/src/content/dependencies/generateTrackInfoPageOtherReleasesList.js
@@ -1,0 +1,78 @@
+import {stitchArrays} from '#sugar';
+
+export default {
+  contentDependencies: [
+    'generateAbsoluteDatetimestamp',
+    'generateColorStyleAttribute',
+    'generateRelativeDatetimestamp',
+    'linkAlbum',
+    'linkTrack',
+  ],
+
+  extraDependencies: ['html', 'language'],
+
+  relations: (relation, track) => ({
+    colorStyles:
+      track.otherReleases
+        .map(track => relation('generateColorStyleAttribute', track.color)),
+
+    trackLinks:
+      track.otherReleases
+        .map(track => relation('linkTrack', track)),
+
+    albumLinks:
+      track.otherReleases
+        .map(track => relation('linkAlbum', track.album)),
+
+    datetimestamps:
+      track.otherReleases.map(track2 =>
+        (track2.date
+          ? (track.date
+              ? relation('generateRelativeDatetimestamp',
+                  track2.date,
+                  track.date)
+              : relation('generateAbsoluteDatetimestamp',
+                  track2.date))
+          : null)),
+
+    items:
+      track.otherReleases.map(track => ({
+        trackLink: relation('linkTrack', track),
+        albumLink: relation('linkAlbum', track.album),
+      })),
+  }),
+
+  generate: (relations, {html, language}) =>
+    html.tag('ul',
+      stitchArrays({
+        trackLink: relations.trackLinks,
+        albumLink: relations.albumLinks,
+        datetimestamp: relations.datetimestamps,
+        colorStyle: relations.colorStyles,
+      }).map(({
+          trackLink,
+          albumLink,
+          datetimestamp,
+          colorStyle,
+        }) => {
+          const parts = ['releaseInfo.alsoReleasedAs.item'];
+          const options = {};
+
+          options.track = trackLink.slot('color', false);
+          options.album = albumLink;
+
+          if (datetimestamp) {
+            parts.push('withYear');
+            options.year =
+              datetimestamp.slots({
+                style: 'year',
+                tooltip: true,
+              });
+          }
+
+          return (
+            html.tag('li',
+              colorStyle,
+              language.$(...parts, options)));
+        })),
+};

--- a/src/content/dependencies/generateTrackList.js
+++ b/src/content/dependencies/generateTrackList.js
@@ -5,55 +5,47 @@ export default {
 
   extraDependencies: ['html', 'language'],
 
-  relations(relation, tracks) {
-    if (empty(tracks)) {
-      return {};
-    }
+  relations: (relation, tracks) => ({
+    trackLinks:
+      tracks
+        .map(track => relation('linkTrack', track)),
 
-    return {
-      trackLinks:
-        tracks
-          .map(track => relation('linkTrack', track)),
-
-      contributionLinks:
-        tracks
-          .map(track =>
-            (empty(track.artistContribs)
-              ? null
-              : track.artistContribs
-                  .map(contrib => relation('linkContribution', contrib)))),
-    };
-  },
+    contributionLinks:
+      tracks
+        .map(track =>
+          track.artistContribs
+            .map(contrib => relation('linkContribution', contrib))),
+  }),
 
   slots: {
     showContribution: {type: 'boolean', default: false},
     showIcons: {type: 'boolean', default: false},
   },
 
-  generate(relations, slots, {html, language}) {
-    return (
-      html.tag('ul',
-        stitchArrays({
-          trackLink: relations.trackLinks,
-          contributionLinks: relations.contributionLinks,
-        }).map(({trackLink, contributionLinks}) =>
-            html.tag('li',
-              (empty(contributionLinks)
-                ? trackLink
-                : language.$('trackList.item.withArtists', {
-                    track: trackLink,
-                    by:
-                      html.tag('span', {class: 'by'},
-                        html.metatag('chunkwrap', {split: ','},
-                          language.$('trackList.item.withArtists.by', {
-                            artists:
-                              language.formatConjunctionList(
-                                contributionLinks.map(link =>
-                                  link.slots({
-                                    showContribution: slots.showContribution,
-                                    showIcons: slots.showIcons,
-                                  }))),
-                          }))),
-                  }))))));
-  },
+  generate: (relations, slots, {html, language}) =>
+    html.tag('ul',
+      {[html.onlyIfContent]: true},
+
+      stitchArrays({
+        trackLink: relations.trackLinks,
+        contributionLinks: relations.contributionLinks,
+      }).map(({trackLink, contributionLinks}) =>
+          html.tag('li',
+            (empty(contributionLinks)
+              ? trackLink
+              : language.$('trackList.item.withArtists', {
+                  track: trackLink,
+                  by:
+                    html.tag('span', {class: 'by'},
+                      html.metatag('chunkwrap', {split: ','},
+                        language.$('trackList.item.withArtists.by', {
+                          artists:
+                            language.formatConjunctionList(
+                              contributionLinks.map(link =>
+                                link.slots({
+                                  showContribution: slots.showContribution,
+                                  showIcons: slots.showIcons,
+                                }))),
+                        }))),
+                }))))),
 };

--- a/src/content/dependencies/generateTrackListDividedByGroups.js
+++ b/src/content/dependencies/generateTrackListDividedByGroups.js
@@ -80,7 +80,7 @@ export default {
 
   generate: (data, relations, slots, {html, language}) =>
     relations.flatList ??
-    html.tag('dl', [
+    html.tag('dl', {[html.onlyIfContent]: true}, [
       stitchArrays({
         groupName: data.groupNames,
         groupLink: relations.groupLinks,

--- a/src/content/dependencies/transformContent.js
+++ b/src/content/dependencies/transformContent.js
@@ -45,7 +45,7 @@ export default {
   sprawl(wikiData, content) {
     const find = bindFind(wikiData);
 
-    const parsedNodes = parseInput(content);
+    const parsedNodes = parseInput(content ?? '');
 
     return {
       nodes: parsedNodes
@@ -512,7 +512,11 @@ export default {
         addText(markedOutput.slice(parseFrom));
       }
 
-      return html.tags(tags, {[html.joinChildren]: ''});
+      return (
+        html.tags(tags, {
+          [html.joinChildren]: '',
+          [html.onlyIfContent]: true,
+        }));
     };
 
     if (slots.mode === 'inline') {

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -217,9 +217,17 @@ export function isBlank(content) {
     // could include content. These need to be checked too.
     // Check each of the templates one at a time.
     for (const template of result) {
-      if (!template.blank) {
-        return false;
+      const content = template.content;
+
+      if (content instanceof Tag && content.onlyIfSiblings) {
+        continue;
       }
+
+      if (isBlank(content)) {
+        continue;
+      }
+
+      return false;
     }
 
     // If none of the templates included content either,

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -649,10 +649,12 @@ export class Tag {
     }
 
     for (const [index, item] of contentItems.entries()) {
-      let itemContent;
+      const nonTemplateItem =
+        Template.resolve(item);
 
+      let itemContent;
       try {
-        itemContent = item.toString();
+        itemContent = nonTemplateItem.toString();
       } catch (caughtError) {
         const indexPart = colors.yellow(`child #${index + 1}`);
 
@@ -681,12 +683,12 @@ export class Tag {
         continue;
       }
 
-      if (!(item instanceof Tag && item.onlyIfSiblings)) {
+      if (!(nonTemplateItem instanceof Tag) || !nonTemplateItem.onlyIfSiblings) {
         seenSiblingIndependentContent = true;
       }
 
       const chunkwrapChunks =
-        (typeof item === 'string' && chunkwrapSplitter
+        (typeof nonTemplateItem === 'string' && chunkwrapSplitter
           ? itemContent.split(chunkwrapSplitter)
           : null);
 
@@ -726,7 +728,7 @@ export class Tag {
       // itemContent check. They also never apply at the very start of content,
       // because at that point there aren't any preceding words from which the
       // blockwrap would differentiate its content.
-      if (item instanceof Tag && item.blockwrap && content) {
+      if (nonTemplateItem instanceof Tag && nonTemplateItem.blockwrap && content) {
         content += `<span class="blockwrap">`;
         blockwrapClosers += `</span>`;
       }


### PR DESCRIPTION
This PR builds on #510 (and subsequent bug fixes) to pretty dramatically improve the code layout of content functions in info pages. Here's the todo list:

- [x] `generateTrackInfoPage`
- [x] `generateAlbumInfoPage`
- [x] `generateFlashInfoPage`
- [x] `generateGroupInfoPage`
- [x] `generateArtistInfoPage`

And the details:

- We've changed a bunch of components to *work* when provided empty sets of data - for example a track list will generate without error even if you provide it an array of tracks that is empty. They now return blank content - generally through `[html.onlyIfContent]: true` on the top-level tag. This lets us still use those components as relations a lot more greedily, reducing logic in the actual page components!
- We've made `generateContentHeading` return a tag that is `[html.onlyIfSiblings]: true`. This makes it nice and easy to integrate in content: rather than perform a manual blank check, just nest the heading and section content in a conditionless `html.tags([...])`. The heading will only show if the section content is non-blank! This combines with the above "blank if empty" changes super nicely.
  - Getting this to work right involved some investigation and bug-fixing for templates in stringified content in general, i.e. the template itself isn't `onlyIfSiblings` but its content is, and we need to be able to detect that. The fixes shouldn't affect performance at all and will probably enable better integration of templates (or rather their content) with funky html stringification features in general!
- We've just given pages a single `generateContentHeading` relation, instead of one for each section. We clone it with `.clone()` before setting slots.
- We've removed the awkward `relations.sections` / `sec` syntax used across most info pages. It was just a needless idiosyncrasy, born super early on in the development of content functions in general.
- We've tidied most parts of info page content functions to use arrow function syntax, instead of statement blocks! These are a heck of a lot nicer to read and edit, and much easier to integrate with the reduced logic and tossed-away `sec` syntax.

These make info pages a bunch nicer to navigate and work with, and make them a lot more in line with other content functions. Good stuff!