### PR TITLE
Quick description!

### DIFF
--- a/src/content/dependencies/generateGroupGalleryPage.js
+++ b/src/content/dependencies/generateGroupGalleryPage.js
@@ -10,8 +10,10 @@ export default {
     'generateGroupSecondaryNav',
     'generateGroupSidebar',
     'generatePageLayout',
+    'generateQuickDescription',
     'image',
     'linkAlbum',
+    'linkGroup',
     'linkListing',
   ],
 
@@ -54,6 +56,12 @@ export default {
         carouselAlbums
           .map(album => relation('image', album.artTags));
     }
+
+    relations.quickDescription =
+      relation('generateQuickDescription', group);
+
+    relations.quickDescriptionInfoLink =
+      relation('linkGroup', group);
 
     relations.coverGrid =
       relation('generateCoverGrid');
@@ -127,6 +135,9 @@ export default {
                 }).map(({image, path}) =>
                     image.slot('path', path)),
             }),
+
+          relations.quickDescription
+            .slot('infoPageLink', relations.quickDescriptionInfoLink),
 
           html.tag('p', {class: 'quick-info'},
             language.$('groupGalleryPage.infoLine', {

--- a/src/content/dependencies/generateGroupGalleryPage.js
+++ b/src/content/dependencies/generateGroupGalleryPage.js
@@ -13,7 +13,6 @@ export default {
     'generateQuickDescription',
     'image',
     'linkAlbum',
-    'linkGroup',
     'linkListing',
   ],
 
@@ -59,9 +58,6 @@ export default {
 
     relations.quickDescription =
       relation('generateQuickDescription', group);
-
-    relations.quickDescriptionInfoLink =
-      relation('linkGroup', group);
 
     relations.coverGrid =
       relation('generateCoverGrid');
@@ -136,8 +132,7 @@ export default {
                     image.slot('path', path)),
             }),
 
-          relations.quickDescription
-            .slot('infoPageLink', relations.quickDescriptionInfoLink),
+          relations.quickDescription,
 
           html.tag('p', {class: 'quick-info'},
             language.$('groupGalleryPage.infoLine', {

--- a/src/content/dependencies/generateQuickDescription.js
+++ b/src/content/dependencies/generateQuickDescription.js
@@ -1,0 +1,41 @@
+export default {
+  contentDependencies: ['transformContent'],
+  extraDependencies: ['html', 'language'],
+
+  relations: (relation, thing) =>
+    ({description:
+        (thing.descriptionShort || thing.description
+          ? relation('transformContent',
+              thing.descriptionShort ?? thing.description)
+          : null)}),
+
+  data: (thing) =>
+    ({hasLongerDescription:
+        thing.description &&
+        thing.descriptionShort &&
+        thing.descriptionShort !== thing.description}),
+
+  slots: {
+    infoPageLink: {
+      type: 'html',
+      mutable: true,
+    },
+  },
+
+  generate: (data, relations, slots, {html, language}) =>
+    html.tag('p', {class: 'quick-info'},
+      {[html.joinChildren]: html.tag('br')},
+      {[html.onlyIfContent]: true},
+
+      [
+        relations.description?.slot('mode', 'inline'),
+
+        data.hasLongerDescription &&
+        slots.infoPageLink &&
+          language.$('misc.quickDescription.moreInfo', {
+            link:
+              slots.infoPageLink
+                .slot('content', language.$('misc.quickDescription.moreInfo.link')),
+          }),
+      ]),
+};

--- a/src/content/dependencies/generateQuickDescription.js
+++ b/src/content/dependencies/generateQuickDescription.js
@@ -2,40 +2,92 @@ export default {
   contentDependencies: ['transformContent'],
   extraDependencies: ['html', 'language'],
 
-  relations: (relation, thing) =>
-    ({description:
-        (thing.descriptionShort || thing.description
-          ? relation('transformContent',
-              thing.descriptionShort ?? thing.description)
-          : null)}),
+  query: (thing) => ({
+    hasDescription:
+      !!thing.description,
 
-  data: (thing) =>
-    ({hasLongerDescription:
-        thing.description &&
-        thing.descriptionShort &&
-        thing.descriptionShort !== thing.description}),
+    hasLongerDescription:
+      thing.description &&
+      thing.descriptionShort &&
+      thing.descriptionShort !== thing.description,
+  }),
 
-  slots: {
-    infoPageLink: {
-      type: 'html',
-      mutable: true,
-    },
-  },
+  relations: (relation, query, thing) => ({
+    description:
+      (query.hasLongerDescription || !thing.description
+        ? null
+        : relation('transformContent', thing.description)),
 
-  generate: (data, relations, slots, {html, language}) =>
-    html.tag('p', {class: 'quick-info'},
-      {[html.joinChildren]: html.tag('br')},
-      {[html.onlyIfContent]: true},
+    descriptionShort:
+      (query.hasLongerDescription
+        ? relation('transformContent', thing.descriptionShort)
+        : null),
 
-      [
-        relations.description?.slot('mode', 'inline'),
+    descriptionLong:
+      (query.hasLongerDescription
+        ? relation('transformContent', thing.description)
+        : null),
+  }),
+
+  data: (query) => ({
+    hasDescription: query.hasDescription,
+    hasLongerDescription: query.hasLongerDescription,
+  }),
+
+  generate(data, relations, {html, language}) {
+    const prefix = 'misc.quickDescription';
+
+    const wrapExpandCollapseLink = (expandCollapse, content) =>
+      html.tag('a', {class: `${expandCollapse}-link`},
+        {href: '#'},
+        content);
+
+    const actionsWhenCollapsed =
+      (data.hasLongerDescription
+        ? language.$(prefix, 'expandDescription', {
+            expand:
+              wrapExpandCollapseLink('expand',
+                language.$(prefix, 'expandDescription.expand')),
+          })
+        : null);
+
+    const actionsWhenExpanded =
+      (data.hasLongerDescription
+        ? language.$(prefix, 'collapseDescription', {
+            collapse:
+              wrapExpandCollapseLink('collapse',
+                language.$(prefix, 'collapseDescription.collapse')),
+          })
+        : null);
+
+    const wrapActions = (attributes, children) =>
+      html.tag('p', {class: 'quick-description-actions'},
+        {[html.onlyIfContent]: true},
+        attributes,
+
+        children);
+
+    const wrapContent = (attributes, content) =>
+      html.tag('div', {class: 'description-content'},
+        {[html.onlyIfContent]: true},
+        attributes,
+
+        content?.slot('mode', 'multiline'));
+
+    return (
+      html.tag('div', {class: 'quick-description'},
+        {[html.onlyIfContent]: true},
 
         data.hasLongerDescription &&
-        slots.infoPageLink &&
-          language.$('misc.quickDescription.moreInfo', {
-            link:
-              slots.infoPageLink
-                .slot('content', language.$('misc.quickDescription.moreInfo.link')),
-          }),
-      ]),
+          {class: 'collapsed'},
+
+        [
+          wrapContent(null, relations.description),
+          wrapContent({class: 'short'}, relations.descriptionShort),
+          wrapContent({class: 'long'}, relations.descriptionLong),
+
+          wrapActions({class: 'when-collapsed'}, actionsWhenCollapsed),
+          wrapActions({class: 'when-expanded'}, actionsWhenExpanded),
+        ]));
+  }
 };

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -1263,16 +1263,25 @@ ul.quick-info li:not(:last-child)::after {
   margin-top: 25px;
 }
 
-.quick-description {
+.quick-description:not(.has-external-links-only) {
   margin-left: 8%;
   margin-right: 8%;
   padding-left: 4%;
   padding-right: 4%;
   padding-top: 0.25em;
-  padding-bottom: 0.5em;
+  padding-bottom: 0.75em;
   border-left: 1px solid var(--dim-color);
   border-right: 1px solid var(--dim-color);
   line-height: 1.25em;
+}
+
+.quick-description.has-external-links-only {
+  padding-left: 12%;
+  padding-right: 12%;
+}
+
+.quick-description.has-content-only {
+  padding-bottom: 0.5em;
 }
 
 .quick-description p {

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -1258,8 +1258,51 @@ ul.quick-info li:not(:last-child)::after {
   font-weight: 800;
 }
 
-.carousel-container + .quick-info {
+.carousel-container + .quick-info,
+.carousel-container + .quick-description {
   margin-top: 25px;
+}
+
+.quick-description {
+  margin-left: 8%;
+  margin-right: 8%;
+  padding-left: 4%;
+  padding-right: 4%;
+  padding-top: 0.25em;
+  padding-bottom: 0.5em;
+  border-left: 1px solid var(--dim-color);
+  border-right: 1px solid var(--dim-color);
+  line-height: 1.25em;
+}
+
+.quick-description p {
+  text-align: center;
+}
+
+.quick-description .description-content.long hr ~ p {
+  text-align: left;
+}
+
+.quick-description > .description-content :first-child {
+  margin-top: 0;
+}
+
+.quick-description > .quick-description-actions,
+.quick-description.has-content-only .description-content :last-child {
+  margin-bottom: 0;
+}
+
+.quick-description:not(.collapsed) .description-content.short,
+.quick-description:not(.collapsed) .quick-description-actions.when-collapsed,
+.quick-description:not(.expanded) .description-content.long,
+.quick-description:not(.expanded) .quick-description-actions.when-expanded {
+  display: none;
+}
+
+.quick-description .quick-description-actions .expand-link,
+.quick-description .quick-description-actions .collapse-link {
+  text-decoration: underline;
+  text-decoration-style: dotted;
 }
 
 #intro-menu {

--- a/src/static/js/client.js
+++ b/src/static/js/client.js
@@ -3524,6 +3524,72 @@ clientSteps.getPageReferences.push(getArtistExternalLinkTooltipPageReferences);
 clientSteps.addInternalListeners.push(addArtistExternalLinkTooltipInternalListeners);
 clientSteps.addPageListeners.push(addArtistExternalLinkTooltipPageListeners);
 
+// Quick description --------------------------------------
+
+const quickDescriptionInfo = initInfo('quickDescriptionInfo', {
+  quickDescriptionContainers: null,
+
+  quickDescriptionsAreExpandable: null,
+
+  expandDescriptionLinks: null,
+  collapseDescriptionLinks: null,
+});
+
+function getQuickDescriptionReferences() {
+  const info = quickDescriptionInfo;
+
+  info.quickDescriptionContainers =
+    Array.from(document.querySelectorAll('#content .quick-description'));
+
+  info.quickDescriptionsAreExpandable =
+    info.quickDescriptionContainers
+      .map(container =>
+        container.querySelector('.quick-description-actions.when-expanded'));
+
+  info.expandDescriptionLinks =
+    info.quickDescriptionContainers
+      .map(container =>
+        container.querySelector('.quick-description-actions .expand-link'));
+
+  info.collapseDescriptionLinks =
+    info.quickDescriptionContainers
+      .map(container =>
+        container.querySelector('.quick-description-actions .collapse-link'));
+}
+
+function addQuickDescriptionListeners() {
+  const info = quickDescriptionInfo;
+
+  for (const {
+    isExpandable,
+    container,
+    expandLink,
+    collapseLink,
+  } of stitchArrays({
+    isExpandable: info.quickDescriptionsAreExpandable,
+    container: info.quickDescriptionContainers,
+    expandLink: info.expandDescriptionLinks,
+    collapseLink: info.collapseDescriptionLinks,
+  })) {
+    if (!isExpandable) continue;
+
+    expandLink.addEventListener('click', event => {
+      event.preventDefault();
+      container.classList.add('expanded');
+      container.classList.remove('collapsed');
+    });
+
+    collapseLink.addEventListener('click', event => {
+      event.preventDefault();
+      container.classList.add('collapsed');
+      container.classList.remove('expanded');
+    });
+  }
+}
+
+clientSteps.getPageReferences.push(getQuickDescriptionReferences);
+clientSteps.addPageListeners.push(addQuickDescriptionListeners);
+
 // Internal search functionality --------------------------
 
 const wikiSearchInfo = initInfo('wikiSearchInfo', {

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -625,6 +625,11 @@ misc:
 
   missingLinkContent: "(Missing link content)"
 
+  # quickDescription:
+  #   Toggleable display where a shorter blurb from a description is
+  #   initially visible, and a button can be clicked to display the
+  #   rest. May also display "read more" links (to external sites).
+
   quickDescription:
     moreInfo:
       _: "({LINK})"
@@ -634,8 +639,16 @@ misc:
       _: "({EXPAND})"
       expand: "Expand description..."
 
+    expandDescription.orReadMore:
+      _: "({EXPAND}, or read more on {LINKS})"
+      expand: "Expand description"
+
     collapseDescription:
       _: "({COLLAPSE})"
+      collapse: "Collapse description"
+
+    collapseDescription.orReadMore:
+      _: "({COLLAPSE}, or read more on {LINKS})"
       collapse: "Collapse description"
 
   # nav:

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -625,6 +625,11 @@ misc:
 
   missingLinkContent: "(Missing link content)"
 
+  quickDescription:
+    moreInfo:
+      _: "({LINK})"
+      link: "More info..."
+
   # nav:
   #   Generic navigational elements. These usually only appear in the
   #   wiki's nav bar, at the top of the page.

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -630,6 +630,14 @@ misc:
       _: "({LINK})"
       link: "More info..."
 
+    expandDescription:
+      _: "({EXPAND})"
+      expand: "Expand description..."
+
+    collapseDescription:
+      _: "({COLLAPSE})"
+      collapse: "Collapse description"
+
   # nav:
   #   Generic navigational elements. These usually only appear in the
   #   wiki's nav bar, at the top of the page.


### PR DESCRIPTION
<img width="1030" alt="Unofficial MSPA Fans gallery page, with the new quick description component. It's a box with thin solid colored left and right borders, and the group description center-aligned." src="https://github.com/hsmusic/hsmusic-wiki/assets/9948030/6535517c-505b-4615-81a8-9032bb0ff61a">

<img width="1015" alt="Quick description for Psycholonials. There is the usual 'split' horizontal rule, and then the two paragraphs of the extended description - these ones are left-aligned. At the bottom is a center-aligned button, Collapse description." src="https://github.com/hsmusic/hsmusic-wiki/assets/9948030/50569013-3b30-4f1a-a811-edf4a6b580d7">

This component was introduced as part of networked tags #291 — it's extracted into its own thing here! It is currently present only on group gallery pages. Besides expand/collapse controls, it also supports extra reading links, which are currently unused.

Most of this code is from October and is practically one of the oldest client-side dynamic components on the site. So, it's a bit crufty LOL. We gave a good go at refactoring and nicening it up, but got lost in the weeds in more than a couple ways—probably best off rewriting this component from the ground up, if we want to make its logic nicer in the future.

We did clean up the existing logic a little and break it into cleaner commits, though. Could be a bunch worse and technically still functioning! ✨ 