### PR TITLE
Pad quick-info lines

### DIFF
--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -1268,10 +1268,13 @@ ul.quick-info li:not(:last-child)::after {
 }
 
 .quick-description:not(.has-external-links-only) {
-  margin-left: 8%;
-  margin-right: 8%;
-  padding-left: 4%;
-  padding-right: 4%;
+  --clamped-padding-ratio: max(var(--responsive-padding-ratio), 0.06);
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: calc(0.40 * var(--clamped-padding-ratio) * 100%);
+  padding-right: calc(0.40 * var(--clamped-padding-ratio) * 100%);
+  max-width: 500px;
+
   padding-top: 0.25em;
   padding-bottom: 0.75em;
   border-left: 1px solid var(--dim-color);

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -1242,8 +1242,8 @@ html[data-url-key="localized.home"] #content h1 {
 
 .quick-info {
   text-align: center;
-  padding-left: 12%;
-  padding-right: 12%;
+  padding-left: calc(var(--responsive-padding-ratio) * 100%);
+  padding-right: calc(var(--responsive-padding-ratio) * 100%);
   line-height: 1.25em;
 }
 

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -1385,8 +1385,12 @@ p code {
   font-style: oblique;
 }
 
+main {
+  --responsive-padding-ratio: 0.10;
+}
+
 main.long-content {
-  --long-content-padding-ratio: 0.10;
+  --long-content-padding-ratio: var(--responsive-padding-ratio);
 }
 
 main.long-content .main-content-container,
@@ -2668,9 +2672,9 @@ html[data-language-code="preview-en"][data-url-key="localized.home"] #content
    * don't apply the similar layout change of widening the long-content area
    * if this page doesn't have a sidebar to hide in the first place.
    */
-  #page-container.showing-sidebar-left main.long-content,
-  #page-container.showing-sidebar-right main.long-content {
-    --long-content-padding-ratio: 0.06;
+  #page-container.showing-sidebar-left main,
+  #page-container.showing-sidebar-right main {
+    --responsive-padding-ratio: 0.06;
   }
 }
 
@@ -2757,8 +2761,8 @@ html[data-language-code="preview-en"][data-url-key="localized.home"] #content
     columns: 1;
   }
 
-  main.long-content {
-    --long-content-padding-ratio: 0.02;
+  main {
+    --responsive-padding-ratio: 0.02;
   }
 
   #cover-art-container {

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -1249,6 +1249,8 @@ html[data-url-key="localized.home"] #content h1 {
 
 ul.quick-info {
   list-style: none;
+  padding-left: 0;
+  padding-right: 0;
 }
 
 ul.quick-info li {

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -1242,11 +1242,13 @@ html[data-url-key="localized.home"] #content h1 {
 
 .quick-info {
   text-align: center;
+  padding-left: 12%;
+  padding-right: 12%;
+  line-height: 1.25em;
 }
 
 ul.quick-info {
   list-style: none;
-  padding-left: 0;
 }
 
 ul.quick-info li {


### PR DESCRIPTION
Extracted behavior from #291, but all touched up too. This gives `.quick-info` lines (which are not also `ul`) some padding around the edges - equal to the current layout's responsive padding ratio. That's a new term! It's the same thing as the page's long-content padding ratio (which adapts to the viewport width), but exists in every layout, instead of just `.long-content` pages.

It also makes quick descriptions use the responsive width, or a nearby value, and gives them a constant `max-width`, to help improve word wrap stability.
