### PR TITLE
Search magnifying glass & hover cues

### DIFF
--- a/src/content/dependencies/generateSearchSidebarBox.js
+++ b/src/content/dependencies/generateSearchSidebarBox.js
@@ -14,12 +14,14 @@ export default {
         collapsible: false,
 
         content: [
-          html.tag('input', {class: 'wiki-search-input'},
-            {
-              placeholder:
-                language.$(capsule, 'placeholder').toString(),
-            },
-            {type: 'search'}),
+          html.tag('label', {class: 'wiki-search-label'},
+            html.tag('input', {class: 'wiki-search-input'},
+              {type: 'search'},
+
+              {
+                placeholder:
+                  language.$(capsule, 'placeholder').toString(),
+              })),
 
           html.tag('template', {class: 'wiki-search-preparing-string'},
             language.$(capsule, 'preparing')),

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -545,6 +545,10 @@ summary .group-name {
   flex-grow: 1;
 }
 
+.wiki-search-input::-webkit-search-cancel-button {
+  filter: grayscale(1) invert(1);
+}
+
 .wiki-search-label.disabled {
   opacity: 0.6;
 }

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -514,21 +514,71 @@ summary .group-name {
   filter: brightness(0.7);
 }
 
-.wiki-search-input {
+.wiki-search-label {
   width: calc(100% - 4px);
   padding: 2px 4px;
   margin: 2px 2px 3px 2px;
   box-sizing: border-box;
 
+  display: flex;
+  flex-direction: row;
+
   background: transparent;
   border: 1px solid var(--dim-color);
   border-radius: 3px;
-  color: inherit;
 }
 
-.wiki-search-input[disabled] {
+.wiki-search-label::before {
+  display: inline-block;
+  padding-left: 3px;
+  padding-right: 3px;
+  margin-right: 3px;
+  width: 1.8em;
+  text-align: center;
+  content: '\1f50d\fe0e';
+}
+
+.wiki-search-input {
+  background: transparent;
+  border: transparent;
+  color: inherit;
+  flex-grow: 1;
+}
+
+.wiki-search-label.disabled {
   opacity: 0.6;
+}
+
+.wiki-search-label.disabled,
+.wiki-search-input[disabled] {
   cursor: not-allowed;
+}
+
+.wiki-search-label:not(.disabled):hover,
+.wiki-search-label:focus-within {
+  background: var(--light-ghost-color);
+}
+
+.wiki-search-label:focus-within {
+  border-color: var(--primary-color);
+}
+
+.wiki-search-label:focus-within::before {
+  opacity: 0.7;
+}
+
+.wiki-search-input:focus {
+  border: none;
+  outline: none;
+}
+
+.wiki-search-input::placeholder {
+  color: var(--primary-color);
+  font-style: oblique;
+}
+
+.wiki-search-input:focus::placeholder {
+  color: var(--dim-color);
 }
 
 .wiki-search-sidebar-box hr {
@@ -692,19 +742,6 @@ summary .group-name {
   opacity: 1;
   background: var(--light-ghost-color);
   border-color: var(--deep-color);
-}
-
-.wiki-search-input:focus {
-  border-color: var(--primary-color);
-}
-
-.wiki-search-input::placeholder {
-  color: var(--primary-color);
-  font-style: oblique;
-}
-
-.wiki-search-input:focus::placeholder {
-  color: var(--dim-color);
 }
 
 #content {

--- a/src/static/js/client.js
+++ b/src/static/js/client.js
@@ -3831,6 +3831,7 @@ const sidebarSearchInfo = initInfo('sidebarSearchInfo', {
 
   searchSidebarColumn: null,
   searchBox: null,
+  searchLabel: null,
   searchInput: null,
 
   progressRule: null,
@@ -3918,6 +3919,9 @@ function getSidebarSearchReferences() {
   if (!info.searchBox) {
     return;
   }
+
+  info.searchLabel =
+    info.searchBox.querySelector('.wiki-search-label');
 
   info.searchInput =
     info.searchBox.querySelector('.wiki-search-input');
@@ -4360,6 +4364,7 @@ function showSidebarSearchFailed() {
   cssProp(info.failedRule, 'display', null);
   cssProp(info.failedContainer, 'display', null);
 
+  info.searchLabel.classList.add('disabled');
   info.searchInput.disabled = true;
 
   if (state.stoppedTypingTimeout) {


### PR DESCRIPTION
Adds a got-dang magnifying glass to the search box, and lightly tints the box background when hovered or focused. Thanks to Makin for suggestions here.

https://github.com/hsmusic/hsmusic-wiki/assets/9948030/494c178d-a4f2-421c-80e6-22d27ad20c47
