### PR TITLE
Improve tooltip placement dynamics!

### DIFF
--- a/src/static/js/client.js
+++ b/src/static/js/client.js
@@ -1765,6 +1765,11 @@ function showTooltipFromHoverable(hoverable) {
 
   positionTooltipFromHoverableWithBrains(hoverable);
 
+  // After a tooltip is shown, if we *didn't* specify an anchor,
+  // assume it was shown in its default position - generally presented
+  // as down and to the right. Successive repositioning will base on this.
+  state.dynamicTooltipAnchorDirection ??= ['down', 'right'];
+
   cssProp(tooltip, 'display', 'block');
   tooltip.inert = false;
 


### PR DESCRIPTION
This PR does two things to improve how tooltips get placed dynamically (when they'd be cut off in the default placement):

* We support placing tooltips along the horizontal (long) edge of a hoverable! This just means that tooltips can appear above and below the hoverable, instead of only to the left and right. Twice the possible placements means far fewer occasions where the tooltip just can't fit (and gets placed in the top-left as a fallback).
* We *reposition* a tooltip when taking an action that changes its dimensions (i.e. showing the platforms column in a contribution tooltip) - this way, the newly visible content doesn't get cut off. We also try to use the same kind of placement as before so that it doesn't move somewhere else, out from under your cursor (or where you're visually reading).

This improves tooltip stability in general, and supports larger, more complex tooltips in particular.