### PR TITLE
Fix 'Other' in contribution tooltip, for "www" domains and similar

### DIFF
--- a/src/content/dependencies/generateContributionTooltipExternalLinkSection.js
+++ b/src/content/dependencies/generateContributionTooltipExternalLinkSection.js
@@ -58,8 +58,10 @@ export default {
                 // don't have a way of telling formatExternalLink to *not*
                 // use the fallback string, which just formats the URL as
                 // its host/domain... so is technically detectable.
-                ((html.resolve(platform, {normalize: 'string'}) ===
-                  (new URL(url)).host)
+                (((new URL(url))
+                    .host
+                    .endsWith(
+                      html.resolve(platform, {normalize: 'string'})))
 
                   ? language.$(capsule, 'noExternalLinkPlatformName')
                   : platform)),


### PR DESCRIPTION
Just a simple (albeit evil) fix! URLs like `https://www.tristanscroggins.com/` get the "www" BLD\* cut off, showing just `tristanscroggins.com`. That messes with detecting the domain and showing "Other" in the platform column, so now we detect by `host.endsWith` instead.

(\* As opposed to TLD :shipit:)