### PR TITLE
Align group info page album list with group gallery page

### DIFF
--- a/src/content/dependencies/generateGroupInfoPageAlbumsSection.js
+++ b/src/content/dependencies/generateGroupInfoPageAlbumsSection.js
@@ -1,5 +1,4 @@
-import {empty} from '#sugar';
-import {stitchArrays} from '#sugar';
+import {empty, stitchArrays} from '#sugar';
 
 export default {
   contentDependencies: [
@@ -59,7 +58,7 @@ export default {
           .map(group => relation('linkGroup', group))),
 
     datetimestamps:
-      group.albums.map(album =>
+      query.albums.map(album =>
         (album.date
           ? relation('generateAbsoluteDatetimestamp', album.date)
           : null)),

--- a/src/content/dependencies/generateGroupInfoPageAlbumsSection.js
+++ b/src/content/dependencies/generateGroupInfoPageAlbumsSection.js
@@ -1,3 +1,4 @@
+import {sortChronologically} from '#sort';
 import {empty, stitchArrays} from '#sugar';
 
 export default {
@@ -13,8 +14,15 @@ export default {
   extraDependencies: ['html', 'language'],
 
   query(group) {
+    // Typically, a latestFirst: false (default) chronological sort would be
+    // appropriate here, but navigation between adjacent albums in a group is a
+    // rather "essential" movement or relationship in the wiki, and we consider
+    // the sorting order of a group's gallery page (latestFirst: true) to be
+    // "canonical" in this regard. We exactly match its sort here, but reverse
+    // it, to still present earlier albums preceding later ones.
     const albums =
-      group.albums;
+      sortChronologically(group.albums.slice(), {latestFirst: true})
+        .reverse();
 
     const albumGroups =
       albums


### PR DESCRIPTION
Changes the album info page to sort chronologically latest-first, then reverse. This is usually an anti-pattern — we have `latestFirst: false` for a reason! — but we decided it's more important for relative placements on the group info page to always be exactly mirrored from the gallery page, because the gallery page is considered the "main" sort. This is a very similar change in effect to #379.
