### PR TITLE
Commentary access/capture dates

### DIFF
--- a/src/content/dependencies/generateCommentaryEntry.js
+++ b/src/content/dependencies/generateCommentaryEntry.js
@@ -3,6 +3,8 @@ import {empty} from '#sugar';
 export default {
   contentDependencies: [
     'generateColorStyleAttribute',
+    'generateTextWithTooltip',
+    'generateTooltip',
     'linkArtist',
     'transformContent',
   ],
@@ -33,10 +35,18 @@ export default {
 
     colorStyle:
       relation('generateColorStyleAttribute'),
+
+    textWithTooltip:
+      relation('generateTextWithTooltip'),
+
+    tooltip:
+      relation('generateTooltip'),
   }),
 
   data: (entry) => ({
     date: entry.date,
+    accessDate: entry.accessDate,
+    accessKind: entry.accessKind,
   }),
 
   slots: {
@@ -52,15 +62,32 @@ export default {
               .slot('color', slots.color),
 
           language.encapsulate(entryCapsule, 'title', titleCapsule => [
-            html.tag('time',
-              {[html.onlyIfContent]: true},
+            relations.textWithTooltip.slots({
+              attributes: {class: 'commentary-date'},
 
-              language.$(titleCapsule, 'date', {
-                [language.onlyIfOptions]: ['date'],
+              text:
+                html.tag('time',
+                  {[html.onlyIfContent]: true},
 
-                date:
-                  language.formatDate(data.date),
-              })),
+                  language.$(titleCapsule, 'date', {
+                    [language.onlyIfOptions]: ['date'],
+
+                    date:
+                      language.formatDate(data.date),
+                  })),
+
+              tooltip:
+                data.accessKind &&
+                  relations.tooltip.slots({
+                    attributes: {class: 'commentary-date-tooltip'},
+
+                    content:
+                      language.$(titleCapsule, 'date', data.accessKind, {
+                        date:
+                          language.formatDate(data.accessDate),
+                      }),
+                  }),
+            }),
 
             language.encapsulate(titleCapsule, workingCapsule => {
               const workingOptions = {};

--- a/src/content/dependencies/generateTextWithTooltip.js
+++ b/src/content/dependencies/generateTextWithTooltip.js
@@ -36,6 +36,7 @@ export default {
     if (hasTooltip) {
       attributes = attributes.clone();
       attributes.add({
+        [html.onlyIfContent]: true,
         [html.joinChildren]: '',
         [html.noEdgeWhitespace]: true,
         class: 'text-with-tooltip',

--- a/src/data/composite/wiki-data/withParsedCommentaryEntries.js
+++ b/src/data/composite/wiki-data/withParsedCommentaryEntries.js
@@ -95,6 +95,8 @@ export default templateCompositeFrom({
         'artistDisplayText',
         'annotation',
         'date',
+        'accessDate',
+        'accessKind',
       ]),
     }),
 
@@ -150,11 +152,28 @@ export default templateCompositeFrom({
     },
 
     {
+      dependencies: ['#entries.accessDate'],
+      compute: (continuation, {
+        ['#entries.accessDate']: accessDate,
+      }) => continuation({
+        ['#entries.accessDate']:
+          accessDate.map(date => date ? new Date(date) : null),
+      }),
+    },
+
+    fillMissingListItems({
+      list: '#entries.accessKind',
+      fill: input.value(null),
+    }),
+
+    {
       dependencies: [
         '#entries.artists',
         '#entries.artistDisplayText',
         '#entries.annotation',
         '#entries.date',
+        '#entries.accessDate',
+        '#entries.accessKind',
         '#entries.body',
       ],
 
@@ -163,6 +182,8 @@ export default templateCompositeFrom({
         ['#entries.artistDisplayText']: artistDisplayText,
         ['#entries.annotation']: annotation,
         ['#entries.date']: date,
+        ['#entries.accessDate']: accessDate,
+        ['#entries.accessKind']: accessKind,
         ['#entries.body']: body,
       }) => continuation({
         ['#parsedCommentaryEntries']:
@@ -171,6 +192,8 @@ export default templateCompositeFrom({
             artistDisplayText,
             annotation,
             date,
+            accessDate,
+            accessKind,
             body,
           }),
       }),

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -844,7 +844,8 @@ a:not([href]):hover {
 }
 
 .text-with-tooltip.datetimestamp .text-with-tooltip-interaction-cue,
-.text-with-tooltip.missing-duration .text-with-tooltip-interaction-cue {
+.text-with-tooltip.missing-duration .text-with-tooltip-interaction-cue,
+.text-with-tooltip.commentary-date .text-with-tooltip-interaction-cue {
   cursor: default;
 }
 
@@ -898,7 +899,8 @@ li:not(:first-child:last-child) .tooltip,
 }
 
 .datetimestamp-tooltip,
-.missing-duration-tooltip {
+.missing-duration-tooltip,
+.commentary-date-tooltip {
   padding: 3px 4px 2px 2px;
   left: -10px;
 }
@@ -1045,7 +1047,8 @@ li:not(:first-child:last-child) .tooltip,
 }
 
 .datetimestamp-tooltip .tooltip-content,
-.missing-duration-tooltip .tooltip-content {
+.missing-duration-tooltip .tooltip-content,
+.commentary-date-tooltip .tooltip-content {
   padding: 5px 6px;
   white-space: nowrap;
   font-size: 0.9em;
@@ -1186,8 +1189,11 @@ ul.image-details li {
   font-style: oblique;
 }
 
-.commentary-entry-heading time {
+.commentary-entry-heading .commentary-date {
   float: right;
+}
+
+.commentary-entry-heading .commentary-date .hoverable {
   padding-left: 0.5ch;
   padding-right: 0.25ch;
   margin-left: 0.75ch;
@@ -1195,7 +1201,8 @@ ul.image-details li {
   transition: border-left-color 0.15s;
 }
 
-.commentary-entry-heading time:hover {
+.commentary-entry-heading .commentary-date .hoverable:hover,
+.commentary-entry-heading .commentary-date .hoverable.has-visible-tooltip {
   border-left-color: white;
 }
 

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -463,6 +463,8 @@ misc:
           withAnnotation: "({ANNOTATION})"
 
         date: "{DATE}"
+        date.accessed: "accessed {DATE}"
+        date.captured: "captured {DATE}"
 
       seeOriginalRelease: "See {ORIGINAL}!"
 

--- a/src/util/wiki-data.js
+++ b/src/util/wiki-data.js
@@ -90,7 +90,7 @@ export function getKebabCase(name) {
 // out of the original string based on the indices matched using this.
 //
 const commentaryRegexRaw =
-  String.raw`^<i>(?<artistReferences>.+?)(?:\|(?<artistDisplayText>.+))?:<\/i>(?: \((?<annotation>(?:.*?(?=,|\)[^)]*$))*?)(?:,? ?(?<date>[a-zA-Z]+ [0-9]{1,2}, [0-9]{4,4}|[0-9]{1,2} [^,]*[0-9]{4,4}|[0-9]{1,4}[-/][0-9]{1,4}[-/][0-9]{1,4}))?\))?`;
+  String.raw`^<i>(?<artistReferences>.+?)(?:\|(?<artistDisplayText>.+))?:<\/i>(?: \((?<annotation>(?:.*?(?=,|\)[^)]*$))*?)(?:,? ?(?<date>[a-zA-Z]+ [0-9]{1,2}, [0-9]{4,4}|[0-9]{1,2} [^,]*[0-9]{4,4}|[0-9]{1,4}[-/][0-9]{1,4}[-/][0-9]{1,4}))?(?: (?<accessKind>captured|accessed) (?<accessDate>[a-zA-Z]+ [0-9]{1,2}, [0-9]{4,4}|[0-9]{1,2} [^,]*[0-9]{4,4}|[0-9]{1,4}[-/][0-9]{1,4}[-/][0-9]{1,4}))?\))?`;
 export const commentaryRegexCaseInsensitive =
   new RegExp(commentaryRegexRaw, 'gmi');
 export const commentaryRegexCaseSensitive =


### PR DESCRIPTION
Adds access/capture dates to commentary entries, as a tooltip udner the main date:

<img width="758" alt="Right-aligned date in a commentary entry, reading 9/1/2010, with a tooltip beneath, reading captured 5/30/2013." src="https://github.com/hsmusic/hsmusic-wiki/assets/9948030/80328e2e-72b4-4b14-aeb4-7fe1fa80986f">

Capture dates are supplementary to the main date—they won't appear without a main date. To enter them you just write `captured 1/1/2011` or `accessed May 30, 2024` right after the main date. They're also parsed automatically from a web.archive.org URL in the annotation, if present.

We only support two "kinds" right now - "captured" and "accessed" - but more can be added if desired later. We do hard-code those forms (and they are localized strings).