### PR TITLE
Commentary heading style improvements

### DIFF
--- a/src/content/dependencies/generateCommentaryEntry.js
+++ b/src/content/dependencies/generateCommentaryEntry.js
@@ -65,8 +65,11 @@ export default {
             relations.textWithTooltip.slots({
               attributes: {class: 'commentary-date'},
 
+              customInteractionCue: true,
+
               text:
                 html.tag('time',
+                  {class: 'text-with-tooltip-interaction-cue'},
                   {[html.onlyIfContent]: true},
 
                   language.$(titleCapsule, 'date', {

--- a/src/content/dependencies/generateCommentaryEntry.js
+++ b/src/content/dependencies/generateCommentaryEntry.js
@@ -62,6 +62,47 @@ export default {
               .slot('color', slots.color),
 
           language.encapsulate(entryCapsule, 'title', titleCapsule => [
+            html.tag('span', {class: 'commentary-entry-heading-text'},
+              language.encapsulate(titleCapsule, workingCapsule => {
+                const workingOptions = {};
+
+                workingOptions.artists =
+                  html.tag('span', {class: 'commentary-entry-artists'},
+                    (relations.artistsContent
+                      ? relations.artistsContent.slot('mode', 'inline')
+                   : relations.artistLinks
+                      ? language.formatConjunctionList(relations.artistLinks)
+                      : language.$(titleCapsule, 'noArtists')));
+
+                const accent =
+                  html.tag('span', {class: 'commentary-entry-accent'},
+                    {[html.onlyIfContent]: true},
+
+                    language.encapsulate(titleCapsule, 'accent', accentCapsule =>
+                      language.encapsulate(accentCapsule, workingCapsule => {
+                        const workingOptions = {};
+
+                        if (relations.annotationContent) {
+                          workingCapsule += '.withAnnotation';
+                          workingOptions.annotation =
+                            relations.annotationContent.slot('mode', 'inline');
+                        }
+
+                        if (workingCapsule === accentCapsule) {
+                          return html.blank();
+                        } else {
+                          return language.$(workingCapsule, workingOptions);
+                        }
+                      })));
+
+                if (!html.isBlank(accent)) {
+                  workingCapsule += '.withAccent';
+                  workingOptions.accent = accent;
+                }
+
+                return language.$(workingCapsule, workingOptions);
+              })),
+
             relations.textWithTooltip.slots({
               attributes: {class: 'commentary-date'},
 
@@ -90,46 +131,6 @@ export default {
                           language.formatDate(data.accessDate),
                       }),
                   }),
-            }),
-
-            language.encapsulate(titleCapsule, workingCapsule => {
-              const workingOptions = {};
-
-              workingOptions.artists =
-                html.tag('span', {class: 'commentary-entry-artists'},
-                  (relations.artistsContent
-                    ? relations.artistsContent.slot('mode', 'inline')
-                 : relations.artistLinks
-                    ? language.formatConjunctionList(relations.artistLinks)
-                    : language.$(titleCapsule, 'noArtists')));
-
-              const accent =
-                html.tag('span', {class: 'commentary-entry-accent'},
-                  {[html.onlyIfContent]: true},
-
-                  language.encapsulate(titleCapsule, 'accent', accentCapsule =>
-                    language.encapsulate(accentCapsule, workingCapsule => {
-                      const workingOptions = {};
-
-                      if (relations.annotationContent) {
-                        workingCapsule += '.withAnnotation';
-                        workingOptions.annotation =
-                          relations.annotationContent.slot('mode', 'inline');
-                      }
-
-                      if (workingCapsule === accentCapsule) {
-                        return html.blank();
-                      } else {
-                        return language.$(workingCapsule, workingOptions);
-                      }
-                    })));
-
-              if (!html.isBlank(accent)) {
-                workingCapsule += '.withAccent';
-                workingOptions.accent = accent;
-              }
-
-              return language.$(workingCapsule, workingOptions);
             }),
           ])),
 

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -1211,17 +1211,10 @@ ul.image-details li {
 .commentary-entry-heading .commentary-date time {
   padding-left: 0.5ch;
   padding-right: 0.25ch;
-  border-left: 1px dotted transparent;
-  transition: border-left-color 0.15s;
 }
 
 .commentary-entry-heading .hoverable {
   box-shadow: 1px 2px 6px 5px #04040460;
-}
-
-.commentary-entry-heading .commentary-date time:hover,
-.commentary-entry-heading .commentary-date .hoverable.has-visible-tooltip time {
-  border-left-color: white;
 }
 
 .commentary-art {

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -1179,7 +1179,8 @@ ul.image-details li {
 
 .commentary-entry-heading {
   margin-left: 15px;
-  padding-left: 5px;
+  padding-left: calc(5px + 1.25ch);
+  text-indent: -1.25ch;
   max-width: 625px;
   padding-bottom: 0.2em;
   border-bottom: 1px dotted var(--primary-color);

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -1180,12 +1180,21 @@ ul.image-details li {
 }
 
 .commentary-entry-heading {
+  display: flex;
+  flex-direction: row;
+
   margin-left: 15px;
-  padding-left: calc(5px + 1.25ch);
-  text-indent: -1.25ch;
+  padding-left: 5px;
   max-width: 625px;
   padding-bottom: 0.2em;
+
   border-bottom: 1px solid var(--dim-color);
+}
+
+.commentary-entry-heading-text {
+  flex-grow: 1;
+  padding-left: 1.25ch;
+  text-indent: -1.25ch;
 }
 
 .commentary-entry-accent {
@@ -1193,9 +1202,10 @@ ul.image-details li {
 }
 
 .commentary-entry-heading .commentary-date {
-  float: right;
-  text-indent: 0;
+  flex-shrink: 0;
+
   margin-left: 0.75ch;
+  align-self: flex-end;
 }
 
 .commentary-entry-heading .commentary-date time {

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -1185,7 +1185,7 @@ ul.image-details li {
   text-indent: -1.25ch;
   max-width: 625px;
   padding-bottom: 0.2em;
-  border-bottom: 1px dotted var(--primary-color);
+  border-bottom: 1px solid var(--dim-color);
 }
 
 .commentary-entry-accent {

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -1205,6 +1205,10 @@ ul.image-details li {
   transition: border-left-color 0.15s;
 }
 
+.commentary-entry-heading .hoverable {
+  box-shadow: 1px 2px 6px 5px #04040460;
+}
+
 .commentary-entry-heading .commentary-date time:hover,
 .commentary-entry-heading .commentary-date .hoverable.has-visible-tooltip time {
   border-left-color: white;

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -1194,12 +1194,13 @@ ul.image-details li {
 
 .commentary-entry-heading .commentary-date {
   float: right;
+  text-indent: 0;
+  margin-left: 0.75ch;
 }
 
 .commentary-entry-heading .commentary-date time {
   padding-left: 0.5ch;
   padding-right: 0.25ch;
-  margin-left: 0.75ch;
   border-left: 1px dotted transparent;
   transition: border-left-color 0.15s;
 }

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -1193,7 +1193,7 @@ ul.image-details li {
   float: right;
 }
 
-.commentary-entry-heading .commentary-date .hoverable {
+.commentary-entry-heading .commentary-date time {
   padding-left: 0.5ch;
   padding-right: 0.25ch;
   margin-left: 0.75ch;
@@ -1201,8 +1201,8 @@ ul.image-details li {
   transition: border-left-color 0.15s;
 }
 
-.commentary-entry-heading .commentary-date .hoverable:hover,
-.commentary-entry-heading .commentary-date .hoverable.has-visible-tooltip {
+.commentary-entry-heading .commentary-date time:hover,
+.commentary-entry-heading .commentary-date .hoverable.has-visible-tooltip time {
   border-left-color: white;
 }
 

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -891,6 +891,8 @@ li:not(:first-child:last-child) .tooltip,
   box-shadow:
     0 3px 4px 4px #000000aa,
     0 -2px 4px -2px var(--primary-color) inset;
+
+  text-indent: 0;
 }
 
 .contribution-tooltip {


### PR DESCRIPTION
This PR makes a bunch of tweaks to how commentary entries' headings are styled! In summary:

* The actual line for a commentary entry is now solid rather than dotted, and `--dim-color` rather than `--primary-color`. It more or less has about the same apparent "boldness", but is harder to confuse with the dotted underline we use for hover/interactibility cues in general—used for capture/access dates. (#527)
* The main text of a heading is hanging-indented! This means all but the first line are aligned a little deeper. This helps legibility a little for particularly long commentary lines.
* The commentary date is now bottom-aligned (so it's always right on top of the heading line), and as far as word-wrap for main text is concerned, it occupies the entire horizontal column it's placed in.
* The commentary date gets a friggin' shadow—when it's interactive! (Due to a capture/access date.) This serves as a secondary cue, and helps the dotted underline pop out from the header line. Totally static dates don't get this effect.
* The commentary date doesn't do its little left-border effect when hovered. Since it gets its own column, it's less likely to accidentally look like "part of" the main heading text. And we use a change when hovered as a *different* cue (to indicate that a tooltip will appear soon), so better not to mix those up.
* Also like, a margin fix. Commentary dates once again get the margin they're supposed to.