### PR TITLE
Commentary date kinds and ranges

### DIFF
--- a/src/content/dependencies/generateCommentaryEntry.js
+++ b/src/content/dependencies/generateCommentaryEntry.js
@@ -2,9 +2,8 @@ import {empty} from '#sugar';
 
 export default {
   contentDependencies: [
+    'generateCommentaryEntryDate',
     'generateColorStyleAttribute',
-    'generateTextWithTooltip',
-    'generateTooltip',
     'linkArtist',
     'transformContent',
   ],
@@ -36,27 +35,15 @@ export default {
     colorStyle:
       relation('generateColorStyleAttribute'),
 
-    textWithTooltip:
-      relation('generateTextWithTooltip'),
-
-    tooltip:
-      relation('generateTooltip'),
-  }),
-
-  data: (entry) => ({
-    date: entry.date,
-    secondDate: entry.secondDate,
-    dateKind: entry.dateKind,
-
-    accessDate: entry.accessDate,
-    accessKind: entry.accessKind,
+    date:
+      relation('generateCommentaryEntryDate', entry),
   }),
 
   slots: {
     color: {validate: v => v.isColor},
   },
 
-  generate: (data, relations, slots, {html, language}) =>
+  generate: (relations, slots, {html, language}) =>
     language.encapsulate('misc.artistCommentary.entry', entryCapsule =>
       html.tags([
         html.tag('p', {class: 'commentary-entry-heading'},
@@ -106,60 +93,7 @@ export default {
                 return language.$(workingCapsule, workingOptions);
               })),
 
-            relations.textWithTooltip.slots({
-              attributes: {class: 'commentary-date'},
-
-              customInteractionCue: true,
-
-              text:
-                html.tag('time',
-                  {class: 'text-with-tooltip-interaction-cue'},
-                  {[html.onlyIfContent]: true},
-
-                  language.encapsulate(titleCapsule, 'date', workingCapsule => {
-                    const workingOptions = {};
-
-                    if (!data.date) {
-                      return html.blank();
-                    }
-
-                    const rangeNeeded =
-                      data.dateKind === 'sometime' ||
-                      data.dateKind === 'throughout';
-
-                    if (rangeNeeded && !data.secondDate) {
-                      workingOptions.date = language.formatDate(data.date);
-                      return language.$(workingCapsule, workingOptions);
-                    }
-
-                    if (data.dateKind) {
-                      workingCapsule += '.' + data.dateKind;
-                    }
-
-                    if (data.secondDate) {
-                      workingCapsule += '.range';
-                      workingOptions.dateRange =
-                        language.formatDateRange(data.date, data.secondDate);
-                    } else {
-                      workingOptions.date =
-                        language.formatDate(data.date);
-                    }
-
-                    return language.$(workingCapsule, workingOptions);
-                  })),
-
-              tooltip:
-                data.accessKind &&
-                  relations.tooltip.slots({
-                    attributes: {class: 'commentary-date-tooltip'},
-
-                    content:
-                      language.$(titleCapsule, 'date', data.accessKind, {
-                        date:
-                          language.formatDate(data.accessDate),
-                      }),
-                  }),
-            }),
+            relations.date,
           ])),
 
         html.tag('blockquote', {class: 'commentary-entry-body'},

--- a/src/content/dependencies/generateCommentaryEntry.js
+++ b/src/content/dependencies/generateCommentaryEntry.js
@@ -45,6 +45,9 @@ export default {
 
   data: (entry) => ({
     date: entry.date,
+    secondDate: entry.secondDate,
+    dateKind: entry.dateKind,
+
     accessDate: entry.accessDate,
     accessKind: entry.accessKind,
   }),
@@ -113,11 +116,36 @@ export default {
                   {class: 'text-with-tooltip-interaction-cue'},
                   {[html.onlyIfContent]: true},
 
-                  language.$(titleCapsule, 'date', {
-                    [language.onlyIfOptions]: ['date'],
+                  language.encapsulate(titleCapsule, 'date', workingCapsule => {
+                    const workingOptions = {};
 
-                    date:
-                      language.formatDate(data.date),
+                    if (!data.date) {
+                      return html.blank();
+                    }
+
+                    const rangeNeeded =
+                      data.dateKind === 'sometime' ||
+                      data.dateKind === 'throughout';
+
+                    if (rangeNeeded && !data.secondDate) {
+                      workingOptions.date = language.formatDate(data.date);
+                      return language.$(workingCapsule, workingOptions);
+                    }
+
+                    if (data.dateKind) {
+                      workingCapsule += '.' + data.dateKind;
+                    }
+
+                    if (data.secondDate) {
+                      workingCapsule += '.range';
+                      workingOptions.dateRange =
+                        language.formatDateRange(data.date, data.secondDate);
+                    } else {
+                      workingOptions.date =
+                        language.formatDate(data.date);
+                    }
+
+                    return language.$(workingCapsule, workingOptions);
                   })),
 
               tooltip:

--- a/src/content/dependencies/generateCommentaryEntryDate.js
+++ b/src/content/dependencies/generateCommentaryEntryDate.js
@@ -1,0 +1,78 @@
+export default {
+  contentDependencies: ['generateTextWithTooltip', 'generateTooltip'],
+  extraDependencies: ['html', 'language'],
+
+  relations: (relation, _entry) => ({
+    textWithTooltip:
+      relation('generateTextWithTooltip'),
+
+    tooltip:
+      relation('generateTooltip'),
+  }),
+
+  data: (entry) => ({
+    date: entry.date,
+    secondDate: entry.secondDate,
+    dateKind: entry.dateKind,
+
+    accessDate: entry.accessDate,
+    accessKind: entry.accessKind,
+  }),
+
+  generate: (data, relations, {html, language}) =>
+    language.encapsulate('misc.artistCommentary.entry.title', titleCapsule =>
+      relations.textWithTooltip.slots({
+        attributes: {class: 'commentary-date'},
+
+        customInteractionCue: true,
+
+        text:
+          html.tag('time',
+            {class: 'text-with-tooltip-interaction-cue'},
+            {[html.onlyIfContent]: true},
+
+            language.encapsulate(titleCapsule, 'date', workingCapsule => {
+              const workingOptions = {};
+
+              if (!data.date) {
+                return html.blank();
+              }
+
+              const rangeNeeded =
+                data.dateKind === 'sometime' ||
+                data.dateKind === 'throughout';
+
+              if (rangeNeeded && !data.secondDate) {
+                workingOptions.date = language.formatDate(data.date);
+                return language.$(workingCapsule, workingOptions);
+              }
+
+              if (data.dateKind) {
+                workingCapsule += '.' + data.dateKind;
+              }
+
+              if (data.secondDate) {
+                workingCapsule += '.range';
+                workingOptions.dateRange =
+                  language.formatDateRange(data.date, data.secondDate);
+              } else {
+                workingOptions.date =
+                  language.formatDate(data.date);
+              }
+
+              return language.$(workingCapsule, workingOptions);
+            })),
+
+        tooltip:
+          data.accessKind &&
+            relations.tooltip.slots({
+              attributes: {class: 'commentary-date-tooltip'},
+
+              content:
+                language.$(titleCapsule, 'date', data.accessKind, {
+                  date:
+                    language.formatDate(data.accessDate),
+                }),
+            }),
+      })),
+}

--- a/src/content/dependencies/generateCommentaryEntryDate.js
+++ b/src/content/dependencies/generateCommentaryEntryDate.js
@@ -19,60 +19,75 @@ export default {
     accessKind: entry.accessKind,
   }),
 
-  generate: (data, relations, {html, language}) =>
-    language.encapsulate('misc.artistCommentary.entry.title', titleCapsule =>
-      relations.textWithTooltip.slots({
-        attributes: {class: 'commentary-date'},
+  generate(data, relations, {html, language}) {
+    const titleCapsule = language.encapsulate('misc.artistCommentary.entry.title');
 
+    const willDisplayTooltip =
+      !!(data.accessKind && data.accessDate);
+
+    const topAttributes =
+      {class: 'commentary-date'};
+
+    const time =
+      html.tag('time',
+        {[html.onlyIfContent]: true},
+
+        (willDisplayTooltip
+          ? {class: 'text-with-tooltip-interaction-cue'}
+          : topAttributes),
+
+        language.encapsulate(titleCapsule, 'date', workingCapsule => {
+          const workingOptions = {};
+
+          if (!data.date) {
+            return html.blank();
+          }
+
+          const rangeNeeded =
+            data.dateKind === 'sometime' ||
+            data.dateKind === 'throughout';
+
+          if (rangeNeeded && !data.secondDate) {
+            workingOptions.date = language.formatDate(data.date);
+            return language.$(workingCapsule, workingOptions);
+          }
+
+          if (data.dateKind) {
+            workingCapsule += '.' + data.dateKind;
+          }
+
+          if (data.secondDate) {
+            workingCapsule += '.range';
+            workingOptions.dateRange =
+              language.formatDateRange(data.date, data.secondDate);
+          } else {
+            workingOptions.date =
+              language.formatDate(data.date);
+          }
+
+          return language.$(workingCapsule, workingOptions);
+        }));
+
+    if (willDisplayTooltip) {
+      return relations.textWithTooltip.slots({
         customInteractionCue: true,
 
-        text:
-          html.tag('time',
-            {class: 'text-with-tooltip-interaction-cue'},
-            {[html.onlyIfContent]: true},
-
-            language.encapsulate(titleCapsule, 'date', workingCapsule => {
-              const workingOptions = {};
-
-              if (!data.date) {
-                return html.blank();
-              }
-
-              const rangeNeeded =
-                data.dateKind === 'sometime' ||
-                data.dateKind === 'throughout';
-
-              if (rangeNeeded && !data.secondDate) {
-                workingOptions.date = language.formatDate(data.date);
-                return language.$(workingCapsule, workingOptions);
-              }
-
-              if (data.dateKind) {
-                workingCapsule += '.' + data.dateKind;
-              }
-
-              if (data.secondDate) {
-                workingCapsule += '.range';
-                workingOptions.dateRange =
-                  language.formatDateRange(data.date, data.secondDate);
-              } else {
-                workingOptions.date =
-                  language.formatDate(data.date);
-              }
-
-              return language.$(workingCapsule, workingOptions);
-            })),
+        attributes: topAttributes,
+        text: time,
 
         tooltip:
-          data.accessKind &&
-            relations.tooltip.slots({
-              attributes: {class: 'commentary-date-tooltip'},
+          relations.tooltip.slots({
+            attributes: {class: 'commentary-date-tooltip'},
 
-              content:
-                language.$(titleCapsule, 'date', data.accessKind, {
-                  date:
-                    language.formatDate(data.accessDate),
-                }),
-            }),
-      })),
+            content:
+              language.$(titleCapsule, 'date', data.accessKind, {
+                date:
+                  language.formatDate(data.accessDate),
+              }),
+          }),
+      });
+    } else {
+      return time;
+    }
+  },
 }

--- a/src/data/composite/wiki-data/withParsedCommentaryEntries.js
+++ b/src/data/composite/wiki-data/withParsedCommentaryEntries.js
@@ -95,6 +95,8 @@ export default templateCompositeFrom({
         'artistDisplayText',
         'annotation',
         'date',
+        'secondDate',
+        'dateKind',
         'accessDate',
         'accessKind',
       ]),
@@ -165,9 +167,26 @@ export default templateCompositeFrom({
         ['#entries.date']: date,
       }) => continuation({
         ['#entries.date']:
-          date.map(date => date ? new Date(date) : null),
+          date
+            .map(date => date ? new Date(date) : null),
       }),
     },
+
+    {
+      dependencies: ['#entries.secondDate'],
+      compute: (continuation, {
+        ['#entries.secondDate']: secondDate,
+      }) => continuation({
+        ['#entries.secondDate']:
+          secondDate
+            .map(date => date ? new Date(date) : null),
+      }),
+    },
+
+    fillMissingListItems({
+      list: '#entries.dateKind',
+      fill: input.value(null),
+    }),
 
     {
       dependencies: ['#entries.accessDate', '#entries.webArchiveDate'],
@@ -206,6 +225,8 @@ export default templateCompositeFrom({
         '#entries.artistDisplayText',
         '#entries.annotation',
         '#entries.date',
+        '#entries.secondDate',
+        '#entries.dateKind',
         '#entries.accessDate',
         '#entries.accessKind',
         '#entries.body',
@@ -216,6 +237,8 @@ export default templateCompositeFrom({
         ['#entries.artistDisplayText']: artistDisplayText,
         ['#entries.annotation']: annotation,
         ['#entries.date']: date,
+        ['#entries.secondDate']: secondDate,
+        ['#entries.dateKind']: dateKind,
         ['#entries.accessDate']: accessDate,
         ['#entries.accessKind']: accessKind,
         ['#entries.body']: body,
@@ -226,6 +249,8 @@ export default templateCompositeFrom({
             artistDisplayText,
             annotation,
             date,
+            secondDate,
+            dateKind,
             accessDate,
             accessKind,
             body,

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -1206,9 +1206,7 @@ ul.image-details li {
 
   margin-left: 0.75ch;
   align-self: flex-end;
-}
 
-.commentary-entry-heading .commentary-date time {
   padding-left: 0.5ch;
   padding-right: 0.25ch;
 }

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -463,8 +463,16 @@ misc:
           withAnnotation: "({ANNOTATION})"
 
         date: "{DATE}"
+        date.range: "{DATE_RANGE}"
+
         date.accessed: "accessed {DATE}"
         date.captured: "captured {DATE}"
+
+        date.around: "around {DATE}"
+        date.around.range: "around {DATE_RANGE}"
+
+        date.sometime.range: "sometime {DATE_RANGE}"
+        date.throughout.range: "throughout {DATE_RANGE}"
 
       seeOriginalRelease: "See {ORIGINAL}!"
 

--- a/src/util/wiki-data.js
+++ b/src/util/wiki-data.js
@@ -94,7 +94,7 @@ const dateRegex = groupName =>
   String.raw`(?<${groupName}>[a-zA-Z]+ [0-9]{1,2}, [0-9]{4,4}|[0-9]{1,2} [^,]*[0-9]{4,4}|[0-9]{1,4}[-/][0-9]{1,4}[-/][0-9]{1,4})`;
 
 const commentaryRegexRaw =
-  String.raw`^<i>(?<artistReferences>.+?)(?:\|(?<artistDisplayText>.+))?:<\/i>(?: \((?<annotation>(?:.*?(?=,|\)[^)]*$))*?)(?:,? ?${dateRegex('date')}(?: (?<accessKind>captured|accessed) ${dateRegex('accessDate')})?)?\))?`;
+  String.raw`^<i>(?<artistReferences>.+?)(?:\|(?<artistDisplayText>.+))?:<\/i>(?: \((?<annotation>(?:.*?(?=,|\)[^)]*$))*?)(?:,? ?(?:(?<dateKind>sometime|throughout|around) )?${dateRegex('date')}(?: ?- ?${dateRegex('secondDate')})?(?: (?<accessKind>captured|accessed) ${dateRegex('accessDate')})?)?\))?`;
 export const commentaryRegexCaseInsensitive =
   new RegExp(commentaryRegexRaw, 'gmi');
 export const commentaryRegexCaseSensitive =

--- a/src/util/wiki-data.js
+++ b/src/util/wiki-data.js
@@ -89,8 +89,12 @@ export function getKebabCase(name) {
 // This regular expression *doesn't* match bodies, which will need to be parsed
 // out of the original string based on the indices matched using this.
 //
+
+const dateRegex = groupName =>
+  String.raw`(?<${groupName}>[a-zA-Z]+ [0-9]{1,2}, [0-9]{4,4}|[0-9]{1,2} [^,]*[0-9]{4,4}|[0-9]{1,4}[-/][0-9]{1,4}[-/][0-9]{1,4})`;
+
 const commentaryRegexRaw =
-  String.raw`^<i>(?<artistReferences>.+?)(?:\|(?<artistDisplayText>.+))?:<\/i>(?: \((?<annotation>(?:.*?(?=,|\)[^)]*$))*?)(?:,? ?(?<date>[a-zA-Z]+ [0-9]{1,2}, [0-9]{4,4}|[0-9]{1,2} [^,]*[0-9]{4,4}|[0-9]{1,4}[-/][0-9]{1,4}[-/][0-9]{1,4}))?(?: (?<accessKind>captured|accessed) (?<accessDate>[a-zA-Z]+ [0-9]{1,2}, [0-9]{4,4}|[0-9]{1,2} [^,]*[0-9]{4,4}|[0-9]{1,4}[-/][0-9]{1,4}[-/][0-9]{1,4}))?\))?`;
+  String.raw`^<i>(?<artistReferences>.+?)(?:\|(?<artistDisplayText>.+))?:<\/i>(?: \((?<annotation>(?:.*?(?=,|\)[^)]*$))*?)(?:,? ?${dateRegex('date')})?(?: (?<accessKind>captured|accessed) ${dateRegex('accessDate')})?\))?`;
 export const commentaryRegexCaseInsensitive =
   new RegExp(commentaryRegexRaw, 'gmi');
 export const commentaryRegexCaseSensitive =

--- a/src/util/wiki-data.js
+++ b/src/util/wiki-data.js
@@ -94,7 +94,7 @@ const dateRegex = groupName =>
   String.raw`(?<${groupName}>[a-zA-Z]+ [0-9]{1,2}, [0-9]{4,4}|[0-9]{1,2} [^,]*[0-9]{4,4}|[0-9]{1,4}[-/][0-9]{1,4}[-/][0-9]{1,4})`;
 
 const commentaryRegexRaw =
-  String.raw`^<i>(?<artistReferences>.+?)(?:\|(?<artistDisplayText>.+))?:<\/i>(?: \((?<annotation>(?:.*?(?=,|\)[^)]*$))*?)(?:,? ?${dateRegex('date')})?(?: (?<accessKind>captured|accessed) ${dateRegex('accessDate')})?\))?`;
+  String.raw`^<i>(?<artistReferences>.+?)(?:\|(?<artistDisplayText>.+))?:<\/i>(?: \((?<annotation>(?:.*?(?=,|\)[^)]*$))*?)(?:,? ?${dateRegex('date')}(?: (?<accessKind>captured|accessed) ${dateRegex('accessDate')})?)?\))?`;
 export const commentaryRegexCaseInsensitive =
   new RegExp(commentaryRegexRaw, 'gmi');
 export const commentaryRegexCaseSensitive =

--- a/test/unit/data/composite/wiki-data/withParsedCommentaryEntries.js
+++ b/test/unit/data/composite/wiki-data/withParsedCommentaryEntries.js
@@ -28,7 +28,7 @@ function stubArtist(artistName = `Test Artist`) {
 }
 
 t.test(`withParsedCommentaryEntries: basic behavior`, t => {
-  t.plan(4);
+  t.plan(7);
 
   const artist1 = stubArtist(`Mobius Trip`);
   const artist2 = stubArtist(`Hadron Kaleido`);
@@ -56,6 +56,8 @@ t.test(`withParsedCommentaryEntries: basic behavior`, t => {
       date: null,
       accessDate: null,
       accessKind: null,
+      secondDate: null,
+      dateKind: null,
       body: `Some commentary.\nVery cool.`,
     },
   ]);
@@ -79,6 +81,8 @@ t.test(`withParsedCommentaryEntries: basic behavior`, t => {
       annotation: `music, art`,
       date: new Date('12 January 2015'),
       body: `First commentary entry.\nVery cool.`,
+      secondDate: null,
+      dateKind: null,
       accessDate: null,
       accessKind: null,
     },
@@ -88,6 +92,8 @@ t.test(`withParsedCommentaryEntries: basic behavior`, t => {
       annotation: `moral support`,
       date: new Date('4 April 2022'),
       body: `Second commentary entry. Yes. So cool.`,
+      secondDate: null,
+      dateKind: null,
       accessDate: null,
       accessKind: null,
     },
@@ -97,6 +103,8 @@ t.test(`withParsedCommentaryEntries: basic behavior`, t => {
       annotation: `pingas`,
       date: new Date('25 August 2023'),
       body: `Oh no.. Oh dear...`,
+      secondDate: null,
+      dateKind: null,
       accessDate: null,
       accessKind: null,
     },
@@ -106,6 +114,8 @@ t.test(`withParsedCommentaryEntries: basic behavior`, t => {
       annotation: null,
       date: null,
       body: `And back around we go.`,
+      secondDate: null,
+      dateKind: null,
       accessDate: null,
       accessKind: null,
     },
@@ -136,6 +146,8 @@ t.test(`withParsedCommentaryEntries: basic behavior`, t => {
       body:
         `Written by [[artist:michael-guy-bowman|Michael Guy Bowman]]<br>\n` +
         `Arrangement by [[artist:mark-j-hadley|Mark Hadley]]`,
+      secondDate: null,
+      dateKind: null,
       accessDate: new Date('10/24/2020'),
       accessKind: 'captured',
     },
@@ -145,6 +157,8 @@ t.test(`withParsedCommentaryEntries: basic behavior`, t => {
       annotation: `[fake](https://web.archive.org/web/20201024170202/https://homestuck.bandcamp.com/fake)`,
       date: new Date('7/20/2019'),
       body: `This isn't real!`,
+      secondDate: null,
+      dateKind: null,
       accessDate: new Date('4/13/2024'),
       accessKind: 'captured',
     },
@@ -154,6 +168,8 @@ t.test(`withParsedCommentaryEntries: basic behavior`, t => {
       annotation: `[fake](https://homestuck.com/fake)`,
       date: new Date('10/25/2011'),
       body: `This isn't real either!`,
+      secondDate: null,
+      dateKind: null,
       accessDate: new Date('10/27/2011'),
       accessKind: 'accessed',
     },
@@ -163,6 +179,193 @@ t.test(`withParsedCommentaryEntries: basic behavior`, t => {
       annotation: `[fake](https://web.archive.org/web/20201024170202/https://homestuck.bandcamp.com/fake)`,
       date: new Date('7/20/2019'),
       body: `Not this one, neither!`,
+      secondDate: null,
+      dateKind: null,
+      accessDate: new Date('4/13/2024'),
+      accessKind: 'accessed',
+    },
+  ]);
+
+  t.same(composite.expose.compute({
+    artistData,
+    from:
+      `<i>Homestuck:</i> ([MSPA sound credits](https://web.archive.org/web/20120805031705/http://www.mspaintadventures.com:80/soundcredits.html), sometime 6/21/2012 - 8/5/2012)\n` +
+      `\n` +
+      `[[flash:246|Page 2146]] - <b>"Sburban Countdown"</b><br>\n` +
+      `Available on Bandcamp in [[album:homestuck-vol-1-4|Homestuck Vol. 1-4]]<br>\n` +
+      `Written by [[artist:michael-guy-bowman|Michael Guy Bowman]]<br>\n` +
+      `Arrangement by [[artist:mark-j-hadley|Mark Hadley]]\n` +
+      `\n` +
+      `<i>Homestuck:</i> ([fake](https://web.archive.org/web/20201024170202/https://homestuck.bandcamp.com/fake), 7/20/2019 - 7/20/2022 captured 4/13/2024)\n` +
+      `It's goin' once.\n` +
+      `\n` +
+      `<i>Homestuck:</i> (10/25/2011 - 10/28/2011 accessed 10/27/2011)\n` +
+      `It's goin' twice.\n` +
+      `\n` +
+      `<i>Homestuck:</i> ([fake](https://web.archive.org/web/20201024170202/https://homestuck.bandcamp.com/fake), 7/20/2019 - 7/20/2022 accessed 4/13/2024)\n` +
+      `It's goin' thrice!\n`
+  }), [
+    {
+      artists: [artist3],
+      artistDisplayText: null,
+      annotation: `[MSPA sound credits](https://web.archive.org/web/20120805031705/http://www.mspaintadventures.com:80/soundcredits.html)`,
+      body:
+        `[[flash:246|Page 2146]] - <b>"Sburban Countdown"</b><br>\n` +
+        `Available on Bandcamp in [[album:homestuck-vol-1-4|Homestuck Vol. 1-4]]<br>\n` +
+        `Written by [[artist:michael-guy-bowman|Michael Guy Bowman]]<br>\n` +
+        `Arrangement by [[artist:mark-j-hadley|Mark Hadley]]`,
+      date: new Date('6/21/2012'),
+      secondDate: new Date('8/5/2012'),
+      dateKind: 'sometime',
+      accessDate: new Date('8/5/2012'),
+      accessKind: 'captured',
+    },
+    {
+      artists: [artist3],
+      artistDisplayText: null,
+      annotation: `[fake](https://web.archive.org/web/20201024170202/https://homestuck.bandcamp.com/fake)`,
+      body: `It's goin' once.`,
+      date: new Date('7/20/2019'),
+      secondDate: new Date('7/20/2022'),
+      dateKind: null,
+      accessDate: new Date('4/13/2024'),
+      accessKind: 'captured',
+    },
+    {
+      artists: [artist3],
+      artistDisplayText: null,
+      annotation: '', // TODO: This should be null, but the regex isn't structured for that, at the moment.
+      body: `It's goin' twice.`,
+      date: new Date('10/25/2011'),
+      secondDate: new Date('10/28/2011'),
+      dateKind: null,
+      accessDate: new Date('10/27/2011'),
+      accessKind: 'accessed',
+
+    },
+    {
+      artists: [artist3],
+      artistDisplayText: null,
+      annotation: `[fake](https://web.archive.org/web/20201024170202/https://homestuck.bandcamp.com/fake)`,
+      body: `It's goin' thrice!`,
+      date: new Date('7/20/2019'),
+      secondDate: new Date('7/20/2022'),
+      dateKind: null,
+      accessDate: new Date('4/13/2024'),
+      accessKind: 'accessed',
+    },
+  ]);
+
+  t.same(composite.expose.compute({
+    artistData,
+    from:
+      `<i>Homestuck:</i> ([MSPA sound credits](https://web.archive.org/web/20120805031705/http://www.mspaintadventures.com:80/soundcredits.html), sometime 6/21/2012 - 8/5/2012)\n` +
+      `\n` +
+      `[[flash:246|Page 2146]] - <b>"Sburban Countdown"</b><br>\n` +
+      `Available on Bandcamp in [[album:homestuck-vol-1-4|Homestuck Vol. 1-4]]<br>\n` +
+      `Written by [[artist:michael-guy-bowman|Michael Guy Bowman]]<br>\n` +
+      `Arrangement by [[artist:mark-j-hadley|Mark Hadley]]\n` +
+      `\n` +
+      `<i>Homestuck:</i> ([fake](https://web.archive.org/web/20201024170202/https://homestuck.bandcamp.com/fake), 7/20/2019 - 7/20/2022 captured 4/13/2024)\n` +
+      `It's goin' once.\n` +
+      `\n` +
+      `<i>Homestuck:</i> (10/25/2011 - 10/28/2011 accessed 10/27/2011)\n` +
+      `It's goin' twice.\n` +
+      `\n` +
+      `<i>Homestuck:</i> ([fake](https://web.archive.org/web/20201024170202/https://homestuck.bandcamp.com/fake), 7/20/2019 - 7/20/2022 accessed 4/13/2024)\n` +
+      `It's goin' thrice!\n`
+  }), [
+    {
+      artists: [artist3],
+      artistDisplayText: null,
+      annotation: `[MSPA sound credits](https://web.archive.org/web/20120805031705/http://www.mspaintadventures.com:80/soundcredits.html)`,
+      body:
+        `[[flash:246|Page 2146]] - <b>"Sburban Countdown"</b><br>\n` +
+        `Available on Bandcamp in [[album:homestuck-vol-1-4|Homestuck Vol. 1-4]]<br>\n` +
+        `Written by [[artist:michael-guy-bowman|Michael Guy Bowman]]<br>\n` +
+        `Arrangement by [[artist:mark-j-hadley|Mark Hadley]]`,
+      date: new Date('6/21/2012'),
+      secondDate: new Date('8/5/2012'),
+      dateKind: 'sometime',
+      accessDate: new Date('8/5/2012'),
+      accessKind: 'captured',
+    },
+    {
+      artists: [artist3],
+      artistDisplayText: null,
+      annotation: `[fake](https://web.archive.org/web/20201024170202/https://homestuck.bandcamp.com/fake)`,
+      body: `It's goin' once.`,
+      date: new Date('7/20/2019'),
+      secondDate: new Date('7/20/2022'),
+      dateKind: null,
+      accessDate: new Date('4/13/2024'),
+      accessKind: 'captured',
+    },
+    {
+      artists: [artist3],
+      artistDisplayText: null,
+      annotation: '', // TODO: This should be null, but the regex isn't structured for that, at the moment.
+      body: `It's goin' twice.`,
+      date: new Date('10/25/2011'),
+      secondDate: new Date('10/28/2011'),
+      dateKind: null,
+      accessDate: new Date('10/27/2011'),
+      accessKind: 'accessed',
+
+    },
+    {
+      artists: [artist3],
+      artistDisplayText: null,
+      annotation: `[fake](https://web.archive.org/web/20201024170202/https://homestuck.bandcamp.com/fake)`,
+      body: `It's goin' thrice!`,
+      date: new Date('7/20/2019'),
+      secondDate: new Date('7/20/2022'),
+      dateKind: null,
+      accessDate: new Date('4/13/2024'),
+      accessKind: 'accessed',
+    },
+  ]);
+
+  t.same(composite.expose.compute({
+    artistData,
+    from:
+      `<i>Homestuck:</i> ([Homestuck sound credits](https://web.archive.org/web/20180717171235/https://www.homestuck.com/credits/sound), excerpt, around 4/3/2018)\n` +
+      `blablabla\n` +
+      `<i>Homestuck:</i> ([fake](https://web.archive.org/web/20201024170202/https://homestuck.bandcamp.com/fake), around 7/20/2019 - 7/20/2022 captured 4/13/2024)\n` +
+      `Snoopin', snoopin', snoo,\n` +
+      `<i>Homestuck:</i> ([fake](https://web.archive.org/web/20201024170202/https://homestuck.bandcamp.com/fake), throughout 7/20/2019 - 7/20/2022 accessed 4/13/2024)\n` +
+      `~ pingas ~\n`
+  }), [
+    {
+      artists: [artist3],
+      artistDisplayText: null,
+      annotation: `[Homestuck sound credits](https://web.archive.org/web/20180717171235/https://www.homestuck.com/credits/sound), excerpt`,
+      body: `blablabla`,
+      date: new Date('4/3/2018'),
+      secondDate: null,
+      dateKind: 'around',
+      accessDate: new Date('7/17/2018'),
+      accessKind: 'captured',
+    },
+    {
+      artists: [artist3],
+      artistDisplayText: null,
+      annotation: `[fake](https://web.archive.org/web/20201024170202/https://homestuck.bandcamp.com/fake)`,
+      body: `Snoopin', snoopin', snoo,`,
+      date: new Date('7/20/2019'),
+      secondDate: new Date('7/20/2022'),
+      dateKind: 'around',
+      accessDate: new Date('4/13/2024'),
+      accessKind: 'captured',
+    },
+    {
+      artists: [artist3],
+      artistDisplayText: null,
+      annotation: `[fake](https://web.archive.org/web/20201024170202/https://homestuck.bandcamp.com/fake)`,
+      body: `~ pingas ~`,
+      date: new Date('7/20/2019'),
+      secondDate: new Date('7/20/2022'),
+      dateKind: 'throughout',
       accessDate: new Date('4/13/2024'),
       accessKind: 'accessed',
     },


### PR DESCRIPTION
Expands the kinds of dates you can enter in commentary entries!

* `around <date>`
* `around <date> - <secondDate>`
* `throughout <date> - <secondDate>`
* `sometime <date> - <secondDate>`
* or just `<date> - <secondDate>`

All of these work alongside access/capture date (#527). They're displayed in the date column (#530), just like normal dates. (The entire date line is the tooltip hoverable.)

Technically, all combinations of date kind (or none) and `- <secondDate>` are valid, as far as parsing is concerned. You can do `throughout 2024/04/15` and it'll, ah, "Just Work". Content code deals with semantics, here, for now, and will make sure "sometime" and "throughout" are only shown next to an actual range. There are probably nicer ways to approach this, especially if we support less specific dates (e.g. "May 2008"), but for now it's OK. ✨ 

Updating the unit tests has sucked the life out of us lol