### PR TITLE
Crediting sources section

### DIFF
--- a/src/content/dependencies/generateCommentarySection.js
+++ b/src/content/dependencies/generateCommentarySection.js
@@ -29,6 +29,7 @@ export default {
 
   slots: {
     title: {type: 'html', mutable: false},
+    id: {type: 'string', default: 'artist-commentary'},
   },
 
   generate: (data, relations, slots, {html, language}) =>
@@ -41,7 +42,7 @@ export default {
               : slots.title),
 
           attributes: [
-            {id: 'artist-commentary'},
+            {id: slots.id},
             data.firstEntryIsDated &&
               {class: 'first-entry-is-dated'},
           ],

--- a/src/content/dependencies/generateCommentarySection.js
+++ b/src/content/dependencies/generateCommentarySection.js
@@ -27,11 +27,19 @@ export default {
         : !!entries[0].date),
   }),
 
-  generate: (data, relations, {html, language}) =>
+  slots: {
+    title: {type: 'html', mutable: false},
+  },
+
+  generate: (data, relations, slots, {html, language}) =>
     html.tags([
       relations.heading
         .slots({
-          title: language.$('misc.artistCommentary'),
+          title:
+            (html.isBlank(slots.title)
+              ? language.$('misc.artistCommentary')
+              : slots.title),
+
           attributes: [
             {id: 'artist-commentary'},
             data.firstEntryIsDated &&

--- a/src/content/dependencies/generatePageLayout.js
+++ b/src/content/dependencies/generatePageLayout.js
@@ -495,6 +495,7 @@ export default {
               {id: 'additional-files', string: 'additionalFiles'},
               {id: 'commentary', string: 'commentary'},
               {id: 'artist-commentary', string: 'artistCommentary'},
+              {id: 'credit-sources', string: 'creditSources'},
             ])),
         ]);
 

--- a/src/content/dependencies/generatePageLayout.js
+++ b/src/content/dependencies/generatePageLayout.js
@@ -327,28 +327,26 @@ export default {
                 if (cur.html) {
                   content = cur.html;
                 } else {
+                  const attributes = html.attributes();
                   let title;
-                  let href;
 
                   switch (cur.auto) {
                     case 'home':
                       title = data.wikiName;
-                      href = to('localized.home');
+                      attributes.set('href', to('localized.home'));
                       break;
                     case 'current':
                       title = slots.title;
-                      href = '';
+                      attributes.set('href', '');
                       break;
                     case null:
                     case undefined:
                       title = cur.title;
-                      href = to(...cur.path);
+                      attributes.set('href', to(...cur.path));
                       break;
                   }
 
-                  content = html.tag('a',
-                    {href},
-                    title);
+                  content = html.tag('a', attributes, title);
                 }
 
                 const showAsCurrent =

--- a/src/content/dependencies/generateTrackInfoPage.js
+++ b/src/content/dependencies/generateTrackInfoPage.js
@@ -113,6 +113,9 @@ export default {
 
     artistCommentarySection:
       relation('generateCommentarySection', track.commentary),
+
+    creditSourcesSection:
+      relation('generateCommentarySection', track.creditSources),
   }),
 
   data: (sprawl, track) => ({
@@ -359,6 +362,11 @@ export default {
           ]),
 
           relations.artistCommentarySection,
+
+          relations.creditSourcesSection.slots({
+            title:
+              language.$('misc.creditSources'),
+          }),
         ],
 
         navLinkStyle: 'hierarchical',

--- a/src/content/dependencies/generateTrackInfoPage.js
+++ b/src/content/dependencies/generateTrackInfoPage.js
@@ -364,8 +364,8 @@ export default {
           relations.artistCommentarySection,
 
           relations.creditSourcesSection.slots({
-            title:
-              language.$('misc.creditSources'),
+            id: 'credit-sources',
+            title: language.$('misc.creditSources'),
           }),
         ],
 

--- a/src/content/dependencies/generateTrackInfoPage.js
+++ b/src/content/dependencies/generateTrackInfoPage.js
@@ -197,6 +197,15 @@ export default {
                         {href: '#artist-commentary'},
                         language.$(capsule, 'link')),
                   })),
+
+              !html.isBlank(relations.creditSourcesSection) &&
+                language.encapsulate(capsule, 'readCreditSources', capsule =>
+                  language.$(capsule, {
+                    link:
+                      html.tag('a',
+                        {href: '#credit-sources'},
+                        language.$(capsule, 'link')),
+                  })),
             ])),
 
           html.tags([

--- a/src/data/checks.js
+++ b/src/data/checks.js
@@ -544,6 +544,7 @@ export function reportContentTextErrors(wikiData, {
     ['trackData', {
       additionalFiles: additionalFileShape,
       commentary: commentaryShape,
+      creditSources: commentaryShape,
       lyrics: '_content',
       midiProjectFiles: additionalFileShape,
       sheetMusicFiles: additionalFileShape,

--- a/src/data/things/album.js
+++ b/src/data/things/album.js
@@ -132,6 +132,7 @@ export class Album extends Thing {
     isListedInGalleries: flag(true),
 
     commentary: commentary(),
+    creditSources: commentary(),
     additionalFiles: additionalFiles(),
 
     trackSections: referenceList({
@@ -366,6 +367,7 @@ export class Album extends Thing {
       },
 
       'Commentary': {property: 'commentary'},
+      'Credit Sources': {property: 'creditSources'},
 
       'Additional Files': {
         property: 'additionalFiles',

--- a/src/data/things/flash.js
+++ b/src/data/things/flash.js
@@ -112,6 +112,7 @@ export class Flash extends Thing {
     urls: urls(),
 
     commentary: commentary(),
+    creditSources: commentary(),
 
     // Update only
 
@@ -200,6 +201,7 @@ export class Flash extends Thing {
       },
 
       'Commentary': {property: 'commentary'},
+      'Credit Sources': {property: 'creditSources'},
 
       'Review Points': {ignore: true},
     },

--- a/src/data/things/track.js
+++ b/src/data/things/track.js
@@ -170,6 +170,7 @@ export class Track extends Thing {
     ],
 
     commentary: commentary(),
+    creditSources: commentary(),
 
     lyrics: [
       inheritFromOriginalRelease(),
@@ -459,6 +460,7 @@ export class Track extends Thing {
 
       'Lyrics': {property: 'lyrics'},
       'Commentary': {property: 'commentary'},
+      'Credit Sources': {property: 'creditSources'},
 
       'Additional Files': {
         property: 'additionalFiles',

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -344,6 +344,10 @@ releaseInfo:
     _: "Read {LINK}."
     link: "artist commentary"
 
+  readCreditSources:
+    _: "Read {LINK}."
+    link: "crediting sources"
+
   additionalFiles:
     heading: "View or download additional files:"
 

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -547,6 +547,9 @@ misc:
       trackArt: "{INDEX} track art by {ARTIST}"
       onlyIndex: "Only"
 
+  creditSources:
+    _: "Crediting sources:"
+
   # external:
   #   Links which will generally bring you somewhere off of the wiki.
   #   The list of sites is hard-coded into the wiki software, so it

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -752,11 +752,17 @@ misc:
       left: "Sidebar (left)"
       right: "Sidebar (right)"
 
+    # Displayed on various info pages.
+
+    artistCommentary: "Artist commentary"
+    creditSources: "Crediting sources"
+
     # Displayed on artist info page.
 
     tracks: "Tracks"
     artworks: "Artworks"
     flashes: "Flashes & Games"
+    commentary: "Commentary"
 
     # Displayed on track and flash info pages.
 
@@ -778,9 +784,6 @@ misc:
 
     # Displayed on track and album info pages.
 
-    commentary: "Commentary"
-
-    artistCommentary: "Commentary"
     additionalFiles: "Additional files"
 
   # socialEmbed:


### PR DESCRIPTION
Closes #432.

Bog-simple approach: crediting sources are identical to artist commentary, just tracked in a separate property/field and shown in a separate section.

There is currently literally no "special" behavior. They're present at the bottom of the page so as not to distract from any of the main content, and to keep next to artist commentary. They get a skipper link as well as a jump link. Neither individual entries nor the section itself can be expanded/collapsed, and they are not listed on artist pages, and they are not aggregated on an album credit page. They don't use the layout we'll eventually use for multiple lyrics (#397).