### PR TITLE
Sort reverse reference lists by date, in data

### DIFF
--- a/src/data/composite/wiki-data/withReverseReferenceList.js
+++ b/src/data/composite/wiki-data/withReverseReferenceList.js
@@ -12,6 +12,7 @@
 // so any changes should be reflected there (until these are combined).
 
 import {input, templateCompositeFrom} from '#composite';
+import {sortByDate} from '#sort';
 import {stitchArrays} from '#sugar';
 
 import {exitWithoutDependency, raiseOutputWithoutDependency}
@@ -128,9 +129,10 @@ export default templateCompositeFrom({
 
     // Actually fill in the cache record. Since we're building up a *reverse*
     // reference list, track connections in terms of the referenced thing.
-    // No newly-provided dependencies here since we're mutating the cache
-    // record, which is properly in store and will probably be reused in the
-    // future (and certainly in the next step).
+    // Although we gather all referenced things into a set and provide that
+    // for sorting purposes in the next step, we *don't* reprovide the cache
+    // record, because we're mutating that in-place - we'll just reuse its
+    // existing '#cacheRecord' dependency.
     {
       dependencies: ['#cacheRecord', '#referencingThings', '#referencedThings'],
       compute: (continuation, {
@@ -138,6 +140,8 @@ export default templateCompositeFrom({
         ['#referencingThings']: referencingThings,
         ['#referencedThings']: referencedThings,
       }) => {
+        const allReferencedThings = new Set();
+
         stitchArrays({
           referencingThing: referencingThings,
           referencedThings: referencedThings,
@@ -147,9 +151,35 @@ export default templateCompositeFrom({
                 cacheRecord.get(referencedThing).push(referencingThing);
               } else {
                 cacheRecord.set(referencedThing, [referencingThing]);
+                allReferencedThings.add(referencedThing);
               }
             }
           });
+
+        return continuation({
+          ['#allReferencedThings']:
+            allReferencedThings,
+        });
+      },
+    },
+
+    // Sort the entries in the cache records, too, just by date - the rest of
+    // sorting should be handled outside of withReverseContributionList, either
+    // preceding (changing the 'data' input) or following (sorting the output).
+    // Again we're mutating in place, so no need to reprovide '#cacheRecord'
+    // here.
+    {
+      dependencies: ['#cacheRecord', '#allReferencedThings'],
+      compute: (continuation, {
+        ['#cacheRecord']: cacheRecord,
+        ['#allReferencedThings']: allReferencedThings,
+      }) => {
+        for (const referencedThing of allReferencedThings) {
+          if (cacheRecord.has(referencedThing)) {
+            const referencingThings = cacheRecord.get(referencedThing);
+            sortByDate(referencingThings);
+          }
+        }
 
         return continuation();
       },


### PR DESCRIPTION
Sorts reverse reference and contribution lists by date, notably using the intrinsically provided dates provided through `withResolvedContribs` (etc).

Lists are only sorted by the literal property `date` on the referencing things; additionally disambiguating sorting should be performed before or after. (Although for "before" - the sorting should be done to the array *shared* by all things, or else the caching is defeated. We declare sorting through YAML loading specs' `sort` step. Detailed discussion: [#code-quarantine](https://discord.com/channels/749042497610842152/854020929113423924/1255509077786890320))

Re: #383, sorting occurs for every reverse reference list (of the respective `input('data')` and `input('list')` all at once, at the same time as the reverse lists / cache records are basically prepared (i.e. on the first call with those inputs). Although we haven't 100% confirmed this is never significantly consequential, some initial measures suggest we'd have to be dealing with pretty big data to run into trouble. (Intro: [#code-quarantine](https://discord.com/channels/749042497610842152/854020929113423924/1255507658396401776), summary: [#code-quarantine](https://discord.com/channels/749042497610842152/854020929113423924/1255537532880289942))

Resolves #529, fixing cover artwork chronology links (whose dates can vary from the respective track). We haven't integrated a predictable sort order into general content yet, and there probably needs to be a broader look at how sorted lists are represented to enable that (e.g. we should only sort according to language rules within ranges that are otherwise ambiguous).