### PR TITLE
composite: expose used defaultDependency/defaultValue at step instantiation

### DIFF
--- a/src/data/composite.js
+++ b/src/data/composite.js
@@ -342,7 +342,27 @@ export function templateCompositeFrom(description) {
       }
     });
 
-    const inputMetadata = getStaticInputMetadata(inputOptions);
+    const inputMapping = {};
+    if ('inputs' in description) {
+      for (const [name, token] of Object.entries(description.inputs)) {
+        const tokenValue = getInputTokenValue(token);
+        if (name in inputOptions) {
+          if (typeof inputOptions[name] === 'string') {
+            inputMapping[name] = input.dependency(inputOptions[name]);
+          } else {
+            inputMapping[name] = inputOptions[name];
+          }
+        } else if (tokenValue.defaultValue) {
+          inputMapping[name] = input.value(tokenValue.defaultValue);
+        } else if (tokenValue.defaultDependency) {
+          inputMapping[name] = input.dependency(tokenValue.defaultDependency);
+        } else {
+          inputMapping[name] = input.value(null);
+        }
+      }
+    }
+
+    const inputMetadata = getStaticInputMetadata(inputMapping);
 
     const expectedOutputNames =
       (Array.isArray(description.outputs)
@@ -414,25 +434,6 @@ export function templateCompositeFrom(description) {
         }
 
         if ('inputs' in description) {
-          const inputMapping = {};
-
-          for (const [name, token] of Object.entries(description.inputs)) {
-            const tokenValue = getInputTokenValue(token);
-            if (name in inputOptions) {
-              if (typeof inputOptions[name] === 'string') {
-                inputMapping[name] = input.dependency(inputOptions[name]);
-              } else {
-                inputMapping[name] = inputOptions[name];
-              }
-            } else if (tokenValue.defaultValue) {
-              inputMapping[name] = input.value(tokenValue.defaultValue);
-            } else if (tokenValue.defaultDependency) {
-              inputMapping[name] = input.dependency(tokenValue.defaultDependency);
-            } else {
-              inputMapping[name] = input.value(null);
-            }
-          }
-
           finalDescription.inputMapping = inputMapping;
           finalDescription.inputDescriptions = description.inputs;
         }

--- a/src/data/composite.js
+++ b/src/data/composite.js
@@ -72,30 +72,22 @@ function getInputTokenValue(token) {
   }
 }
 
-function getStaticInputMetadata(inputOptions) {
+function getStaticInputMetadata(inputMapping) {
   const metadata = {};
 
-  for (const [name, token] of Object.entries(inputOptions)) {
-    if (typeof token === 'string') {
-      metadata[input.staticDependency(name)] = token;
-      metadata[input.staticValue(name)] = null;
-    } else if (isInputToken(token)) {
-      const tokenShape = getInputTokenShape(token);
-      const tokenValue = getInputTokenValue(token);
+  for (const [name, token] of Object.entries(inputMapping)) {
+    const tokenShape = getInputTokenShape(token);
+    const tokenValue = getInputTokenValue(token);
 
-      metadata[input.staticDependency(name)] =
-        (tokenShape === 'input.dependency'
-          ? tokenValue
-          : null);
+    metadata[input.staticDependency(name)] =
+      (tokenShape === 'input.dependency'
+        ? tokenValue
+        : null);
 
-      metadata[input.staticValue(name)] =
-        (tokenShape === 'input.value'
-          ? tokenValue
-          : null);
-    } else {
-      metadata[input.staticDependency(name)] = null;
-      metadata[input.staticValue(name)] = null;
-    }
+    metadata[input.staticValue(name)] =
+      (tokenShape === 'input.value'
+        ? tokenValue
+        : null);
   }
 
   return metadata;
@@ -350,6 +342,8 @@ export function templateCompositeFrom(description) {
           if (typeof inputOptions[name] === 'string') {
             inputMapping[name] = input.dependency(inputOptions[name]);
           } else {
+            // This is always an input token, since only a string or
+            // an input token is a valid input option (asserted above).
             inputMapping[name] = inputOptions[name];
           }
         } else if (tokenValue.defaultValue) {

--- a/src/data/composite.js
+++ b/src/data/composite.js
@@ -526,7 +526,10 @@ export function compositeFrom(description) {
         ? compositeFrom(step.toResolvedComposition())
         : step));
 
-  const inputMetadata = getStaticInputMetadata(description.inputMapping ?? {});
+  const inputMetadata =
+    (description.inputMapping
+      ? getStaticInputMetadata(description.inputMapping)
+      : {});
 
   function _mapDependenciesToOutputs(providedDependencies) {
     if (!description.outputs) {

--- a/src/data/composite/control-flow/raiseOutputWithoutDependency.js
+++ b/src/data/composite/control-flow/raiseOutputWithoutDependency.js
@@ -17,7 +17,7 @@ export default templateCompositeFrom({
 
   outputs: ({
     [input.staticValue('output')]: output,
-  }) => Object.keys(output ?? {}),
+  }) => Object.keys(output),
 
   steps: () => [
     withResultOfAvailabilityCheck({

--- a/src/data/composite/control-flow/raiseOutputWithoutUpdateValue.js
+++ b/src/data/composite/control-flow/raiseOutputWithoutUpdateValue.js
@@ -16,7 +16,7 @@ export default templateCompositeFrom({
 
   outputs: ({
     [input.staticValue('output')]: output,
-  }) => Object.keys(output ?? {}),
+  }) => Object.keys(output),
 
   steps: () => [
     withResultOfAvailabilityCheck({


### PR DESCRIPTION
`getStaticInputMetadata` is a function used to pick out information about the actual shape of how a compositional step was instantiated. For example, it converts the options provided here:

```js
withResolvedReferenceList({
  list: 'trackSections',
  data: 'ownTrackSectionData',
  find: input.value(find.unqualifiedTrackSection),
})

withPropertyFromObject({
  object: '#artist',
  property: input('artistProperty'),
})
```

Into these:

```js
{
  [input.staticDependency('list')]: 'trackSections',
  [input.staticDependency('data')]: 'ownTrackSectionData',
  [input.staticDependency('find')]: null,
  [input.staticValue('list')]: null,
  [input.staticValue('data')]: null,
  [input.staticValue('find')]: find.unqualifiedTrackSection,
}

{
  [input.staticDependency('object')]: '#artist',
  [input.staticDependency('property')]: null,
  [input.staticValue('object')]: null,
  [input.staticValue('property')]: null,
}
```

In practice, it's actually called in two places. The normal place is right before computing the expected output names for the template / compositional step, so that an upcoming call to `.outputs()` can be validated. (A dynamic `update` description is also computed at this time.) In this case, it used to operate on just the literal object provided to the step, as demo'd above.

The composition's *steps themselves* can also depend on the static metadata (typically, in order to compute the appropriate names to provide as dependencies). This metadata is computed, though, from the *final* input mapping. It looks similar, but factors in the `defaultDependency` or `defaultValue` details provided on the step's input descriptions. (It also normalizes string literals into `input.dependency()` form, and maps to `input.value(null)` if the input is missing.)

Since it was called with different arguments, the available static input metadata differed — mainly, default values weren't present when computing dynamic `outputs` / `update`.

This PR changes both calls to work off the computed input mapping. To do this, during step instantiation, it computes the input mapping earlier. We couldn't move the call later, because we need to have static input metadata right away, to compute available output names, for validation of a subsequent `.outputs()` call. But we *could* move the input mapping compute earlier, because it depends only on the composition's description (constant) and on the provided input options (known at instantiation, and never changed afterwards).

There are also a couple code cleanups here. Don't be distracted: the changes inside `getStaticInputMetadata` are just for tidiness, since it's not used on two differently shaped parameters.