### PR TITLE
Make album links scroll to album commentary, on album commentary page

### DIFF
--- a/src/content/dependencies/generateAlbumCommentaryPage.js
+++ b/src/content/dependencies/generateAlbumCommentaryPage.js
@@ -161,6 +161,7 @@ export default {
               language.encapsulate(entryCapsule, 'title.albumCommentary', titleCapsule =>
                 relations.albumCommentaryHeading.slots({
                   tag: 'h3',
+                  attributes: {id: 'album-commentary'},
                   color: data.color,
 
                   title:

--- a/src/content/dependencies/linkAlbumDynamically.js
+++ b/src/content/dependencies/linkAlbumDynamically.js
@@ -7,8 +7,24 @@ export default {
     infoLink: relation('linkAlbum', album),
   }),
 
-  generate: (relations, {pagePath}) =>
-    (pagePath[0] === 'albumGallery'
+  data: (album) => ({
+    albumDirectory:
+      album.directory,
+
+    albumHasCommentary:
+      !!album.commentary,
+  }),
+
+  generate: (data, relations, {pagePath}) =>
+    (pagePath[0] === 'albumCommentary' &&
+     pagePath[1] === data.albumDirectory &&
+     data.albumHasCommentary
+      ? relations.infoLink.slots({
+          anchor: true,
+          hash: 'album-commentary',
+        })
+
+   : pagePath[0] === 'albumGallery'
       ? relations.galleryLink
       : relations.infoLink),
 };

--- a/src/util/replacer.js
+++ b/src/util/replacer.js
@@ -13,7 +13,7 @@ import {escapeRegex, typeAppearance} from '#sugar';
 export const replacerSpec = {
   'album': {
     find: 'album',
-    link: 'linkAlbum',
+    link: 'linkAlbumDynamically',
   },
 
   'album-commentary': {


### PR DESCRIPTION
Through a new clause in `linkAlbumDynamically` (based off `linkTrackDynamically`), if a track or album commentary entry includes a link to the same album - and that album has album commentary - then on the album commentary page, the link will scroll up to the album commentary entry.

That's to say that stuff like "continued from album commentary" will scroll you back up to the album commentary entry, at the top of the page.