### PR TITLE
Move "edits for wiki" credits into tooltip, and more

### DIFF
--- a/src/content/dependencies/generateArtistGalleryPage.js
+++ b/src/content/dependencies/generateArtistGalleryPage.js
@@ -19,6 +19,7 @@ export default {
         artist.albumCoverArtistContributions,
         artist.trackCoverArtistContributions,
       ]).flat()
+        .filter(({annotation}) => !annotation?.startsWith(`edits for wiki`))
         .map(({thing}) => thing);
 
     sortAlbumsTracksChronologically(things, {

--- a/src/content/dependencies/generateArtistInfoPage.js
+++ b/src/content/dependencies/generateArtistInfoPage.js
@@ -40,6 +40,7 @@ export default {
         artist.albumBannerArtistContributions,
         artist.trackCoverArtistContributions,
       ]).flat()
+        .filter(({annotation}) => !annotation?.startsWith('edits for wiki'))
         .map(({thing}) => thing),
 
     // Banners and wallpapers don't show up in the artist gallery page, only
@@ -78,7 +79,10 @@ export default {
       relation('generateArtistGroupContributionsInfo', query.allTracks),
 
     artworksChunkedList:
-      relation('generateArtistInfoPageArtworksChunkedList', artist),
+      relation('generateArtistInfoPageArtworksChunkedList', artist, false),
+
+    editsForWikiArtworksChunkedList:
+      relation('generateArtistInfoPageArtworksChunkedList', artist, true),
 
     artworksGroupInfo:
       relation('generateArtistGroupContributionsInfo', query.allArtworks),
@@ -181,10 +185,11 @@ export default {
                       {href: '#tracks'},
                       language.$(pageCapsule, 'trackList.title')),
 
-                  !html.isBlank(relations.artworksChunkedList) &&
-                    html.tag('a',
-                      {href: '#art'},
-                      language.$(pageCapsule, 'artList.title')),
+                  (!html.isBlank(relations.artworksChunkedList) ||
+                   !html.isBlank(relations.editsForWikiArtworksChunkedList)) &&
+                      html.tag('a',
+                        {href: '#art'},
+                        language.$(pageCapsule, 'artList.title')),
 
                   !html.isBlank(relations.flashesChunkedList) &&
                     html.tag('a',
@@ -276,6 +281,17 @@ export default {
                         countUnit: 'artworks',
                       })),
               }),
+
+            html.tags([
+              html.tag('p',
+                {[html.onlyIfSiblings]: true},
+
+                language.$(pageCapsule, 'wikiEditArtworks', {
+                  artist: data.name,
+                })),
+
+              relations.editsForWikiArtworksChunkedList,
+            ]),
           ]),
 
           html.tags([

--- a/src/content/dependencies/generateArtistInfoPageChunk.js
+++ b/src/content/dependencies/generateArtistInfoPageChunk.js
@@ -29,6 +29,11 @@ export default {
 
     duration: {validate: v => v.isDuration},
     durationApproximate: {type: 'boolean'},
+
+    trimAnnotations: {
+      type: 'boolean',
+      default: false,
+    },
   },
 
   generate(slots, {html, language}) {
@@ -102,7 +107,10 @@ export default {
       html.tag('dt', accentedLink),
       html.tag('dd',
         html.tag('ul',
-          slots.items)),
+          slots.items
+            .map(item => item.slots({
+              trimAnnotation: slots.trimAnnotations,
+            })))),
     ]);
   },
 };

--- a/src/content/dependencies/generateArtistInfoPageChunkItem.js
+++ b/src/content/dependencies/generateArtistInfoPageChunkItem.js
@@ -9,16 +9,18 @@ export default {
       mutable: false,
     },
 
-    annotation: {
-      type: 'html',
-      mutable: false,
-    },
+    annotation: {type: 'string'},
 
     otherArtistLinks: {
       validate: v => v.strictArrayOf(v.isHTML),
     },
 
     rerelease: {type: 'boolean'},
+
+    trimAnnotation: {
+      type: 'boolean',
+      default: false,
+    },
   },
 
   generate: (slots, {html, language}) =>
@@ -43,10 +45,15 @@ export default {
               language.formatConjunctionList(slots.otherArtistLinks);
           }
 
-          if (!html.isBlank(slots.annotation)) {
+          const annotation =
+            (slots.trimAnnotation
+              ? slots.annotation?.replace(/^edits for wiki(: )?/, '')
+              : slots.annotation);
+
+          if (annotation) {
             anyAccent = true;
             workingCapsule += '.withAnnotation';
-            workingOptions.annotation = slots.annotation;
+            workingOptions.annotation = annotation;
           }
 
           if (anyAccent) {

--- a/src/content/dependencies/generateContributionList.js
+++ b/src/content/dependencies/generateContributionList.js
@@ -20,8 +20,8 @@ export default {
         .map(contributionLink =>
           html.tag('li',
             contributionLink.slots({
+              showAnnotation: true,
               showExternalLinks: true,
-              showContribution: true,
               showChronology: true,
               preventWrapping: false,
               chronologyKind: slots.chronologyKind,

--- a/src/content/dependencies/generateReleaseInfoContributionsLine.js
+++ b/src/content/dependencies/generateReleaseInfoContributionsLine.js
@@ -34,7 +34,7 @@ export default {
   }),
 
   slots: {
-    showContribution: {type: 'boolean', default: true},
+    showAnnotation: {type: 'boolean', default: true},
     showExternalLinks: {type: 'boolean', default: true},
     showChronology: {type: 'boolean', default: true},
 
@@ -47,7 +47,7 @@ export default {
       language.formatConjunctionList(
         relations.contributionLinks.map(link =>
           link.slots({
-            showContribution: slots.showContribution,
+            showAnnotation: slots.showAnnotation,
             showExternalLinks: slots.showExternalLinks,
             showChronology: slots.showChronology,
             chronologyKind: slots.chronologyKind,

--- a/src/content/dependencies/generateReleaseInfoContributionsLine.js
+++ b/src/content/dependencies/generateReleaseInfoContributionsLine.js
@@ -11,11 +11,11 @@ export default {
   query: (contributions) => ({
     normalContributions:
       contributions
-        .filter(contrib => contrib.annotation !== 'edits for wiki'),
+        .filter(contrib => !contrib.annotation?.startsWith(`edits for wiki`)),
 
     wikiEditContributions:
       contributions
-        .filter(contrib => contrib.annotation === 'edits for wiki'),
+        .filter(contrib => contrib.annotation?.startsWith(`edits for wiki`)),
   }),
 
   relations: (relation, query, _contributions) => ({

--- a/src/content/dependencies/generateReleaseInfoContributionsLineWikiEditsPart.js
+++ b/src/content/dependencies/generateReleaseInfoContributionsLineWikiEditsPart.js
@@ -39,9 +39,8 @@ export default {
                   language.$(capsule, 'editsLine', {
                     artist:
                       link.slots({
-                        showContribution: false,
-                        showExternalLinks: false,
-                        showChronology: false,
+                        showAnnotation: true,
+                        trimAnnotation: true,
                         preventTooltip: true,
                       }),
                   })),

--- a/src/content/dependencies/generateReleaseInfoContributionsLineWikiEditsPart.js
+++ b/src/content/dependencies/generateReleaseInfoContributionsLineWikiEditsPart.js
@@ -5,7 +5,7 @@ export default {
     'linkContribution',
   ],
 
-  extraDependencies: ['html', 'language'],
+  extraDependencies: ['language'],
 
   relations: (relation, contributions) => ({
     textWithTooltip:
@@ -19,7 +19,7 @@ export default {
         .map(contrib => relation('linkContribution', contrib)),
   }),
 
-  generate: (relations, {html, language}) =>
+  generate: (relations, {language}) =>
     language.encapsulate('misc.artistLink.withEditsForWiki', capsule =>
       relations.textWithTooltip.slots({
         attributes:
@@ -34,18 +34,18 @@ export default {
               {class: 'wiki-edits-tooltip'},
 
             content:
-              html.tags(
-                relations.contributionLinks.map(link =>
-                  language.$(capsule, 'editsLine', {
-                    artist:
+              language.$(capsule, 'editsLine', {
+                [language.onlyIfOptions]: ['artists'],
+
+                artists:
+                  language.formatConjunctionList(
+                    relations.contributionLinks.map(link =>
                       link.slots({
                         showAnnotation: true,
                         trimAnnotation: true,
                         preventTooltip: true,
-                      }),
-                  })),
-
-                {[html.joinChildren]: html.tag('br')}),
+                      }))),
+                }),
           }),
       })),
 };

--- a/src/content/dependencies/generateReleaseInfoContributionsLineWikiEditsPart.js
+++ b/src/content/dependencies/generateReleaseInfoContributionsLineWikiEditsPart.js
@@ -1,0 +1,52 @@
+export default {
+  contentDependencies: [
+    'generateTextWithTooltip',
+    'generateTooltip',
+    'linkContribution',
+  ],
+
+  extraDependencies: ['html', 'language'],
+
+  relations: (relation, contributions) => ({
+    textWithTooltip:
+      relation('generateTextWithTooltip'),
+
+    tooltip:
+      relation('generateTooltip'),
+
+    contributionLinks:
+      contributions
+        .map(contrib => relation('linkContribution', contrib)),
+  }),
+
+  generate: (relations, {html, language}) =>
+    language.encapsulate('misc.artistLink.withEditsForWiki', capsule =>
+      relations.textWithTooltip.slots({
+        attributes:
+          {class: 'wiki-edits'},
+
+        text:
+          language.$(capsule, 'edits'),
+
+        tooltip:
+          relations.tooltip.slots({
+            attributes:
+              {class: 'wiki-edits-tooltip'},
+
+            content:
+              html.tags(
+                relations.contributionLinks.map(link =>
+                  language.$(capsule, 'editsLine', {
+                    artist:
+                      link.slots({
+                        showContribution: false,
+                        showExternalLinks: false,
+                        showChronology: false,
+                        preventTooltip: true,
+                      }),
+                  })),
+
+                {[html.joinChildren]: html.tag('br')}),
+          }),
+      })),
+};

--- a/src/content/dependencies/linkContribution.js
+++ b/src/content/dependencies/linkContribution.js
@@ -29,6 +29,7 @@ export default {
     showChronology: {type: 'boolean', default: false},
 
     preventWrapping: {type: 'boolean', default: true},
+    preventTooltip: {type: 'boolean', default: false},
     chronologyKind: {type: 'string'},
   },
 
@@ -52,7 +53,7 @@ export default {
         });
 
         workingOptions.artist =
-          (html.isBlank(relations.tooltip)
+          (html.isBlank(relations.tooltip) || slots.preventTooltip
             ? relations.artistLink
             : relations.textWithTooltip.slots({
                 customInteractionCue: true,

--- a/src/content/dependencies/linkContribution.js
+++ b/src/content/dependencies/linkContribution.js
@@ -42,6 +42,9 @@ export default {
       language.encapsulate('misc.artistLink', workingCapsule => {
         const workingOptions = {};
 
+        // Filling slots early is necessary to actually give the tooltip
+        // content. Otherwise, the coming-up html.isBlank() always reports
+        // the tooltip as blank!
         relations.tooltip.setSlots({
           showExternalLinks: slots.showExternalLinks,
           showChronology: slots.showChronology,
@@ -60,11 +63,7 @@ export default {
                   }),
 
                 tooltip:
-                  relations.tooltip.slots({
-                    showExternalLinks: slots.showExternalLinks,
-                    showChronology: slots.showChronology,
-                    chronologyKind: slots.chronologyKind,
-                  }),
+                  relations.tooltip,
               }));
 
         if (slots.showContribution && data.contribution) {

--- a/src/content/dependencies/linkContribution.js
+++ b/src/content/dependencies/linkContribution.js
@@ -28,8 +28,11 @@ export default {
     showExternalLinks: {type: 'boolean', default: false},
     showChronology: {type: 'boolean', default: false},
 
+    trimAnnotation: {type: 'boolean', default: false},
+
     preventWrapping: {type: 'boolean', default: true},
     preventTooltip: {type: 'boolean', default: false},
+
     chronologyKind: {type: 'string'},
   },
 
@@ -67,10 +70,14 @@ export default {
                   relations.tooltip,
               }));
 
-        if (slots.showAnnotation && data.annotation) {
+        const annotation =
+          (slots.trimAnnotation
+            ? data.annotation?.replace(/^edits for wiki(: )?/, '')
+            : data.annotation);
+
+        if (slots.showAnnotation && annotation) {
           workingCapsule += '.withContribution';
-          workingOptions.contrib =
-            data.annotation;
+          workingOptions.contrib = annotation;
         }
 
         return language.formatString(workingCapsule, workingOptions);

--- a/src/content/dependencies/linkContribution.js
+++ b/src/content/dependencies/linkContribution.js
@@ -19,12 +19,12 @@ export default {
   }),
 
   data: (contribution) => ({
-    contribution: contribution.annotation,
+    annotation: contribution.annotation,
     urls: contribution.artist.urls,
   }),
 
   slots: {
-    showContribution: {type: 'boolean', default: false},
+    showAnnotation: {type: 'boolean', default: false},
     showExternalLinks: {type: 'boolean', default: false},
     showChronology: {type: 'boolean', default: false},
 
@@ -67,10 +67,10 @@ export default {
                   relations.tooltip,
               }));
 
-        if (slots.showContribution && data.contribution) {
+        if (slots.showAnnotation && data.annotation) {
           workingCapsule += '.withContribution';
           workingOptions.contrib =
-            data.contribution;
+            data.annotation;
         }
 
         return language.formatString(workingCapsule, workingOptions);

--- a/src/data/things/contribution.js
+++ b/src/data/things/contribution.js
@@ -146,9 +146,9 @@ export class Contribution extends Thing {
         }) => continuation({
           ['#likeContributionsFilter']:
             contributionAnnotations.map(mappingAnnotation =>
-              (annotation === 'edits for wiki'
-                ? mappingAnnotation === annotation
-                : mappingAnnotation !== 'edits for wiki')),
+              (annotation?.startsWith(`edits for wiki`)
+                ? mappingAnnotation?.startsWith(`edits for wiki`)
+                : !mappingAnnotation?.startsWith(`edits for wiki`))),
         }),
       },
 

--- a/src/data/things/contribution.js
+++ b/src/data/things/contribution.js
@@ -8,9 +8,15 @@ import Thing from '#thing';
 import {isStringNonEmpty, isThing, validateReference} from '#validators';
 
 import {exitWithoutDependency, exposeDependency} from '#composite/control-flow';
-import {withNearbyItemFromList, withPropertyFromObject} from '#composite/data';
 import {withResolvedReference} from '#composite/wiki-data';
 import {flag, simpleDate} from '#composite/wiki-properties';
+
+import {
+  withFilteredList,
+  withNearbyItemFromList,
+  withPropertyFromList,
+  withPropertyFromObject,
+} from '#composite/data';
 
 import {
   inheritFromContributionPresets,
@@ -123,10 +129,38 @@ export class Contribution extends Thing {
       withPropertyFromObject({
         object: 'thing',
         property: 'thingProperty',
+      }).outputs({
+        '#value': '#contributions',
+      }),
+
+      withPropertyFromList({
+        list: '#contributions',
+        property: input.value('annotation'),
+      }),
+
+      {
+        dependencies: ['#contributions.annotation', 'annotation'],
+        compute: (continuation, {
+          ['#contributions.annotation']: contributionAnnotations,
+          ['annotation']: annotation,
+        }) => continuation({
+          ['#likeContributionsFilter']:
+            contributionAnnotations.map(mappingAnnotation =>
+              (annotation === 'edits for wiki'
+                ? mappingAnnotation === annotation
+                : mappingAnnotation !== 'edits for wiki')),
+        }),
+      },
+
+      withFilteredList({
+        list: '#contributions',
+        filter: '#likeContributionsFilter',
+      }).outputs({
+        '#filteredList': '#contributions',
       }),
 
       exposeDependency({
-        dependency: '#value',
+        dependency: '#contributions',
       }),
     ],
 

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -845,7 +845,8 @@ a:not([href]):hover {
 
 .text-with-tooltip.datetimestamp .text-with-tooltip-interaction-cue,
 .text-with-tooltip.missing-duration .text-with-tooltip-interaction-cue,
-.text-with-tooltip.commentary-date .text-with-tooltip-interaction-cue {
+.text-with-tooltip.commentary-date .text-with-tooltip-interaction-cue,
+.text-with-tooltip.wiki-edits .text-with-tooltip-interaction-cue {
   cursor: default;
 }
 
@@ -907,15 +908,21 @@ li:not(:first-child:last-child) .tooltip,
   left: -10px;
 }
 
-.thing-name-tooltip {
+.thing-name-tooltip,
+.wiki-edits-tooltip {
   padding: 3px 4px 2px 2px;
   left: -6px !important;
-
-  /* Terrifying?
-   * https://stackoverflow.com/a/64424759/4633828
-   */
-  margin-right: -120px;
 }
+
+.wiki-edits-tooltip {
+  font-size: 0.85em;
+}
+
+/* Terrifying?
+ * https://stackoverflow.com/a/64424759/4633828
+ */
+.thing-name-tooltip { margin-right: -120px; }
+.wiki-edits-tooltip { margin-right: -200px; }
 
 .contribution-tooltip .tooltip-content {
   padding: 6px 2px 2px 2px;
@@ -1056,7 +1063,8 @@ li:not(:first-child:last-child) .tooltip,
   font-size: 0.9em;
 }
 
-.thing-name-tooltip .tooltip-content {
+.thing-name-tooltip .tooltip-content,
+.wiki-edits-tooltip .tooltip-content {
   padding: 3px 4.5px;
 }
 

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -490,6 +490,14 @@ misc:
     # Contribution to a track, artwork, or other thing.
     withContribution: "{ARTIST} ({CONTRIB})"
 
+    # Contributions that are annotated "edits for wiki" are
+    # displayed differently from normal contributions, in a
+    # tooltip next to the rest of the credits on that line.
+    withEditsForWiki:
+      _: "{ARTISTS} ({EDITS})"
+      edits: "+ edits"
+      editsLine: "Edits for wiki by {ARTIST}"
+
     # Displayed in an artist's tooltip, if one of their URLs
     # isn't a specially detected web platform.
     noExternalLinkPlatformName: "Other"

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -496,7 +496,7 @@ misc:
     withEditsForWiki:
       _: "{ARTISTS} ({EDITS})"
       edits: "+ edits"
-      editsLine: "Edits for wiki by {ARTIST}"
+      editsLine: "Edits for wiki by {ARTISTS}"
 
     # Displayed in an artist's tooltip, if one of their URLs
     # isn't a specially detected web platform.

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -1153,6 +1153,9 @@ artistPage:
     orBrowseList: "View {LINK}! Or browse the list:"
     link: "art gallery"
 
+  wikiEditArtworks: >-
+    {ARTIST} has edited these artworks for this wiki:
+
 #
 # artistGalleryPage:
 #   The artist gallery page shows a neat grid of all of the album and

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -1713,6 +1713,10 @@ export class Template {
       if (providedValue instanceof Tag || providedValue instanceof Template) {
         return providedValue.toString();
       }
+
+      if (isBlank(providedValue)) {
+        return null;
+      }
     }
 
     if (providedValue !== null) {

--- a/tap-snapshots/test/snapshot/linkContribution.js.test.cjs
+++ b/tap-snapshots/test/snapshot/linkContribution.js.test.cjs
@@ -73,7 +73,7 @@ exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) >
                 <span class="external-platform">Other</span></span></span></span> (Arrangement)</span>
 `
 
-exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) > only showContribution 1`] = `
+exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) > only showAnnotation 1`] = `
 <span class="contribution nowrap"><a href="artist/clark-powell/">Clark Powell</a></span>
 <span class="contribution nowrap"><a href="artist/the-big-baddies/">Grounder &amp; Scratch</a> (Snooping)</span>
 <span class="contribution nowrap"><a href="artist/toby-fox/">Toby Fox</a> (Arrangement)</span>
@@ -98,7 +98,7 @@ exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) >
                 <span class="external-platform">Other</span></span></span></span></span>
 `
 
-exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) > showContribution & showExternalLinks 1`] = `
+exports[`test/snapshot/linkContribution.js > TAP > linkContribution (snapshot) > showAnnotation & showExternalLinks 1`] = `
 <span class="contribution nowrap"><span class="text-with-tooltip"><span class="hoverable"><a class="text-with-tooltip-interaction-cue" href="artist/clark-powell/">Clark Powell</a></span><span class="tooltip contribution-tooltip"><span class="tooltip-content"><a class="external-link" href="https://soundcloud.com/plazmataz">
                     <span class="external-icon"><svg><use href="static/misc/icons.svg#icon-soundcloud"></use></svg></span>
                     <span class="external-handle">plazmataz</span>

--- a/test/snapshot/linkContribution.js
+++ b/test/snapshot/linkContribution.js
@@ -33,13 +33,13 @@ testContentFunctions(t, 'linkContribution (snapshot)', async (t, evaluate) => {
       slots,
     });
 
-  quickSnapshot('showContribution & showExternalLinks', {
-    showContribution: true,
+  quickSnapshot('showAnnotation & showExternalLinks', {
+    showAnnotation: true,
     showExternalLinks: true,
   });
 
-  quickSnapshot('only showContribution', {
-    showContribution: true,
+  quickSnapshot('only showAnnotation', {
+    showAnnotation: true,
   });
 
   quickSnapshot('only showExternalLinks', {
@@ -66,7 +66,7 @@ testContentFunctions(t, 'linkContribution (snapshot)', async (t, evaluate) => {
   });
 
   quickSnapshot('no preventWrapping', {
-    showContribution: true,
+    showAnnotation: true,
     showExternalLinks: true,
     preventWrapping: false,
   });

--- a/test/unit/content/dependencies/linkContribution.js
+++ b/test/unit/content/dependencies/linkContribution.js
@@ -26,7 +26,7 @@ t.test('generateContributionLinks (unit)', async t => {
 
   await testContentFunctions(t, 'generateContributionLinks (unit 1)', async (t, evaluate) => {
     const slots = {
-      showContribution: true,
+      showAnnotation: true,
       showExternalLinks: true,
     };
 
@@ -81,7 +81,7 @@ t.test('generateContributionLinks (unit)', async t => {
 
   await testContentFunctions(t, 'generateContributionLinks (unit 2)', async (t, evaluate) => {
     const slots = {
-      showContribution: false,
+      showAnnotation: false,
       showExternalLinks: false,
     };
 


### PR DESCRIPTION
Moves "edits for wiki" credits out of the main contributions line text...

<img width="392" alt="Release info for Homestuck Vol. 5, including lines: Wallpaper art by Lexxy and Niklink (edits for wiki), and Banner art by Lexxy and Niklink (edits for wiki)" src="https://github.com/user-attachments/assets/459c49ee-0f9f-4900-86ec-7b6f9854feff">

...and into a tooltip:

<img width="331" alt="Same info, with cleaner lines: Wallpaper art by Lexxy (+edits), and Banner art by Lexxy (+edits). The second line's +edits text is hovered, showing a small tooltip that reads, Edits for wiki by Niklink" src="https://github.com/user-attachments/assets/0d131617-f578-4318-9636-2e37eb018774">

Also adds support for further annotating these credits, as below:

```yaml
Wallpaper Artists:
- Lexxy
- "Niklink (edits for wiki: logo removal)"
- "Quasar Nebula (edits for wiki: crop)"
# Quotation marks are needed to keep this
# from looking like a YAML object. Sorry!
```

<img width="443" alt="Same info, with the wallpaper +edits tooltip visible. It reads, Edits for wiki by Niklink (logo removal) and Quasar Nebula (crop)" src="https://github.com/user-attachments/assets/f87c5e57-c008-4d42-977f-cdc1db61b482">

On the artist info page, we no longer show, for example, "with Niklink" on Lexxy's credit line for Homestuck Vol. 5's banner art. They're completely different kinds of contributions, and shouldn't be displayed beside each other as though a collaboration was involved! We also show the list of artwork credits that are "edits for wiki" completely separately from the main artworks list. (This list doesn't get group contributions info, and doesn't show dates. It trims the "edits for wiki" part off of annotations, too.)

On the artist gallery page, we no longer include cover artworks where the corresponding contribution is annotated "edits for wiki".

Internally, we've made `Contribution.associatedContributions` essentially selects from two separate lists - one with annotations prefixed (or equal to) "edits for wiki", the other without, and selecting based on the current contribution's own annotation. What this means is `generateArtistInfoPageOtherArtistLinks` - the "with (other artists)" line - doesn't need any changes to only show only the relevant co-contributors.

We preferred basing this behavior off the annotation for implementation simplicity and because we already use annotations to mark "edits for wiki". It's possible to rework this into more of a `Wiki Edit Contributors` field on individual artwork objects, once those are implemented — but that's for later!