### PR TITLE
Featuring credits!

### DIFF
--- a/src/content/dependencies/generateAlbumReleaseInfo.js
+++ b/src/content/dependencies/generateAlbumReleaseInfo.js
@@ -69,6 +69,7 @@ export default {
           [
             relations.artistContributionsLine.slots({
               stringKey: capsule + '.by',
+              featuringStringKey: capsule + '.by.featuring',
               chronologyKind: 'album',
             }),
 

--- a/src/content/dependencies/generateArtistCredit.js
+++ b/src/content/dependencies/generateArtistCredit.js
@@ -1,0 +1,82 @@
+import {empty} from '#sugar';
+
+export default {
+  contentDependencies: [
+    'generateArtistCreditWikiEditsPart',
+    'linkContribution',
+  ],
+
+  extraDependencies: ['html', 'language'],
+
+  query: (contributions) => ({
+    normalContributions:
+      contributions
+        .filter(contrib => !contrib.annotation?.startsWith(`edits for wiki`)),
+
+    wikiEditContributions:
+      contributions
+        .filter(contrib => contrib.annotation?.startsWith(`edits for wiki`)),
+  }),
+
+  relations: (relation, query, _contributions) => ({
+    contributionLinks:
+      query.normalContributions
+        .map(contrib => relation('linkContribution', contrib)),
+
+    wikiEditsPart:
+      relation('generateArtistCreditWikiEditsPart',
+        query.wikiEditContributions),
+  }),
+
+  data: (query, _contributions) => ({
+    hasWikiEdits:
+      !empty(query.wikiEditContributions),
+  }),
+
+  slots: {
+    showAnnotation: {type: 'boolean', default: true},
+    showExternalLinks: {type: 'boolean', default: true},
+    showChronology: {type: 'boolean', default: true},
+
+    trimAnnotation: {type: 'boolean', default: false},
+
+    chronologyKind: {type: 'string'},
+
+    stringKey: {type: 'string'},
+  },
+
+  generate(data, relations, slots, {language}) {
+    const contributionsList =
+      language.formatConjunctionList(
+        relations.contributionLinks.map(link =>
+          link.slots({
+            showAnnotation: slots.showAnnotation,
+            showExternalLinks: slots.showExternalLinks,
+            showChronology: slots.showChronology,
+
+            trimAnnotation: slots.trimAnnotation,
+
+            chronologyKind: slots.chronologyKind,
+          })));
+
+    return language.$(slots.stringKey, {
+      [language.onlyIfOptions]: ['artists'],
+
+      artists:
+        (data.hasWikiEdits
+          ? language.encapsulate('misc.artistLink.withEditsForWiki', capsule =>
+              language.$(capsule, {
+                // It's nonsense to display "+ edits" without
+                // having any regular contributions, also.
+                [language.onlyIfOptions]: ['artists'],
+
+                artists: contributionsList,
+                edits:
+                  relations.wikiEditsPart.slots({
+                    showAnnotation: slots.showAnnotation,
+                  }),
+              }))
+          : contributionsList),
+    });
+  },
+};

--- a/src/content/dependencies/generateArtistCredit.js
+++ b/src/content/dependencies/generateArtistCredit.js
@@ -110,7 +110,10 @@ export default {
 
     for (const link of relations.featuringContributionLinks) {
       link.setSlots({
-        showAnnotation: false,
+        showAnnotation:
+          (slots.featuringStringKey
+            ? false
+            : slots.showAnnotation),
       });
     }
 

--- a/src/content/dependencies/generateArtistCreditWikiEditsPart.js
+++ b/src/content/dependencies/generateArtistCreditWikiEditsPart.js
@@ -5,7 +5,7 @@ export default {
     'linkContribution',
   ],
 
-  extraDependencies: ['language'],
+  extraDependencies: ['html', 'language'],
 
   relations: (relation, contributions) => ({
     textWithTooltip:
@@ -19,7 +19,11 @@ export default {
         .map(contrib => relation('linkContribution', contrib)),
   }),
 
-  generate: (relations, {language}) =>
+  slots: {
+    showAnnotation: {type: 'boolean', default: true},
+  },
+
+  generate: (relations, slots, {language}) =>
     language.encapsulate('misc.artistLink.withEditsForWiki', capsule =>
       relations.textWithTooltip.slots({
         attributes:
@@ -41,7 +45,7 @@ export default {
                   language.formatConjunctionList(
                     relations.contributionLinks.map(link =>
                       link.slots({
-                        showAnnotation: true,
+                        showAnnotation: slots.showAnnotation,
                         trimAnnotation: true,
                         preventTooltip: true,
                       }))),

--- a/src/content/dependencies/generateReleaseInfoContributionsLine.js
+++ b/src/content/dependencies/generateReleaseInfoContributionsLine.js
@@ -1,73 +1,27 @@
-import {empty} from '#sugar';
-
 export default {
-  contentDependencies: [
-    'generateReleaseInfoContributionsLineWikiEditsPart',
-    'linkContribution',
-  ],
+  contentDependencies: ['generateArtistCredit'],
+  extraDependencies: ['html'],
 
-  extraDependencies: ['html', 'language'],
-
-  query: (contributions) => ({
-    normalContributions:
-      contributions
-        .filter(contrib => !contrib.annotation?.startsWith(`edits for wiki`)),
-
-    wikiEditContributions:
-      contributions
-        .filter(contrib => contrib.annotation?.startsWith(`edits for wiki`)),
-  }),
-
-  relations: (relation, query, _contributions) => ({
-    contributionLinks:
-      query.normalContributions
-        .map(contrib => relation('linkContribution', contrib)),
-
-    wikiEditsPart:
-      relation('generateReleaseInfoContributionsLineWikiEditsPart',
-        query.wikiEditContributions),
-  }),
-
-  data: (query, _contributions) => ({
-    hasWikiEdits:
-      !empty(query.wikiEditContributions),
+  relations: (relation, contributions) => ({
+    credit:
+      relation('generateArtistCredit', contributions),
   }),
 
   slots: {
-    showAnnotation: {type: 'boolean', default: true},
-    showExternalLinks: {type: 'boolean', default: true},
-    showChronology: {type: 'boolean', default: true},
-
     stringKey: {type: 'string'},
     chronologyKind: {type: 'string'},
   },
 
-  generate(data, relations, slots, {language}) {
-    const contributionsList =
-      language.formatConjunctionList(
-        relations.contributionLinks.map(link =>
-          link.slots({
-            showAnnotation: slots.showAnnotation,
-            showExternalLinks: slots.showExternalLinks,
-            showChronology: slots.showChronology,
-            chronologyKind: slots.chronologyKind,
-          })));
+  generate: (relations, slots) =>
+    relations.credit.slots({
+      showAnnotation: true,
+      showExternalLinks: true,
+      showChronology: true,
 
-    return language.$(slots.stringKey, {
-      [language.onlyIfOptions]: ['artists'],
+      trimAnnotation: false,
 
-      artists:
-        (data.hasWikiEdits
-          ? language.encapsulate('misc.artistLink.withEditsForWiki', capsule =>
-              language.$(capsule, {
-                // It's nonsense to display "+ edits" without
-                // having any regular contributions, also.
-                [language.onlyIfOptions]: ['artists'],
+      stringKey: slots.stringKey,
 
-                artists: contributionsList,
-                edits: relations.wikiEditsPart,
-              }))
-          : contributionsList),
-    });
-  },
+      chronologyKind: slots.chronologyKind,
+    }),
 };

--- a/src/content/dependencies/generateReleaseInfoContributionsLine.js
+++ b/src/content/dependencies/generateReleaseInfoContributionsLine.js
@@ -4,11 +4,13 @@ export default {
 
   relations: (relation, contributions) => ({
     credit:
-      relation('generateArtistCredit', contributions),
+      relation('generateArtistCredit', contributions, []),
   }),
 
   slots: {
     stringKey: {type: 'string'},
+    featuringStringKey: {type: 'string'},
+
     chronologyKind: {type: 'string'},
   },
 
@@ -17,11 +19,13 @@ export default {
       showAnnotation: true,
       showExternalLinks: true,
       showChronology: true,
+      showWikiEdits: true,
 
       trimAnnotation: false,
 
-      stringKey: slots.stringKey,
-
       chronologyKind: slots.chronologyKind,
+
+      normalStringKey: slots.stringKey,
+      normalFeaturingStringKey: slots.featuringStringKey,
     }),
 };

--- a/src/content/dependencies/generateTrackReleaseInfo.js
+++ b/src/content/dependencies/generateTrackReleaseInfo.js
@@ -56,6 +56,7 @@ export default {
           [
             relations.artistContributionLinks.slots({
               stringKey: capsule + '.by',
+              featuringStringKey: capsule + '.by.featuring',
               chronologyKind: 'track',
             }),
 

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -249,7 +249,10 @@ releaseInfo:
 
   # Descriptions
 
-  by: "By {ARTISTS}."
+  by:
+    _: "By {ARTISTS}."
+    featuring: "By {ARTISTS}, featuring {FEATURING}."
+
   from: "From {ALBUM}."
 
   coverArtBy: "Cover art by {ARTISTS}."
@@ -399,18 +402,29 @@ trackList:
 
   item:
     _: "{TRACK}"
-    withDuration: "{DURATION} {TRACK}"
-    withArtists: "{TRACK} {BY}"
-    withDuration.withArtists: "{DURATION} {TRACK} {BY}"
 
-    withDuration.duration:
-      _: "({DURATION})"
-      missing: "_:__"
-      missing.info: "no duration provided; treated as zero seconds long"
+    withDuration:
+      _: >-
+        {DURATION} {TRACK}
 
-    withArtists.by: "by {ARTISTS}"
+      duration:
+        _: "({DURATION})"
+        missing: "_:__"
+        missing.info: "no duration provided; treated as zero seconds long"
 
-    rerelease: "{TRACK} (rerelease)"
+    withArtists:
+      _: >-
+        {TRACK} {BY}
+
+      by: "by {ARTISTS}"
+      featuring: "feat. {ARTISTS}"
+      by.featuring: "by {ARTISTS} feat. {FEATURING}"
+
+    withDuration.withArtists: >-
+      {DURATION} {TRACK} {BY}
+
+    rerelease: >-
+      {TRACK} (rerelease)
 
 #
 # misc:
@@ -479,6 +493,16 @@ misc:
         date.throughout.range: "throughout {DATE_RANGE}"
 
       seeOriginalRelease: "See {ORIGINAL}!"
+
+  artistCredit:
+    withNormalArtists: >-
+      {NORMAL}
+
+    withFeaturingArtists: >-
+      feat. {FEATURING}
+
+    withNormalArtists.withFeaturingArtists: >-
+      {NORMAL} feat. {FEATURING}
 
   # artistLink:
   #   Artist links have special accents which are made conditionally


### PR DESCRIPTION
How relevant! How new! Buy it!

- Adds `generateArtistCredit`, which is a common path between `generateReleaseInfoContributionsLine` and `generateAlbumTrackListItem`.
- Within the component it's part of, this represents the entire space to do with credits, and dynamically switches between one of several (mostly optional) string key slots to display just what's relevant. It's up to the containing component to declare what *kinds* of display are available and appropriate in this context, by slotting in just the relevant string keys.
- It handles comparing the relevant contributions with a contextual set of contributions (if provided), representing the artists of the album when displaying artists in the track list, for example. If the non-featuring credits of the track match the non-featuring credits of the album, only the featuring credits (if any) will be shown.
- `generateArtistCredit` also contains the "+ edits" logic added in #550. It's not as graceful as the rest; if you slot `showWikiEdits: true`, it will just tack any relevant wiki edit credits into "(+ edits)" after the (non-featuring) artist list. This is the same behavior as was in `generateReleaseInfoContributionsLine`.
  - We basically just renamed `generateReleaseInfoContributionsLineWikiEditsPart` to `generateArtistCreditWikiEditsPart`, but it now takes a `showAnnotation` slot, too, for consistency.
- Compared to the original version of this code, we've got improved annotation-hiding dynamics. Annotations will *only* be shown if you provide `showAnnotation: true`. If you do, they're conditional: the "featuring" annotation will still be hidden, *if* you've provided some custom means for displaying "featuring" credits. If you haven't, it will show that "(featuring)" annotation. And other annotations will continue to be shown. (Annotations in the "+ edits" part will be trimmed like usual.)
  - Previous behavior *always* hid annotations. This was basically appropriate for featuring credits, but not so much for normal credits, which are still sometimes generally annotated (in existing data). Now those can live alongside fancy featuring credits (and fancy "edits for wiki" credits), no problem!

Integration-wise, this is purely a content thing that only affects album and track pages. Featuring credits are marked so with the annotation "featuring", and this is displayed just like any other annotation on the artist info page. No data processing changes whatsoever.