### PR TITLE
Recover withReverseSingleReferenceList nicely

### DIFF
--- a/src/data/composite/wiki-data/helpers/withReverseList-template.js
+++ b/src/data/composite/wiki-data/helpers/withReverseList-template.js
@@ -1,0 +1,189 @@
+// Baseline implementation shared by or underlying reverse lists.
+//
+// This is a very rudimentary "these compositions have basically the same
+// shape but slightly different guts midway through" kind of solution,
+// and should use compositional subroutines instead, once those are ready.
+//
+// But, until then, this has the same effect of avoiding code duplication
+// and clearly identifying differences.
+//
+// ---
+//
+// This implementation uses a global cache (via WeakMap) to attempt to speed
+// up subsequent similar accesses.
+//
+// This has absolutely not been rigorously tested with altering properties of
+// data objects in a wiki data array which is reused. If a new wiki data array
+// is used, a fresh cache will always be created.
+//
+
+import {input, templateCompositeFrom} from '#composite';
+import {sortByDate} from '#sort';
+import {stitchArrays} from '#sugar';
+
+import {exitWithoutDependency, raiseOutputWithoutDependency}
+  from '#composite/control-flow';
+import {withFlattenedList, withMappedList} from '#composite/data';
+
+import inputWikiData from '../inputWikiData.js';
+
+export default function withReverseList_template({
+  annotation,
+
+  propertyInputName,
+  outputName,
+
+  customCompositionSteps,
+}) {
+  // Mapping of reference list property to WeakMap.
+  // Each WeakMap maps a wiki data array to another weak map,
+  // which in turn maps each referenced thing to an array of
+  // things referencing it.
+  const caches = new Map();
+
+  return templateCompositeFrom({
+    annotation,
+
+    inputs: {
+      data: inputWikiData({
+        allowMixedTypes: false,
+      }),
+
+      [propertyInputName]: input({
+        type: 'string',
+      }),
+    },
+
+    outputs: [outputName],
+
+    steps: () => [
+      // Early exit with an empty array if the data list isn't available.
+      exitWithoutDependency({
+        dependency: input('data'),
+        value: input.value([]),
+      }),
+
+      // Raise an empty array (don't early exit) if the data list is empty.
+      raiseOutputWithoutDependency({
+        dependency: input('data'),
+        mode: input.value('empty'),
+        output: input.value({[outputName]: []}),
+      }),
+
+      // Check for an existing cache record which corresponds to this
+      // property input and input('data'). If it exists, query it for the
+      // current thing, and raise that; if it doesn't, create it, put it
+      // where it needs to be, and provide it so the next steps can fill
+      // it in.
+      {
+        dependencies: [input(propertyInputName), input('data'), input.myself()],
+
+        compute: (continuation, {
+          [input(propertyInputName)]: property,
+          [input('data')]: data,
+          [input.myself()]: myself,
+        }) => {
+          if (!caches.has(property)) {
+            const cache = new WeakMap();
+            caches.set(property, cache);
+
+            const cacheRecord = new WeakMap();
+            cache.set(data, cacheRecord);
+
+            return continuation({
+              ['#cacheRecord']: cacheRecord,
+            });
+          }
+
+          const cache = caches.get(property);
+
+          if (!cache.has(data)) {
+            const cacheRecord = new WeakMap();
+            cache.set(data, cacheRecord);
+
+            return continuation({
+              ['#cacheRecord']: cacheRecord,
+            });
+          }
+
+          return continuation.raiseOutput({
+            [outputName]:
+              cache.get(data).get(myself) ?? [],
+          });
+        },
+      },
+
+      ...customCompositionSteps(),
+
+      // Actually fill in the cache record. Since we're building up a *reverse*
+      // reference list, track connections in terms of the referenced thing.
+      // Although we gather all referenced things into a set and provide that
+      // for sorting purposes in the next step, we *don't* reprovide the cache
+      // record, because we're mutating that in-place - we'll just reuse its
+      // existing '#cacheRecord' dependency.
+      {
+        dependencies: ['#cacheRecord', '#referencingThings', '#referencedThings'],
+        compute: (continuation, {
+          ['#cacheRecord']: cacheRecord,
+          ['#referencingThings']: referencingThings,
+          ['#referencedThings']: referencedThings,
+        }) => {
+          const allReferencedThings = new Set();
+
+          stitchArrays({
+            referencingThing: referencingThings,
+            referencedThings: referencedThings,
+          }).forEach(({referencingThing, referencedThings}) => {
+              for (const referencedThing of referencedThings) {
+                if (cacheRecord.has(referencedThing)) {
+                  cacheRecord.get(referencedThing).push(referencingThing);
+                } else {
+                  cacheRecord.set(referencedThing, [referencingThing]);
+                  allReferencedThings.add(referencedThing);
+                }
+              }
+            });
+
+          return continuation({
+            ['#allReferencedThings']:
+              allReferencedThings,
+          });
+        },
+      },
+
+      // Sort the entries in the cache records, too, just by date - the rest of
+      // sorting should be handled outside of this composition, either preceding
+      // (changing the 'data' input) or following (sorting the output).
+      // Again we're mutating in place, so no need to reprovide '#cacheRecord'
+      // here.
+      {
+        dependencies: ['#cacheRecord', '#allReferencedThings'],
+        compute: (continuation, {
+          ['#cacheRecord']: cacheRecord,
+          ['#allReferencedThings']: allReferencedThings,
+        }) => {
+          for (const referencedThing of allReferencedThings) {
+            if (cacheRecord.has(referencedThing)) {
+              const referencingThings = cacheRecord.get(referencedThing);
+              sortByDate(referencingThings);
+            }
+          }
+
+          return continuation();
+        },
+      },
+
+      // Then just pluck out the current object from the now-filled cache record!
+      {
+        dependencies: ['#cacheRecord', input.myself()],
+        compute: (continuation, {
+          ['#cacheRecord']: cacheRecord,
+          [input.myself()]: myself,
+        }) => continuation({
+          [outputName]:
+            cacheRecord.get(myself) ?? [],
+        }),
+      },
+    ],
+  });
+}

--- a/src/data/composite/wiki-data/index.js
+++ b/src/data/composite/wiki-data/index.js
@@ -19,5 +19,6 @@ export {default as withResolvedReference} from './withResolvedReference.js';
 export {default as withResolvedReferenceList} from './withResolvedReferenceList.js';
 export {default as withReverseContributionList} from './withReverseContributionList.js';
 export {default as withReverseReferenceList} from './withReverseReferenceList.js';
+export {default as withReverseSingleReferenceList} from './withReverseSingleReferenceList.js';
 export {default as withThingsSortedAlphabetically} from './withThingsSortedAlphabetically.js';
 export {default as withUniqueReferencingThing} from './withUniqueReferencingThing.js';

--- a/src/data/composite/wiki-data/withReverseContributionList.js
+++ b/src/data/composite/wiki-data/withReverseContributionList.js
@@ -1,101 +1,18 @@
 // Analogous implementation for withReverseReferenceList, for contributions.
-// This is mostly duplicate code and both should be ported to the same
-// underlying data form later on.
-//
-// This implementation uses a global cache (via WeakMap) to attempt to speed
-// up subsequent similar accesses.
-//
-// This has absolutely not been rigorously tested with altering properties of
-// data objects in a wiki data array which is reused. If a new wiki data array
-// is used, a fresh cache will always be created.
 
-import {input, templateCompositeFrom} from '#composite';
-import {sortByDate} from '#sort';
-import {stitchArrays} from '#sugar';
+import withReverseList_template from './helpers/withReverseList-template.js';
 
-import {exitWithoutDependency, raiseOutputWithoutDependency}
-  from '#composite/control-flow';
+import {input} from '#composite';
+
 import {withFlattenedList, withMappedList} from '#composite/data';
 
-import inputWikiData from './inputWikiData.js';
-
-// Mapping of reference list property to WeakMap.
-// Each WeakMap maps a wiki data array to another weak map,
-// which in turn maps each referenced thing to an array of
-// things referencing it.
-const caches = new Map();
-
-export default templateCompositeFrom({
+export default withReverseList_template({
   annotation: `withReverseContributionList`,
 
-  inputs: {
-    data: inputWikiData({allowMixedTypes: false}),
-    list: input({type: 'string'}),
-  },
+  propertyInputName: 'list',
+  outputName: '#reverseContributionList',
 
-  outputs: ['#reverseContributionList'],
-
-  steps: () => [
-    // Common behavior --
-
-    // Early exit with an empty array if the data list isn't available.
-    exitWithoutDependency({
-      dependency: input('data'),
-      value: input.value([]),
-    }),
-
-    // Raise an empty array (don't early exit) if the data list is empty.
-    raiseOutputWithoutDependency({
-      dependency: input('data'),
-      mode: input.value('empty'),
-      output: input.value({'#reverseContributionList': []}),
-    }),
-
-    // Check for an existing cache record which corresponds to this
-    // input('list') and input('data'). If it exists, query it for the
-    // current thing, and raise that; if it doesn't, create it, put it
-    // where it needs to be, and provide it so the next steps can fill
-    // it in.
-    {
-      dependencies: [input('list'), input('data'), input.myself()],
-
-      compute: (continuation, {
-        [input('list')]: list,
-        [input('data')]: data,
-        [input.myself()]: myself,
-      }) => {
-        if (!caches.has(list)) {
-          const cache = new WeakMap();
-          caches.set(list, cache);
-
-          const cacheRecord = new WeakMap();
-          cache.set(data, cacheRecord);
-
-          return continuation({
-            ['#cacheRecord']: cacheRecord,
-          });
-        }
-
-        const cache = caches.get(list);
-
-        if (!cache.has(data)) {
-          const cacheRecord = new WeakMap();
-          cache.set(data, cacheRecord);
-
-          return continuation({
-            ['#cacheRecord']: cacheRecord,
-          });
-        }
-
-        return continuation.raiseOutput({
-          ['#reverseContributionList']:
-            cache.get(data).get(myself) ?? [],
-        });
-      },
-    },
-
-    // Unique behavior for contribution lists --
-
+  customCompositionSteps: () => [
     {
       dependencies: [input('list')],
       compute: (continuation, {
@@ -125,77 +42,5 @@ export default templateCompositeFrom({
     }).outputs({
       '#mappedList': '#referencedThings',
     }),
-
-    // Common behavior --
-
-    // Actually fill in the cache record. Since we're building up a *reverse*
-    // reference list, track connections in terms of the referenced thing.
-    // Although we gather all referenced things into a set and provide that
-    // for sorting purposes in the next step, we *don't* reprovide the cache
-    // record, because we're mutating that in-place - we'll just reuse its
-    // existing '#cacheRecord' dependency.
-    {
-      dependencies: ['#cacheRecord', '#referencingThings', '#referencedThings'],
-      compute: (continuation, {
-        ['#cacheRecord']: cacheRecord,
-        ['#referencingThings']: referencingThings,
-        ['#referencedThings']: referencedThings,
-      }) => {
-        const allReferencedThings = new Set();
-
-        stitchArrays({
-          referencingThing: referencingThings,
-          referencedThings: referencedThings,
-        }).forEach(({referencingThing, referencedThings}) => {
-            for (const referencedThing of referencedThings) {
-              if (cacheRecord.has(referencedThing)) {
-                cacheRecord.get(referencedThing).push(referencingThing);
-              } else {
-                cacheRecord.set(referencedThing, [referencingThing]);
-                allReferencedThings.add(referencedThing);
-              }
-            }
-          });
-
-        return continuation({
-          ['#allReferencedThings']:
-            allReferencedThings,
-        });
-      },
-    },
-
-    // Sort the entries in the cache records, too, just by date - the rest of
-    // sorting should be handled outside of withReverseContributionList, either
-    // preceding (changing the 'data' input) or following (sorting the output).
-    // Again we're mutating in place, so no need to reprovide '#cacheRecord'
-    // here.
-    {
-      dependencies: ['#cacheRecord', '#allReferencedThings'],
-      compute: (continuation, {
-        ['#cacheRecord']: cacheRecord,
-        ['#allReferencedThings']: allReferencedThings,
-      }) => {
-        for (const referencedThing of allReferencedThings) {
-          if (cacheRecord.has(referencedThing)) {
-            const referencingThings = cacheRecord.get(referencedThing);
-            sortByDate(referencingThings);
-          }
-        }
-
-        return continuation();
-      },
-    },
-
-    // Then just pluck out the current object from the now-filled cache record!
-    {
-      dependencies: ['#cacheRecord', input.myself()],
-      compute: (continuation, {
-        ['#cacheRecord']: cacheRecord,
-        [input.myself()]: myself,
-      }) => continuation({
-        ['#reverseContributionList']:
-          cacheRecord.get(myself) ?? [],
-      }),
-    },
   ],
 });

--- a/src/data/composite/wiki-data/withReverseReferenceList.js
+++ b/src/data/composite/wiki-data/withReverseReferenceList.js
@@ -1,103 +1,19 @@
 // Check out the info on reverseReferenceList!
 // This is its composable form.
-//
-// This implementation uses a global cache (via WeakMap) to attempt to speed
-// up subsequent similar accesses.
-//
-// This has absolutely not been rigorously tested with altering properties of
-// data objects in a wiki data array which is reused. If a new wiki data array
-// is used, a fresh cache will always be created.
-//
-// Note that this implementation is mirrored in withReverseContributionList,
-// so any changes should be reflected there (until these are combined).
 
-import {input, templateCompositeFrom} from '#composite';
-import {sortByDate} from '#sort';
-import {stitchArrays} from '#sugar';
+import withReverseList_template from './helpers/withReverseList-template.js';
 
-import {exitWithoutDependency, raiseOutputWithoutDependency}
-  from '#composite/control-flow';
+import {input} from '#composite';
+
 import {withMappedList} from '#composite/data';
 
-import inputWikiData from './inputWikiData.js';
-
-// Mapping of reference list property to WeakMap.
-// Each WeakMap maps a wiki data array to another weak map,
-// which in turn maps each referenced thing to an array of
-// things referencing it.
-const caches = new Map();
-
-export default templateCompositeFrom({
+export default withReverseList_template({
   annotation: `withReverseReferenceList`,
 
-  inputs: {
-    data: inputWikiData({allowMixedTypes: false}),
-    list: input({type: 'string'}),
-  },
+  propertyInputName: 'list',
+  outputName: '#reverseReferenceList',
 
-  outputs: ['#reverseReferenceList'],
-
-  steps: () => [
-    // Common behavior --
-
-    // Early exit with an empty array if the data list isn't available.
-    exitWithoutDependency({
-      dependency: input('data'),
-      value: input.value([]),
-    }),
-
-    // Raise an empty array (don't early exit) if the data list is empty.
-    raiseOutputWithoutDependency({
-      dependency: input('data'),
-      mode: input.value('empty'),
-      output: input.value({'#reverseReferenceList': []}),
-    }),
-
-    // Check for an existing cache record which corresponds to this
-    // input('list') and input('data'). If it exists, query it for the
-    // current thing, and raise that; if it doesn't, create it, put it
-    // where it needs to be, and provide it so the next steps can fill
-    // it in.
-    {
-      dependencies: [input('list'), input('data'), input.myself()],
-
-      compute: (continuation, {
-        [input('list')]: list,
-        [input('data')]: data,
-        [input.myself()]: myself,
-      }) => {
-        if (!caches.has(list)) {
-          const cache = new WeakMap();
-          caches.set(list, cache);
-
-          const cacheRecord = new WeakMap();
-          cache.set(data, cacheRecord);
-
-          return continuation({
-            ['#cacheRecord']: cacheRecord,
-          });
-        }
-
-        const cache = caches.get(list);
-
-        if (!cache.has(data)) {
-          const cacheRecord = new WeakMap();
-          cache.set(data, cacheRecord);
-
-          return continuation({
-            ['#cacheRecord']: cacheRecord,
-          });
-        }
-
-        return continuation.raiseOutput({
-          ['#reverseReferenceList']:
-            cache.get(data).get(myself) ?? [],
-        });
-      },
-    },
-
-    // Unique behavior for reference lists --
-
+  customCompositionSteps: () => [
     {
       dependencies: [input('list')],
       compute: (continuation, {
@@ -122,78 +38,6 @@ export default templateCompositeFrom({
       }) => continuation({
         ['#referencingThings']:
           data,
-      }),
-    },
-
-    // Common behavior --
-
-    // Actually fill in the cache record. Since we're building up a *reverse*
-    // reference list, track connections in terms of the referenced thing.
-    // Although we gather all referenced things into a set and provide that
-    // for sorting purposes in the next step, we *don't* reprovide the cache
-    // record, because we're mutating that in-place - we'll just reuse its
-    // existing '#cacheRecord' dependency.
-    {
-      dependencies: ['#cacheRecord', '#referencingThings', '#referencedThings'],
-      compute: (continuation, {
-        ['#cacheRecord']: cacheRecord,
-        ['#referencingThings']: referencingThings,
-        ['#referencedThings']: referencedThings,
-      }) => {
-        const allReferencedThings = new Set();
-
-        stitchArrays({
-          referencingThing: referencingThings,
-          referencedThings: referencedThings,
-        }).forEach(({referencingThing, referencedThings}) => {
-            for (const referencedThing of referencedThings) {
-              if (cacheRecord.has(referencedThing)) {
-                cacheRecord.get(referencedThing).push(referencingThing);
-              } else {
-                cacheRecord.set(referencedThing, [referencingThing]);
-                allReferencedThings.add(referencedThing);
-              }
-            }
-          });
-
-        return continuation({
-          ['#allReferencedThings']:
-            allReferencedThings,
-        });
-      },
-    },
-
-    // Sort the entries in the cache records, too, just by date - the rest of
-    // sorting should be handled outside of withReverseContributionList, either
-    // preceding (changing the 'data' input) or following (sorting the output).
-    // Again we're mutating in place, so no need to reprovide '#cacheRecord'
-    // here.
-    {
-      dependencies: ['#cacheRecord', '#allReferencedThings'],
-      compute: (continuation, {
-        ['#cacheRecord']: cacheRecord,
-        ['#allReferencedThings']: allReferencedThings,
-      }) => {
-        for (const referencedThing of allReferencedThings) {
-          if (cacheRecord.has(referencedThing)) {
-            const referencingThings = cacheRecord.get(referencedThing);
-            sortByDate(referencingThings);
-          }
-        }
-
-        return continuation();
-      },
-    },
-
-    // Then just pluck out the current object from the now-filled cache record!
-    {
-      dependencies: ['#cacheRecord', input.myself()],
-      compute: (continuation, {
-        ['#cacheRecord']: cacheRecord,
-        [input.myself()]: myself,
-      }) => continuation({
-        ['#reverseReferenceList']:
-          cacheRecord.get(myself) ?? [],
       }),
     },
   ],

--- a/src/data/composite/wiki-data/withReverseSingleReferenceList.js
+++ b/src/data/composite/wiki-data/withReverseSingleReferenceList.js
@@ -1,0 +1,50 @@
+// Like withReverseReferenceList, but for finding all things which reference
+// the current thing by a property that contains a single reference, rather
+// than within a reference list.
+
+import withReverseList_template from './helpers/withReverseList-template.js';
+
+import {input} from '#composite';
+
+import {withMappedList} from '#composite/data';
+
+export default withReverseList_template({
+  annotation: `withReverseSingleReferenceList`,
+
+  propertyInputName: 'ref',
+  outputName: '#reverseSingleReferenceList',
+
+  customCompositionSteps: () => [
+    {
+      dependencies: [input('data')],
+      compute: (continuation, {
+        [input('data')]: data,
+      }) => continuation({
+        ['#referencingThings']:
+          data,
+      }),
+    },
+
+    // This map wraps each referenced thing in a single-item array.
+    // Each referencing thing references exactly one thing, if any.
+    {
+      dependencies: [input('ref')],
+      compute: (continuation, {
+        [input('ref')]: ref,
+      }) => continuation({
+        ['#singleReferenceMap']:
+          thing =>
+            (thing[ref]
+              ? [thing[ref]]
+              : []),
+      }),
+    },
+
+    withMappedList({
+      list: '#referencingThings',
+      map: '#singleReferenceMap',
+    }).outputs({
+      '#mappedList': '#referencedThings',
+    }),
+  ],
+});

--- a/src/data/composite/wiki-properties/index.js
+++ b/src/data/composite/wiki-properties/index.js
@@ -21,6 +21,7 @@ export {default as name} from './name.js';
 export {default as referenceList} from './referenceList.js';
 export {default as reverseContributionList} from './reverseContributionList.js';
 export {default as reverseReferenceList} from './reverseReferenceList.js';
+export {default as reverseSingleReferenceList} from './reverseSingleReferenceList.js';
 export {default as simpleDate} from './simpleDate.js';
 export {default as simpleString} from './simpleString.js';
 export {default as singleReference} from './singleReference.js';

--- a/src/data/composite/wiki-properties/reverseSingleReferenceList.js
+++ b/src/data/composite/wiki-properties/reverseSingleReferenceList.js
@@ -1,0 +1,24 @@
+import {input, templateCompositeFrom} from '#composite';
+
+import {exposeDependency} from '#composite/control-flow';
+import {inputWikiData, withReverseSingleReferenceList} from '#composite/wiki-data';
+
+export default templateCompositeFrom({
+  annotation: `reverseSingleReferenceList`,
+
+  compose: false,
+
+  inputs: {
+    data: inputWikiData({allowMixedTypes: false}),
+    ref: input({type: 'string'}),
+  },
+
+  steps: () => [
+    withReverseSingleReferenceList({
+      data: input('data'),
+      ref: input('ref'),
+    }),
+
+    exposeDependency({dependency: '#reverseSingleReferenceList'}),
+  ],
+});


### PR DESCRIPTION
The thing-coding utility function `reverseSingleReference` was removed one year ago (https://github.com/hsmusic/hsmusic-wiki/commit/9d8616ced8f505b499780e859d96f288d67f2154) at about the same time we were implementing compositions in general (#256), so it was never ported compositional data code.

This PR recovers that function, now `reverseSingleReferenceList` and `withReverseSingleReferenceList`, as a composition. It's coded the same way as reverse reference lists and reverse contribution lists (#431) and in order to reduce code duplication, we've "cheaply" moved all the common details into a helper function which offers *all* boilerplate, up to calling `templateCompositeFrom`. This means fast reverse references (#383) and sorting by date (#536) are now part of shared and written-once code, `withReverseList_template`.

There are now three compositions directly based on that shared code:

* `withReverseReferenceList`
* `withReverseContributionList`
* `withReverseSingleReferenceList`

In the future, the helper should be made into a proper composition of its own right, which accepts a compositional subroutine (#342). But that's a ways off, and these changes get essentially the same code-writing benefits via deduplication. It'll be easier to port the new functions over to the subroutine style, once ready, since the differences between these compositions are now laid out plainly.

`reverseSingleReferenceList` is still unused (as it was when we removed it), but we expect to use it to help represent more particular relationships between things in the near future.