### PR TITLE
Miscellaneous build-mode code cleanup

### DIFF
--- a/src/upd8.js
+++ b/src/upd8.js
@@ -2382,29 +2382,37 @@ async function main() {
   logInfo`Passing control over to build mode: ${selectedBuildModeFlag}`;
   console.log('');
 
+  const universalUtilities = {
+    getSizeOfAdditionalFile,
+    getSizeOfImagePath,
+
+    defaultLanguage: finalDefaultLanguage,
+    developersComment,
+    languages,
+    missingImagePaths,
+    thumbsCache,
+    urlSpec,
+    urls,
+    wikiData,
+  };
+
   try {
     buildModeResult = await selectedBuildMode.go({
       cliOptions,
+      queueSize,
+
+      universalUtilities,
+      ...universalUtilities,
+
       dataPath,
       mediaPath,
       mediaCachePath,
       wikiCachePath,
-      queueSize,
       srcRootPath: __dirname,
 
-      defaultLanguage: finalDefaultLanguage,
-      languages,
-      missingImagePaths,
-      thumbsCache,
-      urls,
-      urlSpec,
       webRoutes: preparedWebRoutes,
-      wikiData,
 
       closeLanguageWatchers,
-      developersComment,
-      getSizeOfAdditionalFile,
-      getSizeOfImagePath,
       niceShowAggregate,
     });
   } catch (error) {

--- a/src/write/build-modes/live-dev-server.js
+++ b/src/write/build-modes/live-dev-server.js
@@ -91,6 +91,38 @@ export function getCLIOptions() {
   };
 }
 
+const getContentType = extname => ({
+  // BRB covering all my bases
+  'aac': 'audio/aac',
+  'bmp': 'image/bmp',
+  'css': 'text/css',
+  'csv': 'text/csv',
+  'gif': 'image/gif',
+  'ico': 'image/vnd.microsoft.icon',
+  'jpg': 'image/jpeg',
+  'jpeg': 'image/jpeg',
+  'js': 'text/javascript',
+  'mjs': 'text/javascript',
+  'mp3': 'audio/mpeg',
+  'mp4': 'video/mp4',
+  'oga': 'audio/ogg',
+  'ogg': 'audio/ogg',
+  'ogv': 'video/ogg',
+  'opus': 'audio/opus',
+  'png': 'image/png',
+  'pdf': 'application/pdf',
+  'svg': 'image/svg+xml',
+  'ttf': 'font/ttf',
+  'txt': 'text/plain',
+  'wav': 'audio/wav',
+  'weba': 'audio/webm',
+  'webm': 'video/webm',
+  'woff': 'font/woff',
+  'woff2': 'font/woff2',
+  'xml': 'application/xml',
+  'zip': 'application/zip',
+})[extname];
+
 export async function go({
   cliOptions,
 
@@ -266,38 +298,7 @@ export async function go({
       }
 
       const extname = path.extname(safePath).slice(1).toLowerCase();
-
-      const contentType = {
-        // BRB covering all my bases
-        'aac': 'audio/aac',
-        'bmp': 'image/bmp',
-        'css': 'text/css',
-        'csv': 'text/csv',
-        'gif': 'image/gif',
-        'ico': 'image/vnd.microsoft.icon',
-        'jpg': 'image/jpeg',
-        'jpeg': 'image/jpeg',
-        'js': 'text/javascript',
-        'mjs': 'text/javascript',
-        'mp3': 'audio/mpeg',
-        'mp4': 'video/mp4',
-        'oga': 'audio/ogg',
-        'ogg': 'audio/ogg',
-        'ogv': 'video/ogg',
-        'opus': 'audio/opus',
-        'png': 'image/png',
-        'pdf': 'application/pdf',
-        'svg': 'image/svg+xml',
-        'ttf': 'font/ttf',
-        'txt': 'text/plain',
-        'wav': 'audio/wav',
-        'weba': 'audio/webm',
-        'webm': 'video/webm',
-        'woff': 'font/woff',
-        'woff2': 'font/woff2',
-        'xml': 'application/xml',
-        'zip': 'application/zip',
-      }[extname];
+      const contentType = getContentType(extname);
 
       let fd, size;
       try {

--- a/src/write/build-modes/live-dev-server.js
+++ b/src/write/build-modes/live-dev-server.js
@@ -332,6 +332,17 @@ export async function go({
 
     // Other routes determined by page and URL specs
 
+    const commonUtilities = {
+      defaultLanguage,
+      getSizeOfAdditionalFile,
+      getSizeOfImagePath,
+      languages,
+      missingImagePaths,
+      thumbsCache,
+      urls,
+      wikiData,
+    };
+
     const startTiming = () => {
       if (!showTimings) {
         return () => '';
@@ -417,19 +428,13 @@ export async function go({
       const timing = startTiming();
 
       const bound = bindUtilities({
+        ...commonUtilities,
+
         absoluteTo,
-        defaultLanguage,
-        getSizeOfAdditionalFile,
-        getSizeOfImagePath,
         language,
-        languages,
-        missingImagePaths,
         pagePath: servePath,
         pagePathStringFromRoot: pathname.replace(/^\//, ''),
-        thumbsCache,
         to,
-        urls,
-        wikiData,
       });
 
       const topLevelResult =

--- a/src/write/build-modes/live-dev-server.js
+++ b/src/write/build-modes/live-dev-server.js
@@ -167,6 +167,8 @@ export async function go({
   contentDependenciesWatcher.on('error', () => {});
   await new Promise(resolve => contentDependenciesWatcher.once('ready', resolve));
 
+  const commonUtilities = {...universalUtilities};
+
   let targetSpecPairs = getPageSpecsWithTargets({wikiData});
   const pages = progressCallAll(`Computing page data & paths for ${targetSpecPairs.length} targets.`,
     targetSpecPairs.flatMap(({
@@ -331,17 +333,6 @@ export async function go({
     }
 
     // Other routes determined by page and URL specs
-
-    const commonUtilities = {
-      defaultLanguage,
-      getSizeOfAdditionalFile,
-      getSizeOfImagePath,
-      languages,
-      missingImagePaths,
-      thumbsCache,
-      urls,
-      wikiData,
-    };
 
     const startTiming = () => {
       if (!showTimings) {

--- a/src/write/build-modes/live-dev-server.js
+++ b/src/write/build-modes/live-dev-server.js
@@ -332,6 +332,25 @@ export async function go({
 
     // Other routes determined by page and URL specs
 
+    const startTiming = () => {
+      if (!showTimings) {
+        return () => '';
+      }
+
+      const timeStart = Date.now();
+
+      return () => {
+        const timeEnd = Date.now();
+        const timeDelta = timeEnd - timeStart;
+
+        if (timeDelta > 100) {
+          return `${(timeDelta / 1000).toFixed(2)}s`;
+        } else {
+          return `${timeDelta}ms`;
+        }
+      };
+    };
+
     // URL to page map expects trailing slash but no leading slash.
     const pathnameKey = pathname.replace(/^\//, '') + (pathname.endsWith('/') ? '' : '/');
 
@@ -395,7 +414,7 @@ export async function go({
         return;
       }
 
-      const timeStart = Date.now();
+      const timing = startTiming();
 
       const bound = bindUtilities({
         absoluteTo,
@@ -424,18 +443,10 @@ export async function go({
 
       const {pageHTML} = html.resolve(topLevelResult);
 
-      const timeEnd = Date.now();
-      const timeDelta = timeEnd - timeStart;
-
-      if (showTimings) {
-        const timeString =
-          (timeDelta > 100
-            ? `${(timeDelta / 1000).toFixed(2)}s`
-            : `${timeDelta}ms`);
-
-        console.log(`${requestHead} [200, ${timeString}] ${pathname} (${colors.blue(`page`)})`);
-      } else if (loudResponses) {
-        console.log(`${requestHead} [200] ${pathname} (${colors.blue(`page`)})`);
+      const timeString = timing();
+      const status = (timeString ? `200 ${timeString}` : `200`);
+      if (showTimings || loudResponses) {
+        console.log(`${requestHead} [${status}] ${pathname} (${colors.blue(`page`)})`);
       }
 
       response.writeHead(200, contentTypeHTML);

--- a/src/write/build-modes/repl.js
+++ b/src/write/build-modes/repl.js
@@ -50,17 +50,12 @@ export async function getContextAssignments({
   mediaPath,
   mediaCachePath,
 
+  universalUtilities,
+
   defaultLanguage,
-  languages,
-  missingImagePaths,
-  thumbsCache,
-  urls,
-  webRoutes,
   wikiData,
 
-  getSizeOfAdditionalFile,
-  getSizeOfImagePath,
-  niceShowAggregate,
+  niceShowAggregate: showAggregate,
 }) {
   let find;
   try {
@@ -72,18 +67,14 @@ export async function getContextAssignments({
   }
 
   const replContext = {
+    universalUtilities,
+    ...universalUtilities,
+
     dataPath,
     mediaPath,
     mediaCachePath,
 
-    languages,
-    defaultLanguage,
     language: defaultLanguage,
-
-    missingImagePaths,
-    thumbsCache,
-    urls,
-    webRoutes,
 
     wikiData,
     ...wikiData,
@@ -104,9 +95,7 @@ export async function getContextAssignments({
     find,
     bindFind,
 
-    getSizeOfAdditionalFile,
-    getSizeOfImagePath,
-    showAggregate: niceShowAggregate,
+    showAggregate,
   };
 
   replContext.replContext = replContext;

--- a/src/write/build-modes/static-build.js
+++ b/src/write/build-modes/static-build.js
@@ -288,16 +288,7 @@ export async function go({
     showAggregate: niceShowAggregate,
   });
 
-  const commonUtilities = {
-    defaultLanguage,
-    getSizeOfAdditionalFile,
-    getSizeOfImagePath,
-    languages,
-    missingImagePaths,
-    thumbsCache,
-    urls,
-    wikiData,
-  };
+  const commonUtilities = {...universalUtilities};
 
   const perLanguageFn = async (language, i, entries) => {
     const baseDirectory =

--- a/src/write/build-modes/static-build.js
+++ b/src/write/build-modes/static-build.js
@@ -288,6 +288,17 @@ export async function go({
     showAggregate: niceShowAggregate,
   });
 
+  const commonUtilities = {
+    defaultLanguage,
+    getSizeOfAdditionalFile,
+    getSizeOfImagePath,
+    languages,
+    missingImagePaths,
+    thumbsCache,
+    urls,
+    wikiData,
+  };
+
   const perLanguageFn = async (language, i, entries) => {
     const baseDirectory =
       language === defaultLanguage ? '' : language.code;
@@ -316,19 +327,13 @@ export async function go({
         });
 
         const bound = bindUtilities({
+          ...commonUtilities,
+
           absoluteTo,
-          defaultLanguage,
-          getSizeOfAdditionalFile,
-          getSizeOfImagePath,
           language,
-          languages,
-          missingImagePaths,
           pagePath,
           pagePathStringFromRoot: pathname,
-          thumbsCache,
           to,
-          urls,
-          wikiData,
         });
 
         let pageHTML, oEmbedJSON;


### PR DESCRIPTION
Just a couple of commits, mostly from May, that make the code for live-dev-server and static-build nicer.

Most notably, while each build mode is still responsible for actually processing utilities (i.e. providing them to `bindUtilities` and thereafter as `extraDependencies` in content functions)...

* Each build mode now prepares a `commonUtilities` object early on, outside where individual pages/writes are handled; this is shared by all pages/writes — avoiding code duplication between different kinds of writes.
* upd8.js itself prepares and provides each build mode a `universalUtilities` object, which `commonUtilities` extends from (and is currently equivalent to) — avoiding code duplication between different build modes.

There is also some general cleanup for live-dev-server, moving standalone chunks of behavior further out from where they're used (so they can be used for different kinds of writes, later).