### PR TITLE
Ignore plainly written emails in content text

### DIFF
--- a/src/content/dependencies/transformContent.js
+++ b/src/content/dependencies/transformContent.js
@@ -6,6 +6,21 @@ import {Marked} from 'marked';
 const commonMarkedOptions = {
   headerIds: false,
   mangle: false,
+
+  tokenizer: {
+    url(src) {
+      // Don't link emails
+      const cap = this.rules.inline.url.exec(src);
+      if (cap?.[2] === '@') return;
+
+      // Use normal tokenizer url behavior otherwise
+      // Note that super.url doesn't work here because marked is binding or
+      // applying this function on the tokenizer instance - super.prop would
+      // just read the prototype of the containing object literal, not the
+      // rebound tokenizer. (Thanks MDN.)
+      return Object.getPrototypeOf(this).url.call(this, src);
+    },
+  },
 };
 
 const multilineMarked = new Marked({

--- a/tap-snapshots/test/snapshot/transformContent.js.test.cjs
+++ b/tap-snapshots/test/snapshot/transformContent.js.test.cjs
@@ -14,6 +14,11 @@ exports[`test/snapshot/transformContent.js > TAP > transformContent (snapshot) >
 <p>Very nice: <time datetime="Fri, 25 Oct 2413 03:00:00 GMT">10/25/2413</time></p>
 `
 
+exports[`test/snapshot/transformContent.js > TAP > transformContent (snapshot) > emails 1`] = `
+<p>Email cute dogs to qznebula@protonmail.com please.</p>
+<p>Just kidding... <a class="external-link from-content indicate-external" href="mailto:qznebula@protonmail.com" title="External (opens in new tab)" target="_blank">unless?</a></p>
+`
+
 exports[`test/snapshot/transformContent.js > TAP > transformContent (snapshot) > escape end of tag 1`] = `
 <p>My favorite album is <a style="--primary-color: #123456" href="to-localized.album/cool-album">[Tactical Omission]</a>.</p>
 <p>Your favorite album is <a style="--primary-color: #123456" href="to-localized.album/cool-album">[Tactical Wha-Huh-Now</a>].</p>

--- a/test/snapshot/transformContent.js
+++ b/test/snapshot/transformContent.js
@@ -156,6 +156,11 @@ testContentFunctions(t, 'transformContent (snapshot)', async (t, evaluate) => {
       `[[date:13 April 2004]], and don't ye forget it`,
       {mode: 'lyrics'});
 
+  quickSnapshot(
+    'emails',
+      `Email cute dogs to qznebula@protonmail.com please.\n` +
+      `Just kidding... [unless?](mailto:qznebula@protonmail.com)`);
+
   // TODO: Snapshots for mode: inline
   // TODO: Snapshots for mode: single-link
 });


### PR DESCRIPTION
Gives Marked a tokenizer override function to prevent `url` from operating when it normally would on email addresses. Emails can still be linked to in normal `[foo](mailto:bar@bam.com)` format, as in #560, and this is verified by an addition in the `transformContent` snapshot test.