### PR TITLE
Album additional names, and blank additional names

### DIFF
--- a/src/content/dependencies/generateAdditionalNamesBox.js
+++ b/src/content/dependencies/generateAdditionalNamesBox.js
@@ -9,12 +9,19 @@ export default {
   }),
 
   generate: (relations, {html, language}) =>
-    html.tag('div', {id: 'additional-names-box'}, [
-      html.tag('p',
-        language.$('misc.additionalNames.title')),
+    html.tag('div', {id: 'additional-names-box'},
+      {[html.onlyIfContent]: true},
 
-      html.tag('ul',
-        relations.items
-          .map(item => html.tag('li', item))),
-    ]),
+      [
+        html.tag('p',
+          {[html.onlyIfSiblings]: true},
+
+          language.$('misc.additionalNames.title')),
+
+        html.tag('ul',
+          {[html.onlyIfContent]: true},
+
+          relations.items
+            .map(item => html.tag('li', item))),
+      ]),
 };

--- a/src/content/dependencies/generateAlbumInfoPage.js
+++ b/src/content/dependencies/generateAlbumInfoPage.js
@@ -1,5 +1,6 @@
 export default {
   contentDependencies: [
+    'generateAdditionalNamesBox',
     'generateAlbumAdditionalFilesList',
     'generateAlbumBanner',
     'generateAlbumCoverArtwork',
@@ -37,6 +38,9 @@ export default {
 
     sidebar:
       relation('generateAlbumSidebar', album, null),
+
+    additionalNamesBox:
+      relation('generateAdditionalNamesBox', album.additionalNames),
 
     cover:
       (album.hasCoverArt
@@ -101,6 +105,8 @@ export default {
         color: data.color,
         headingMode: 'sticky',
         styleRules: [relations.albumStyleRules],
+
+        additionalNames: relations.additionalNamesBox,
 
         cover:
           relations.cover

--- a/src/data/things/album.js
+++ b/src/data/things/album.js
@@ -12,8 +12,14 @@ import {sortAlbumsTracksChronologically, sortChronologically} from '#sort';
 import {accumulateSum, empty} from '#sugar';
 import Thing from '#thing';
 import {isColor, isDate, validateWikiData} from '#validators';
-import {parseAdditionalFiles, parseContributors, parseDate, parseDimensions}
-  from '#yaml';
+
+import {
+  parseAdditionalFiles,
+  parseAdditionalNames,
+  parseContributors,
+  parseDate,
+  parseDimensions,
+} from '#yaml';
 
 import {exitWithoutDependency, exposeDependency, exposeUpdateValueOrContinue}
   from '#composite/control-flow';
@@ -28,6 +34,7 @@ import {
 
 import {
   additionalFiles,
+  additionalNameList,
   commentary,
   color,
   commentatorArtists,
@@ -71,6 +78,8 @@ export class Album extends Thing {
     urls: urls(),
 
     alwaysReferenceTracksByDirectory: flag(false),
+
+    additionalNames: additionalNameList(),
 
     bandcampAlbumIdentifier: simpleString(),
     bandcampArtworkIdentifier: simpleString(),
@@ -294,6 +303,11 @@ export class Album extends Thing {
 
       'Always Reference Tracks By Directory': {
         property: 'alwaysReferenceTracksByDirectory',
+      },
+
+      'Additional Names': {
+        property: 'additionalNames',
+        transform: parseAdditionalNames,
       },
 
       'Bandcamp Album ID': {

--- a/src/data/validators.js
+++ b/src/data/validators.js
@@ -468,7 +468,7 @@ const trimWhitespaceNearEndRegexp =
   / +$/gm;
 
 export function isContentString(content) {
-  isStringNonEmpty(content);
+  isString(content);
 
   const mainAggregate = openAggregate({
     message: `Errors validating content string`,

--- a/src/data/validators.js
+++ b/src/data/validators.js
@@ -918,7 +918,7 @@ export function validateWikiData({
 }
 
 export const isAdditionalName = validateProperties({
-  name: isName,
+  name: isContentString,
   annotation: optional(isContentString),
 
   // TODO: This only allows indicating sourcing from a track.

--- a/src/data/yaml.js
+++ b/src/data/yaml.js
@@ -447,7 +447,7 @@ export function parseAdditionalFiles(entries) {
 
 export function parseAdditionalNames(entries) {
   return parseArrayEntries(entries, item => {
-    if (typeof item === 'object' && item['Name'])
+    if (typeof item === 'object' && typeof item['Name'] === 'string')
       return {name: item['Name'], annotation: item['Annotation'] ?? null};
 
     if (typeof item !== 'string') return item;


### PR DESCRIPTION
Adds support for albums to additional names (see hsmusic/hsmusic-data#439) and tweaks validstors to reflect how additional names actually work; plus allowed blank additional names through. Which means *any* content string can now be blank. Evil? Perhaps! 👍 