### PR TITLE
Make external links "absorb" following punctuation

### DIFF
--- a/src/content/dependencies/generateCommentaryEntry.js
+++ b/src/content/dependencies/generateCommentaryEntry.js
@@ -75,7 +75,10 @@ export default {
                         if (relations.annotationContent) {
                           workingCapsule += '.withAnnotation';
                           workingOptions.annotation =
-                            relations.annotationContent.slot('mode', 'inline');
+                            relations.annotationContent.slots({
+                              mode: 'inline',
+                              absorbPunctuationFollowingExternalLinks: false,
+                            });
                         }
 
                         if (workingCapsule === accentCapsule) {

--- a/src/content/dependencies/linkExternal.js
+++ b/src/content/dependencies/linkExternal.js
@@ -11,6 +11,11 @@ export default {
       mutable: false,
     },
 
+    suffixNormalContent: {
+      type: 'html',
+      mutable: false,
+    },
+
     style: {
       // This awkward syntax is because the slot descriptor validator can't
       // differentiate between a function that returns a validator (the usual
@@ -129,6 +134,16 @@ export default {
 
     if (urlIsValid && slots.tab === 'separate') {
       linkAttributes.set('target', '_blank');
+    }
+
+    if (!html.isBlank(slots.suffixNormalContent)) {
+      linkContent =
+        html.tags([
+          linkContent,
+
+          html.tag('span', {class: 'normal-content'},
+            slots.suffixNormalContent),
+        ], {[html.joinChildren]: ''});
     }
 
     return html.tag('a', linkAttributes, linkContent);

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -799,6 +799,10 @@ a:not([href]):hover {
   color: white;
 }
 
+.external-link .normal-content {
+  color: white;
+}
+
 .nav-main-links .nav-link.current > span.nav-link-content > a {
   font-weight: 800;
 }

--- a/tap-snapshots/test/snapshot/transformContent.js.test.cjs
+++ b/tap-snapshots/test/snapshot/transformContent.js.test.cjs
@@ -5,6 +5,11 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`test/snapshot/transformContent.js > TAP > transformContent (snapshot) > absorb punctuation 1`] = `
+<p>Don&#39;t you think this is an <a class="external-link from-content indicate-external" href="https://github.com/hsmusic/hsmusic-wiki/pull/567" title="github.com (opens in new tab)" target="_blank">interesting pull request<span class="normal-content">,</span></a> Steve?</p>
+<p>Aren&#39;t you <a class="external-link from-content indicate-external" href="https://github.com/hsmusic/hsmusic-wiki/pull/567" title="github.com (opens in new tab)" target="_blank">interested<span class="normal-content">...</span></a> in <a class="external-link from-content indicate-external" href="https://github.com/hsmusic/hsmusic-wiki/pull/567" title="github.com (opens in new tab)" target="_blank">checking it out<span class="normal-content">?!!</span></a></p>
+`
+
 exports[`test/snapshot/transformContent.js > TAP > transformContent (snapshot) > basic markdown 1`] = `
 <p>Hello <em>world!</em> This is <strong>SO COOL.</strong></p>
 `

--- a/test/snapshot/transformContent.js
+++ b/test/snapshot/transformContent.js
@@ -161,6 +161,11 @@ testContentFunctions(t, 'transformContent (snapshot)', async (t, evaluate) => {
       `Email cute dogs to qznebula@protonmail.com please.\n` +
       `Just kidding... [unless?](mailto:qznebula@protonmail.com)`);
 
+  quickSnapshot(
+    `absorb punctuation`,
+      `Don't you think this is an [interesting pull request](https://github.com/hsmusic/hsmusic-wiki/pull/567), Steve?\n` +
+      `Aren't you [interested](https://github.com/hsmusic/hsmusic-wiki/pull/567)... in [checking it out](https://github.com/hsmusic/hsmusic-wiki/pull/567)?!!`);
+
   // TODO: Snapshots for mode: inline
   // TODO: Snapshots for mode: single-link
 });


### PR DESCRIPTION
Makes the punctuation following an external link (within text content) become part of the link itself, albeit still styled white like normal text; it is part of the hover area and underlined when any of the link is hovered, but appears inline where it normally would in reading order, instead of after the pictograph (arrow).

The *effect* is the same, so we're still using "absorb" terminology, but this is a substantially simpler implementation than previously proposed. In `transformContent`, we now check if the node *following* an external link is a text node, and see if it begins with (a ≥1-character string of select) punctuation. That punctuation, if present, is put into a new slot on `linkExternal`, and skipped when the text node is processed.

Check out [#code-quarantine](https://discord.com/channels/749042497610842152/854020929113423924/1234510972048379965) for the previous suggestion, which involved an "absorb" metatag.