### PR TITLE
Stylize <details> summary in content

### DIFF
--- a/src/content/dependencies/generateAdditionalFilesListChunk.js
+++ b/src/content/dependencies/generateAdditionalFilesListChunk.js
@@ -29,8 +29,7 @@ export default {
               html.tag('span',
                 language.$(capsule, {
                   title:
-                    html.tag('span', {class: 'group-name'},
-                      slots.title),
+                    html.tag('b', slots.title),
                 }))),
 
             html.tag('ul', [

--- a/src/content/dependencies/generateAlbumSidebarTrackSection.js
+++ b/src/content/dependencies/generateAlbumSidebarTrackSection.js
@@ -58,7 +58,7 @@ export default {
     const capsule = language.encapsulate('albumSidebar.trackList');
 
     const sectionName =
-      html.tag('span', {class: 'group-name'},
+      html.tag('b',
         (data.isDefaultTrackSection
           ? language.$(capsule, 'fallbackSectionName')
           : data.name));

--- a/src/content/dependencies/generateFlashActSidebarCurrentActBox.js
+++ b/src/content/dependencies/generateFlashActSidebarCurrentActBox.js
@@ -44,10 +44,11 @@ export default {
 
           [
             html.tag('summary',
-              html.tag('span', {class: 'group-name'},
-                (data.customListTerminology
-                  ? language.sanitize(data.customListTerminology)
-                  : language.$('flashSidebar.flashList.entriesInThisSection')))),
+              html.tag('span',
+                html.tag('b',
+                  (data.customListTerminology
+                    ? language.sanitize(data.customListTerminology)
+                    : language.$('flashSidebar.flashList.entriesInThisSection'))))),
 
             html.tag('ul',
               relations.flashLinks

--- a/src/content/dependencies/generateFlashActSidebarSideMapBox.js
+++ b/src/content/dependencies/generateFlashActSidebarSideMapBox.js
@@ -68,8 +68,8 @@ export default {
 
               [
                 html.tag('summary',
-                  html.tag('span', {class: 'group-name'},
-                    sideName)),
+                  html.tag('span',
+                    html.tag('b', sideName))),
 
                 html.tag('ul',
                   actLinks.map((actLink, actIndex) =>

--- a/src/content/dependencies/generateGroupSidebarCategoryDetails.js
+++ b/src/content/dependencies/generateGroupSidebarCategoryDetails.js
@@ -59,8 +59,7 @@ export default {
             html.tag('span',
               language.$(capsule, 'category', {
                 category:
-                  html.tag('span', {class: 'group-name'},
-                    data.name),
+                  html.tag('b', data.name),
               }))),
 
           html.tag('ul',

--- a/src/content/dependencies/generateListAllAdditionalFilesChunk.js
+++ b/src/content/dependencies/generateListAllAdditionalFilesChunk.js
@@ -64,8 +64,7 @@ export default {
                           html.tag('span',
                             language.$(capsule, 'withMultipleFiles', {
                               title:
-                                html.tag('span', {class: 'group-name'},
-                                  additionalFileTitle),
+                                html.tag('b', additionalFileTitle),
 
                               files:
                                 language.countAdditionalFiles(

--- a/src/content/dependencies/generateListingIndexList.js
+++ b/src/content/dependencies/generateListingIndexList.js
@@ -107,8 +107,8 @@ export default {
 
                 [
                   html.tag('summary',
-                    html.tag('span', {class: 'group-name'},
-                      targetTitle)),
+                    html.tag('span',
+                      html.tag('b', targetTitle))),
 
                   listingLinkList,
                 ])));

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -397,6 +397,11 @@ body::before {
   padding-left: 5px;
 }
 
+summary > span b {
+  font-weight: normal;
+  color: var(--primary-color);
+}
+
 summary > span:hover {
   cursor: pointer;
   text-decoration: underline;
@@ -431,10 +436,6 @@ summary.underline-white > span:hover {
  */
 summary.underline-white > span:hover a:not(:hover) {
   text-decoration-color: white;
-}
-
-summary .group-name {
-  color: var(--primary-color);
 }
 
 .sidebar > details ul,

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -1227,6 +1227,14 @@ ul.image-details li {
   box-shadow: 1px 2px 6px 5px #04040460;
 }
 
+.commentary-entry-body summary {
+  list-style-position: outside;
+}
+
+.commentary-entry-body summary > span {
+  color: var(--primary-color);
+}
+
 .commentary-art {
   float: right;
   width: 30%;

--- a/src/util/replacer.js
+++ b/src/util/replacer.js
@@ -614,10 +614,15 @@ export function postprocessSummaries(inputNodes) {
       textContent += node.data.slice(parseFrom, match.index);
       parseFrom = match.index + match[0].length;
 
-      // We're wrapping the contents of the <summary> with a <span>.
-      // This means we have to add the closing </span> where the summary ends.
+      const colorizeWholeSummary = !match[1].includes('<b>');
+
+      // We're wrapping the contents of the <summary> with a <span>, and
+      // possibly with a <b>, too. This means we have to add the closing tags
+      // where the summary ends.
       textContent += `<summary><span>`;
+      textContent += (colorizeWholeSummary ? `<b>` : ``);
       textContent += match[1];
+      textContent += (colorizeWholeSummary ? `</b>` : ``);
       textContent += `</span></summary>`;
     }
 


### PR DESCRIPTION
Performs a postprocessing transformation on content text to make `<summary>` elements within content automatically fit in with styling and interaction cues across the wiki.

Write the `<summary>` like normal HTML, *without* a top-level `<span>`:

```html
<summary>2018 track list details</summary>
```

Optionally use `<b>` to mark which part of the label should be colorized:

```html
<summary><b>Toggle Directorylog</b> (13 changes)</summary>
```

This behavior works anywhere with (multi-pargaraph) content text.

---

Internally, `<summary>` elements across the wiki have so far always taken on one of these two HTML layouts:

```js
html.tag('summary',
  html.tag('span', [
    html.tag('span', {class: 'group-name'},
      `Colorize me!`),
    `I am additional text.`,
  ]))

html.tag('summary',
  html.tag('span', {class: 'group-name'},
    `Colorize me!`))
```

This PR changes `<span class="group-name">` to `<b>`, and mandates a separate top-level `<span>`:

```js
html.tag('summary',
  html.tag('span', [
    html.tag('b', `Colorize me!`),
    `I am additional text.`,
  ]))
```

The top-level span has always been necessary because we want to style the text and cursor when the *label* of a `<summary>` is hovered; the summary itself spans the full width of the container (like a block element), so is `:hover` when the cursor is vertically aligned but not over text.

The `class="group-name"` selector dates all the way back to when we first added track sections, which were named track groups (#117, #140). We later expanded the usage of `<details>` across UI, but this selector stuck around. We're using `<b>` now for a few reasons:

1. Get rid of that legacy class name, which has nothing to do with its general usage
2. Use a shorter name for convenient writing in content text
3. Use a tag that's styled if CSS is absent, instead of blending meaningfully separate bits of text together

Consistently standardizing the hierarchical layout of `<summary>` (so there's one shape instead of two) is mostly a bonus, but a nice-to-have for sure!