### PR TITLE
Fix broken contribution annotations on artist info pages

### DIFF
--- a/src/content/dependencies/generateArtistInfoPageArtworksChunk.js
+++ b/src/content/dependencies/generateArtistInfoPageArtworksChunk.js
@@ -5,6 +5,8 @@ export default {
     'linkAlbum',
   ],
 
+  extraDependencies: ['html'],
+
   relations: (relation, album, contribs) => ({
     template:
       relation('generateArtistInfoPageChunk'),
@@ -24,11 +26,25 @@ export default {
         .map(contrib => contrib.date),
   }),
 
-  generate: (data, relations) =>
+  slots: {
+    filterEditsForWiki: {
+      type: 'boolean',
+      default: false,
+    },
+  },
+
+  generate: (data, relations, slots) =>
     relations.template.slots({
       mode: 'album',
       albumLink: relations.albumLink,
-      dates: data.dates,
-      items: relations.items,
+
+      dates:
+        (slots.filterEditsForWiki
+          ? Array.from({length: data.dates}, () => null)
+          : data.dates),
+
+      items:
+        relations.items.map(item =>
+          item.slot('filterEditsForWiki', slots.filterEditsForWiki)),
     }),
 };

--- a/src/content/dependencies/generateArtistInfoPageArtworksChunkItem.js
+++ b/src/content/dependencies/generateArtistInfoPageArtworksChunkItem.js
@@ -39,11 +39,21 @@ export default {
       contrib.annotation,
   }),
 
-  generate: (data, relations, {html, language}) =>
+  slots: {
+    filterEditsForWiki: {
+      type: 'boolean',
+      default: false,
+    },
+  },
+
+  generate: (data, relations, slots, {html, language}) =>
     relations.template.slots({
       otherArtistLinks: relations.otherArtistLinks,
 
-      annotation: data.annotation,
+      annotation:
+        (slots.filterEditsForWiki
+          ? data.annotation?.replace(/^edits for wiki(: )?/, '')
+          : data.annotation),
 
       content:
         language.encapsulate('artistPage.creditList.entry', capsule =>

--- a/src/content/dependencies/generateArtistInfoPageArtworksChunkedList.js
+++ b/src/content/dependencies/generateArtistInfoPageArtworksChunkedList.js
@@ -65,15 +65,7 @@ export default {
   generate: (data, relations) =>
     relations.chunkedList.slots({
       chunks:
-        relations.chunks.map(chunk => {
-          if (data.filterEditsForWiki) {
-            chunk.setSlots({
-              trimAnnotations: true,
-              dates: [],
-            });
-          }
-
-          return chunk;
-        }),
+        relations.chunks.map(chunk =>
+          chunk.slot('filterEditsForWiki', data.filterEditsForWiki)),
     }),
 };

--- a/src/content/dependencies/generateArtistInfoPageChunk.js
+++ b/src/content/dependencies/generateArtistInfoPageChunk.js
@@ -29,11 +29,6 @@ export default {
 
     duration: {validate: v => v.isDuration},
     durationApproximate: {type: 'boolean'},
-
-    trimAnnotations: {
-      type: 'boolean',
-      default: false,
-    },
   },
 
   generate(slots, {html, language}) {
@@ -107,10 +102,7 @@ export default {
       html.tag('dt', accentedLink),
       html.tag('dd',
         html.tag('ul',
-          slots.items
-            .map(item => item.slots({
-              trimAnnotation: slots.trimAnnotations,
-            })))),
+          slots.items)),
     ]);
   },
 };

--- a/src/content/dependencies/generateArtistInfoPageChunkItem.js
+++ b/src/content/dependencies/generateArtistInfoPageChunkItem.js
@@ -9,18 +9,16 @@ export default {
       mutable: false,
     },
 
-    annotation: {type: 'string'},
+    annotation: {
+      type: 'html',
+      mutable: false,
+    },
 
     otherArtistLinks: {
       validate: v => v.strictArrayOf(v.isHTML),
     },
 
     rerelease: {type: 'boolean'},
-
-    trimAnnotation: {
-      type: 'boolean',
-      default: false,
-    },
   },
 
   generate: (slots, {html, language}) =>
@@ -45,15 +43,10 @@ export default {
               language.formatConjunctionList(slots.otherArtistLinks);
           }
 
-          const annotation =
-            (slots.trimAnnotation
-              ? slots.annotation?.replace(/^edits for wiki(: )?/, '')
-              : slots.annotation);
-
-          if (annotation) {
+          if (!html.isBlank(slots.annotation)) {
             anyAccent = true;
             workingCapsule += '.withAnnotation';
-            workingOptions.annotation = annotation;
+            workingOptions.annotation = slots.annotation;
           }
 
           if (anyAccent) {


### PR DESCRIPTION
This basically reverts commit 53794015 (which introduced the trimAnnotation slot). Behavior is pulled out of gAIPChunkItem and into gAIPArtworksChunkItem, with slots similarly shuffled around.

gAIPChunkItem is the final consumer of a contribution's annotation (providing it as part of the item's HTML), but before an annotation gets there, its value (from data a string) may become a live HTML object:

https://github.com/hsmusic/hsmusic-wiki/blob/41f0d592571f7066e785f9a4598fa48e26f1c0a0/src/content/dependencies/generateArtistInfoPageTracksChunkItem.js#L97-L100

https://github.com/hsmusic/hsmusic-wiki/blob/41f0d592571f7066e785f9a4598fa48e26f1c0a0/src/content/dependencies/generateArtistInfoPageCommentaryChunkedList.js#L232-L235

Rather than left as a string:

https://github.com/hsmusic/hsmusic-wiki/blob/41f0d592571f7066e785f9a4598fa48e26f1c0a0/src/content/dependencies/generateArtistInfoPageArtworksChunkItem.js#L46

https://github.com/hsmusic/hsmusic-wiki/blob/41f0d592571f7066e785f9a4598fa48e26f1c0a0/src/content/dependencies/generateArtistInfoPageFlashesChunkItem.js#L27

We probably overlooked this in #550 because we were only considering artworks, which *do* provide annotations directly as a string. But live HTML provided to a string slot gets serialized into a string, and then that string is treated as raw data and sanitized by `language`, and you get apparent HTML markup instead of the actual tags that belong there!