### PR TITLE
Fix up artist nav links + add "imaginary-sibling" metatag

### DIFF
--- a/src/content/dependencies/generateDotSwitcherTemplate.js
+++ b/src/content/dependencies/generateDotSwitcherTemplate.js
@@ -27,8 +27,15 @@ export default {
           html.tag('span',
             {[html.onlyIfContent]: true},
 
+            html.resolve(option, {normalize: 'tag'})
+              .onlyIfSiblings &&
+                {[html.onlyIfSiblings]: true},
+
             index === slots.initialOptionIndex &&
               {class: 'current'},
 
-            option))),
+            [
+              html.metatag('imaginary-sibling'),
+              option,
+            ]))),
 };

--- a/src/content/dependencies/generateDotSwitcherTemplate.js
+++ b/src/content/dependencies/generateDotSwitcherTemplate.js
@@ -16,6 +16,7 @@ export default {
 
   generate: (slots, {html}) =>
     html.tag('span', {class: 'dot-switcher'},
+      {[html.onlyIfContent]: true},
       {[html.noEdgeWhitespace]: true},
       {[html.joinChildren]: ''},
 

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -401,13 +401,15 @@ export class Tag {
   }
 
   set content(value) {
-    if (
-      this.selfClosing &&
-      !(value === null ||
-        value === undefined ||
-        !value ||
-        Array.isArray(value) && value.filter(Boolean).length === 0)
-    ) {
+    const contentful =
+      value !== null &&
+      value !== undefined &&
+      value &&
+      (Array.isArray(value)
+        ? !empty(value.filter(Boolean))
+        : true);
+
+    if (this.selfClosing && contentful) {
       throw new Error(`Tag <${this.tagName}> is self-closing but got content`);
     }
 

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -557,7 +557,7 @@ export class Tag {
     this.#setAttributeFlag(chunkwrap, value);
 
     try {
-      this.content = content;
+      this.content = this.content;
     } catch (error) {
       this.#setAttributeFlag(chunkwrap, false);
       throw error;

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -329,7 +329,7 @@ export function metatag(identifier, ...args) {
       return new Tag(null, {[chunkwrap]: true, ...opts}, content);
 
     case 'imaginary-sibling':
-      return new Tag(null, {[imaginarySibling]: true});
+      return new Tag(null, {[imaginarySibling]: true}, content);
 
     default:
       throw new Error(`Unknown metatag "${identifier}"`);
@@ -411,6 +411,10 @@ export class Tag {
 
     if (this.selfClosing && contentful) {
       throw new Error(`Tag <${this.tagName}> is self-closing but got content`);
+    }
+
+    if (this.imaginarySibling && contentful) {
+      throw new Error(`html.metatag('imaginary-sibling') can't have content`);
     }
 
     const contentArray =
@@ -572,6 +576,12 @@ export class Tag {
 
   set imaginarySibling(value) {
     this.#setAttributeFlag(imaginarySibling, value);
+
+    try {
+      this.content = this.content;
+    } catch (error) {
+      this.#setAttributeFlag(imaginarySibling, false);
+    }
   }
 
   get imaginarySibling() {


### PR DESCRIPTION
Whoopsey, when we were doin' dot links (which has no pull request 👍) we didn't end up getting artist nav links updated like (hopefully) the rest of 'em. This PR fixes that!

It also adds `html.metatag('imaginary-sibling')`, which is a blank tag that is completely ignored when you're doing serialization (`toString`). Instead of doing anything with its own content (which it can't have at all), it just marks that sibling tags with the `[html.onlyIfSiblings]` attribute (#510) should in fact show themselves up.

This basically means we can steal the `onlyIfSiblings` attribute out from a slotted-in child, use that for ourselves, *and* neutralize the effect of the tag on the child, which itself isn't going to have any siblings - not within the tag we're wrapping it under.

This PR also fixes #576 along the way, why not.