### PR TITLE
find.mixed(), find decomposition, and mixed reference lists

### DIFF
--- a/data-tests/index.js
+++ b/data-tests/index.js
@@ -4,7 +4,7 @@ import {fileURLToPath} from 'node:url';
 import chokidar from 'chokidar';
 
 import {colors, logError, logInfo, logWarn, parseOptions} from '#cli';
-import {bindFind, getAllFindSpecs} from '#find';
+import find, {bindFind, getAllFindSpecs} from '#find';
 import {isMain} from '#node-utils';
 import {getContextAssignments} from '#repl';
 import {bindOpts, showAggregate} from '#sugar';
@@ -33,6 +33,7 @@ async function main() {
   const watcher = chokidar.watch(metaDirname);
 
   const wikiData = await quickLoadAllFromYAML(dataPath, {
+    find,
     bindFind,
     getAllFindSpecs,
 

--- a/src/data/checks.js
+++ b/src/data/checks.js
@@ -9,7 +9,7 @@ import {compareArrays, cut, cutStart, empty, getNestedProp, iterateMultiline}
   from '#sugar';
 import Thing from '#thing';
 import thingConstructors from '#things';
-import {commentaryRegexCaseSensitive} from '#wiki-data';
+import {combineWikiDataArrays, commentaryRegexCaseSensitive} from '#wiki-data';
 
 import {
   annotateErrorWithIndex,
@@ -184,8 +184,7 @@ export function filterReferenceErrors(wikiData, {
       bannerArtistContribs: '_contrib',
       groups: 'group',
       artTags: '_artTag',
-      referencedTrackArtworks: '_trackArtwork',
-      referencedAlbumArtworks: '_albumArtwork',
+      referencedArtworks: '_artwork',
       commentary: '_commentary',
     }],
 
@@ -222,8 +221,7 @@ export function filterReferenceErrors(wikiData, {
       referencedTracks: '_trackNotRerelease',
       sampledTracks: '_trackNotRerelease',
       artTags: '_artTag',
-      referencedTrackArtworks: '_trackArtwork',
-      referencedAlbumArtworks: '_albumArtwork',
+      referencedArtworks: '_artwork',
       originalReleaseTrack: '_trackNotRerelease',
       commentary: '_commentary',
     }],
@@ -290,9 +288,23 @@ export function filterReferenceErrors(wikiData, {
             let findFn;
 
             switch (findFnKey) {
-              case '_albumArtwork':
-                findFn = ref => boundFind.album(ref.reference);
+              case '_artwork': {
+                const mixed =
+                  find.mixed({
+                    album: find.album,
+                    track: find.track,
+                  });
+
+                const data =
+                  combineWikiDataArrays([
+                    wikiData.albumData,
+                    wikiData.trackData,
+                  ]);
+
+                findFn = ref => mixed(ref.reference, data);
+
                 break;
+              }
 
               case '_artTag':
                 findFn = boundFind.artTag;

--- a/src/data/checks.js
+++ b/src/data/checks.js
@@ -172,6 +172,7 @@ function getFieldPropertyMessage(yamlDocumentSpec, property) {
 // any errors). At the same time, we remove errored references from the thing's
 // data array.
 export function filterReferenceErrors(wikiData, {
+  find,
   bindFind,
 }) {
   const referenceSpec = [

--- a/src/data/checks.js
+++ b/src/data/checks.js
@@ -301,7 +301,7 @@ export function filterReferenceErrors(wikiData, {
                     wikiData.trackData,
                   ]);
 
-                findFn = ref => mixed(ref.reference, data);
+                findFn = ref => mixed(ref.reference, data, {mode: 'error'});
 
                 break;
               }

--- a/src/data/composite/wiki-data/withResolvedArtworkReferenceList.js
+++ b/src/data/composite/wiki-data/withResolvedArtworkReferenceList.js
@@ -24,7 +24,7 @@ export default templateCompositeFrom({
       acceptsNull: true,
     }),
 
-    data: inputWikiData({allowMixedTypes: false}),
+    data: inputWikiData({allowMixedTypes: true}),
     find: input({type: 'function'}),
 
     notFoundMode: input({
@@ -32,6 +32,8 @@ export default templateCompositeFrom({
       defaultValue: 'filter',
     }),
   },
+
+  outputs: ['#resolvedArtworkReferenceList'],
 
   steps: () => [
     withPropertiesFromList({

--- a/src/data/composite/wiki-data/withResolvedReferenceList.js
+++ b/src/data/composite/wiki-data/withResolvedReferenceList.js
@@ -23,7 +23,7 @@ export default templateCompositeFrom({
       acceptsNull: true,
     }),
 
-    data: inputWikiData({allowMixedTypes: false}),
+    data: inputWikiData({allowMixedTypes: true}),
     find: input({type: 'function'}),
 
     notFoundMode: input({

--- a/src/data/composite/wiki-properties/referenceList.js
+++ b/src/data/composite/wiki-properties/referenceList.js
@@ -31,7 +31,7 @@ export default templateCompositeFrom({
       defaultValue: null,
     }),
 
-    data: inputWikiData({allowMixedTypes: false}),
+    data: inputWikiData({allowMixedTypes: true}),
 
     find: input({type: 'function'}),
   },

--- a/src/data/thing.js
+++ b/src/data/thing.js
@@ -14,6 +14,8 @@ export default class Thing extends CacheableObject {
   static getSerializeDescriptors = Symbol.for('Thing.getSerializeDescriptors');
 
   static findSpecs = Symbol.for('Thing.findSpecs');
+  static findThisThingOnly = Symbol.for('Thing.findThisThingOnly');
+
   static yamlDocumentSpec = Symbol.for('Thing.yamlDocumentSpec');
   static getYamlLoadingSpec = Symbol.for('Thing.getYamlLoadingSpec');
 

--- a/src/data/things/album.js
+++ b/src/data/things/album.js
@@ -233,30 +233,13 @@ export class Album extends Thing {
       }),
     ],
 
-    referencedTrackArtworks: [
+    referencedArtworks: [
       exitWithoutContribs({
         contribs: 'coverArtistContribs',
         value: input.value([]),
       }),
 
-      referencedArtworkList({
-        class: input.value(Track),
-        find: input.value(find.track),
-        data: 'trackData',
-      }),
-    ],
-
-    referencedAlbumArtworks: [
-      exitWithoutContribs({
-        contribs: 'coverArtistContribs',
-        value: input.value([]),
-      }),
-
-      referencedArtworkList({
-        class: input.value(Album),
-        find: input.value(find.album),
-        data: 'albumData',
-      }),
+      referencedArtworkList(),
     ],
 
     // Update only
@@ -429,13 +412,8 @@ export class Album extends Thing {
         transform: parseAdditionalFiles,
       },
 
-      'Referenced Track Artworks': {
-        property: 'referencedTrackArtworks',
-        transform: parseReferencedArtworks,
-      },
-
-      'Referenced Album Artworks': {
-        property: 'referencedAlbumArtworks',
+      'Referenced Artworks': {
+        property: 'referencedArtworks',
         transform: parseReferencedArtworks,
       },
 

--- a/src/data/things/track.js
+++ b/src/data/things/track.js
@@ -352,28 +352,12 @@ export class Track extends Thing {
       }),
     ],
 
-    referencedTrackArtworks: [
+    referencedArtworks: [
       exitWithoutUniqueCoverArt({
         value: input.value([]),
       }),
 
-      referencedArtworkList({
-        class: input.value(Track),
-        find: input.value(find.track),
-        data: 'trackData',
-      }),
-    ],
-
-    referencedAlbumArtworks: [
-      exitWithoutUniqueCoverArt({
-        value: input.value([]),
-      }),
-
-      referencedArtworkList({
-        class: input.value(Album),
-        find: input.value(find.album),
-        data: 'albumData',
-      }),
+      referencedArtworkList(),
     ],
 
     // Update only
@@ -540,13 +524,8 @@ export class Track extends Thing {
       'Referenced Tracks': {property: 'referencedTracks'},
       'Sampled Tracks': {property: 'sampledTracks'},
 
-      'Referenced Track Artworks': {
-        property: 'referencedTrackArtworks',
-        transform: parseReferencedArtworks,
-      },
-
-      'Referenced Album Artworks': {
-        property: 'referencedAlbumArtworks',
+      'Referenced Artworks': {
+        property: 'referencedArtworks',
         transform: parseReferencedArtworks,
       },
 

--- a/src/data/validators.js
+++ b/src/data/validators.js
@@ -804,7 +804,7 @@ export function validateReference(type) {
 
     if (typePart) {
       if (Array.isArray(type)) {
-        if (!typePart.includes(type)) {
+        if (!type.includes(typePart)) {
           throw new TypeError(
             `Expected ref to begin with one of ` +
             type.map(type => `"${type}:"`).join(', ') +

--- a/src/data/validators.js
+++ b/src/data/validators.js
@@ -790,7 +790,7 @@ export function isURL(string) {
   return true;
 }
 
-export function validateReference(type = 'track') {
+export function validateReference(type) {
   return (ref) => {
     isStringNonEmpty(ref);
 
@@ -803,8 +803,17 @@ export function validateReference(type = 'track') {
     const {groups: {typePart, directoryPart}} = match;
 
     if (typePart) {
-      if (typePart !== type)
-        throw new TypeError(`Expected ref to begin with "${type}:", got "${typePart}:"`);
+      if (Array.isArray(type)) {
+        if (!typePart.includes(type)) {
+          throw new TypeError(
+            `Expected ref to begin with one of ` +
+            type.map(type => `"${type}:"`).join(', ') +
+            `, got "${typePart}:"`);
+        }
+      } else if (typePart !== type) {
+        throw new TypeError(
+          `Expected ref to begin with "${type}:", got "${typePart}:"`);
+      }
 
       isDirectory(directoryPart);
     }
@@ -815,18 +824,18 @@ export function validateReference(type = 'track') {
   };
 }
 
-export function validateReferenceList(type = '') {
+export function validateReferenceList(type) {
   return validateArrayItems(validateReference(type));
 }
 
-export function validateAnnotatedReference(type = '') {
+export function validateAnnotatedReference(type) {
   return validateProperties({
     reference: validateReference(type),
     annotation: optional(isContentString),
   });
 }
 
-export function validateAnnotatedReferenceList(type = '') {
+export function validateAnnotatedReferenceList(type) {
   return validateArrayItems(validateAnnotatedReference(type));
 }
 

--- a/src/data/yaml.js
+++ b/src/data/yaml.js
@@ -1314,6 +1314,7 @@ export function sortWikiDataArrays(dataSteps, wikiData) {
 // where reporting info about data loading isn't as relevant as during the
 // main wiki build process.
 export async function quickLoadAllFromYAML(dataPath, {
+  find,
   bindFind,
   getAllFindSpecs,
 
@@ -1350,7 +1351,7 @@ export async function quickLoadAllFromYAML(dataPath, {
   }
 
   try {
-    filterReferenceErrors(wikiData, {bindFind}).close();
+    filterReferenceErrors(wikiData, {find, bindFind}).close();
     logInfo`No reference errors found. (complete data)`;
   } catch (error) {
     showAggregate(error);

--- a/src/find.js
+++ b/src/find.js
@@ -1,7 +1,7 @@
 import {inspect} from 'node:util';
 
 import {colors, logWarn} from '#cli';
-import {compareObjects, typeAppearance} from '#sugar';
+import {compareObjects, stitchArrays, typeAppearance} from '#sugar';
 import thingConstructors from '#things';
 import {isFunction, validateArrayItems} from '#validators';
 
@@ -347,9 +347,27 @@ function findMixedHelper(config) {
       });
     }
 
+    const byDirectory =
+      Object.fromEntries(
+        stitchArrays({
+          referenceType: keys,
+          spec: specs,
+        }).map(({referenceType, spec}) => [
+            referenceType,
+            processAvailableMatchesByDirectory(data, spec).results,
+          ]));
+
     return matchHelper(fullRef, mode, {
-      matchByDirectory:
-        () => null, /* TODO: Do something */
+      matchByDirectory: (referenceType, directory) => {
+        if (!keys.includes(referenceType)) {
+          return oopsWrongReferenceType(mode, {
+            referenceType,
+            referenceTypes: keys,
+          });
+        }
+
+        return byDirectory[referenceType][directory];
+      },
 
       matchByName:
         prepareMatchByName(mode, {

--- a/src/find.js
+++ b/src/find.js
@@ -313,8 +313,6 @@ export const findTokenKey = Symbol.for('find.findTokenKey');
 export const boundFindData = Symbol.for('find.boundFindData');
 export const boundFindOptions = Symbol.for('find.boundFindOptions');
 
-const mixedFindStore = new Map();
-
 function findMixedHelper(config) {
   const
     keys = Object.keys(config),
@@ -378,10 +376,12 @@ function findMixedHelper(config) {
   };
 }
 
-export function mixedFind(config) {
-  for (const key of mixedFindStore.keys()) {
+const findMixedStore = new Map();
+
+export function findMixed(config) {
+  for (const key of findMixedStore.keys()) {
     if (compareObjects(key, config)) {
-      return mixedFindStore.get(key);
+      return findMixedStore.get(key);
     }
   }
 
@@ -394,7 +394,7 @@ export function mixedFind(config) {
       isFunction(token);
 
       if (token[boundFindData])
-        throw new Error(`mixedFind doesn't work with bindFind yet`);
+        throw new Error(`find.mixed doesn't work with bindFind yet`);
 
       if (!token[findTokenKey])
         throw new Error(`missing findTokenKey, is this actually a find.thing token?`);
@@ -403,7 +403,7 @@ export function mixedFind(config) {
     })(tokens);
   } catch (caughtError) {
     throw new Error(
-      `Expected mixedFind mapping to include valid find.thing tokens only`,
+      `Expected find.mixed mapping to include valid find.thing tokens only`,
       {cause: caughtError});
   }
 
@@ -413,14 +413,14 @@ export function mixedFind(config) {
     return (behavior = findMixedHelper(config))(...args);
   };
 
-  mixedFindStore.set(config, (...args) => behavior(...args));
-  return mixedFindStore.get(config);
+  findMixedStore.set(config, (...args) => behavior(...args));
+  return findMixedStore.get(config);
 }
 
 export default new Proxy({}, {
   get: (store, key) => {
     if (key === 'mixed') {
-      return mixedFind;
+      return findMixed;
     }
 
     if (!Object.hasOwn(store, key)) {
@@ -472,7 +472,7 @@ export function bindFind(wikiData, opts1) {
     boundFindFns[key][boundFindOptions] = opts1 ?? {};
   }
 
-  boundFindFns.mixed = mixedFind;
+  boundFindFns.mixed = findMixed;
 
   return boundFindFns;
 }

--- a/src/find.js
+++ b/src/find.js
@@ -112,7 +112,10 @@ function findHelper({
   // 'quiet' both return null, with 'warn' logging details directly to the
   // console.
   return (fullRef, data, {mode = 'warn'} = {}) => {
+    // TODO: Factor out this validation
+
     if (!fullRef) return null;
+
     if (typeof fullRef !== 'string') {
       throw new TypeError(`Expected a string, got ${typeAppearance(fullRef)}`);
     }
@@ -268,6 +271,18 @@ function findMixedHelper(config) {
     specs = specKeys.map(specKey => findFindSpec(specKey));
 
   return (fullRef, data, {mode = 'warn'} = {}) => {
+    // TODO: Factor out this validation
+
+    if (!fullRef) return null;
+
+    if (typeof fullRef !== 'string') {
+      throw new TypeError(`Expected a string, got ${typeAppearance(fullRef)}`);
+    }
+
+    if (!data) {
+      throw new TypeError(`Expected data to be present`);
+    }
+
     // TODO: Cache stuff below by identity of data
 
     const byName = Object.create(null);

--- a/src/find.js
+++ b/src/find.js
@@ -141,24 +141,23 @@ function findHelper({
 
     const {key: keyPart, ref: refPart} = regexMatch.groups;
 
-    if (keyPart && !referenceTypes.includes(keyPart)) {
-      return warnOrThrow(mode,
-        `Reference starts with "${keyPart}:", expected ` +
-        referenceTypes.map(type => `"${type}:"`).join(', '));
-    }
+    let match;
 
-    const normalizedName =
-      (keyPart
-        ? null
-        : refPart.toLowerCase());
+    if (keyPart) {
+      if (!referenceTypes.includes(keyPart)) {
+        return warnOrThrow(mode,
+          `Reference starts with "${keyPart}:", expected ` +
+          referenceTypes.map(type => `"${type}:"`).join(', '));
+      }
 
-    const match =
-      (keyPart
-        ? subcache.byDirectory[refPart]
-        : subcache.byName[normalizedName]);
+      match = subcache.byDirectory[refPart];
+    } else {
+      const normalizedName =
+        refPart.toLowerCase();
 
-    if (!match && !keyPart) {
-      if (subcache.multipleNameMatches[normalizedName]) {
+      match = subcache.byName[normalizedName];
+
+      if (!match && subcache.multipleNameMatches[normalizedName]) {
         return warnOrThrow(mode,
           `Multiple matches for reference "${fullRef}". Please resolve:\n` +
           subcache.multipleNameMatches[normalizedName]
@@ -293,24 +292,25 @@ function findMixedHelper(config) {
 
     const {key: keyPart, ref: refPart} = regexMatch.groups;
 
-    if (keyPart && !referenceTypes.includes(keyPart)) {
-      return warnOrThrow(mode,
-        `Reference starts with "${keyPart}:", expected ` +
-        referenceTypes.map(type => `"${type}:"`).join(', '));
-    }
+    let match;
 
-    const normalizedName =
-      (keyPart
-        ? null
-        : refPart.toLowerCase());
+    if (keyPart) {
+      if (!referenceTypes.includes(keyPart)) {
+        return warnOrThrow(mode,
+          `Reference starts with "${keyPart}:", expected ` +
+          referenceTypes.map(type => `"${type}:"`).join(', '));
+      }
 
-    const match =
-      (keyPart
-        ? null /* TODO: Do something */
-        : byName[normalizedName]);
+      // TODO: Do something
+      match = null;
+    } else {
+      const normalizedName =
+        refPart.toLowerCase();
 
-    if (!match && !keyPart) {
-      if (multipleNameMatches[normalizedName]) {
+      match =
+        byName[normalizedName];
+
+      if (!match && multipleNameMatches[normalizedName]) {
         return warnOrThrow(mode,
           `Multiple matches for reference "${fullRef}". Please resolve:\n` +
           multipleNameMatches[normalizedName]

--- a/src/upd8.js
+++ b/src/upd8.js
@@ -43,7 +43,7 @@ import wrap from 'word-wrap';
 import {mapAggregate, showAggregate} from '#aggregate';
 import CacheableObject from '#cacheable-object';
 import {displayCompositeCacheAnalysis} from '#composite';
-import {bindFind, getAllFindSpecs} from '#find';
+import find, {bindFind, getAllFindSpecs} from '#find';
 import {processLanguageFile, watchLanguageFile, internalDefaultStringsFile}
   from '#language';
 import {isMain, traverse} from '#node-utils';
@@ -1626,7 +1626,7 @@ async function main() {
     });
 
     const filterReferenceErrorsAggregate =
-      filterReferenceErrors(wikiData, {bindFind});
+      filterReferenceErrors(wikiData, {find, bindFind});
 
     try {
       filterReferenceErrorsAggregate.close();

--- a/src/util/sugar.js
+++ b/src/util/sugar.js
@@ -216,6 +216,34 @@ export const compareArrays = (arr1, arr2, {checkOrder = true} = {}) =>
     ? arr1.every((x, i) => arr2[i] === x)
     : arr1.every((x) => arr2.includes(x)));
 
+export function compareObjects(obj1, obj2, {
+  checkOrder = false,
+  checkSymbols = true,
+} = {}) {
+  const keys1 = Object.keys(obj1);
+  const keys2 = Object.keys(obj2);
+  if (!compareArrays(keys1, keys2, {checkOrder})) return false;
+
+  let syms1, syms2;
+  if (checkSymbols) {
+    syms1 = Object.getOwnPropertySymbols(obj1);
+    syms2 = Object.getOwnPropertySymbols(obj2);
+    if (!compareArrays(syms1, syms2, {checkOrder})) return false;
+  }
+
+  for (const key of keys1) {
+    if (obj2[key] !== obj1[key]) return false;
+  }
+
+  if (checkSymbols) {
+    for (const sym of syms1) {
+      if (obj2[sym] !== obj1[sym]) return false;
+    }
+  }
+
+  return true;
+}
+
 // Stolen from jq! Which pro8a8ly stole the concept from other places. Nice.
 export const withEntries = (obj, fn) => {
   const result = fn(Object.entries(obj));

--- a/src/util/wiki-data.js
+++ b/src/util/wiki-data.js
@@ -460,3 +460,16 @@ export class TupleMapForBabies {
     }
   }
 }
+
+const combinedWikiDataTupleMap = new TupleMapForBabies();
+
+export function combineWikiDataArrays(arrays) {
+  const map = combinedWikiDataTupleMap;
+  if (map.has(...arrays)) {
+    return map.get(...arrays);
+  } else {
+    const combined = arrays.flat();
+    map.set(...arrays, combined);
+    return combined;
+  }
+}

--- a/src/util/wiki-data.js
+++ b/src/util/wiki-data.js
@@ -413,3 +413,50 @@ export class TupleMap {
     return value;
   }
 }
+
+export class TupleMapForBabies {
+  #here = new WeakMap();
+  #next = new WeakMap();
+
+  set(...args) {
+    const first = args.at(0);
+    const last = args.at(-1);
+    const rest = args.slice(1, -1);
+
+    if (empty(rest)) {
+      this.#here.set(first, last);
+    } else if (this.#next.has(first)) {
+      this.#next.get(first).set(...rest, last);
+    } else {
+      const tupleMap = new TupleMapForBabies();
+      this.#next.set(first, tupleMap);
+      tupleMap.set(...rest, last);
+    }
+  }
+
+  get(...args) {
+    const first = args.at(0);
+    const rest = args.slice(1);
+
+    if (empty(rest)) {
+      return this.#here.get(first);
+    } else if (this.#next.has(first)) {
+      return this.#next.get(first).get(...rest);
+    } else {
+      return undefined;
+    }
+  }
+
+  has(...args) {
+    const first = args.at(0);
+    const rest = args.slice(1);
+
+    if (empty(rest)) {
+      return this.#here.has(first);
+    } else if (this.#next.has(first)) {
+      return this.#next.get(first).has(...rest);
+    } else {
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
Holy mackerel! This is a pretty big and fancy one. See [#code-quarantine](https://discord.com/channels/749042497610842152/854020929113423924/1306356352322633738) for Tangle's implementation liveblog.

This PR adds:

* `find.mixed()` — Super simple interface for making multiple find-specs' behavior available in a single function/entry point.
    * For example, `find.mixed({album: find.album, track: find.track})` gives you a function you use just like `find.album` or `find.track` on their own, but...
        * You pass a data array containing both albums *and* tracks
        * You pass a reference like `album:directory-of-some-album` *or* like `track:directory-of-some-track`
        * And you can pass a reference like `Name of a Track or an Album`
    * Like `find`, a find.mixed() function caches its matchable results per identity of the data array you pass it. Since just combining `[...albumData, ...trackData]` would result in a new identity each time, you use `combineWikiDataArrays()` instead (see below).
    * Like `find` tokens such as `find.track` (which are really provided by a proxy and are not individually exported "real" variables/functions), find.mixed() functions share an identity if you provide the same mapping of keys -> find functions.
    * `find.mixed` only works with unbound `find` tokens (and don't even think about providing `find.mixed` to another `find.mixed`). This is mostly a "we were too lazy to code it" limitation right now, because general usage of `bindFind` is fairly limited right now, but the right behavior also isn't necessarily obvious.
* `combineWikiDataArrays()` — Concatenates two or more arrays into one, returning the same identity if you combine the same-identity arrays (in the same order), even at totally different times. For example `combineWikiDataArrays([wikiData.trackData, wikiData.albumData])` will always result in the same-identity array of all tracks and albums, as long as the identities of `wikiData.trackData` and `wikiData.albumData` stay the same (i.e. those tokens refer to the same arrays).
    * This is what you use to reuse identities for the sake of `find.mixed()`'s caching, which works on identity, just like normal `find` caching.
* `TupleMapForBabies` — It's like `TupleMap` but simpler. We have no idea how `TupleMap` works, but the same idea is brought over here, probably!
    * It's the backend for `combineWikiDataArrays()`. It just allows a series of identities (i.e. objects/arrays) to be associated with any value, without storing any references to those identities outside of `WeakMap`s.
* Automatic filtering for all find specs defined on things—only instances of the constructor this `[Thing.findSpecs]` is specified on will be included. This is coded as a wrapper around the existing `include` interface, and (purely) postprocessed where find specs are exposed to `find` internals. A spec can opt out of this by providing `[Thing.findThisThingOnly]: false`, but so far no find specs specified on things do so.

Supporting all that is mostly a ton of changes in `find`, decomposing basically every part of the "core" of `findHelper` into bits and pieces we reuse/recompose in `findMixedHelper`. We were originally going to go for a more "make a more customizable core" which underlies both `findHelper` and `findMixedHelper`, but figured going modular/compositional was going to be easier. We were hopefully right. LOL

Besides the `find.mixed()` stuff, this PR also adds...

* Mixed reference lists: These are not actually different from normal reference lists at all! No new compositional steps here. But `withResolvedReferenceList` and `referenceList` now accept lists of mixed wiki data. Provide so alongside a `mixed.find` function in place of any typical `find` token, and it will simply work.
    * Respective validators are also updated. `validateReference(['track', 'album'])` accepts non-directory, `track:directory`, and `album:directory` references, for example.
* A combined `Referenced Artworks` field, replacing the existing and more stubbish `Referenced Track Artworks` and `Referenced Album Artworks` fields, to demo that any of this does in fact work. This field still isn't used anywhere on the website.

We haven't investigated actually coding *this* yet, but this PR additionally serves as groundworks for referencing albums and artists within content text *without* using their directories - e.g. `[[Homestuck Vol. 5]]`, or `[[Mobius Trip & Hadron Kaleido|Bowman's first album]]` - and probably works towards more interesting finding behavior in the future, in general.