### PR TITLE
Closely Linked Artists + annotated reference lists

### DIFF
--- a/src/content/dependencies/generateArtistInfoPage.js
+++ b/src/content/dependencies/generateArtistInfoPage.js
@@ -13,6 +13,7 @@ export default {
     'generatePageLayout',
     'linkArtistGallery',
     'linkExternal',
+    'linkGroup',
     'transformContent',
   ],
 
@@ -67,6 +68,10 @@ export default {
 
     contextNotes:
       relation('transformContent', artist.contextNotes),
+
+    closeGroupLinks:
+      artist.closelyLinkedGroups
+        .map(group => relation('linkGroup', group)),
 
     visitLinks:
       artist.urls
@@ -145,6 +150,21 @@ export default {
               {[html.onlyIfContent]: true},
               relations.contextNotes),
           ]),
+
+          html.tag('p',
+            {[html.onlyIfContent]: true},
+
+            language.encapsulate(pageCapsule, 'closelyLinkedGroups', capsule =>
+              (relations.closeGroupLinks.length === 0
+                ? html.blank()
+             : relations.closeGroupLinks.length === 1
+                ? language.$(capsule, 'one', {
+                    group: relations.closeGroupLinks,
+                  })
+                : language.$(capsule, 'multiple', {
+                    groups:
+                      language.formatUnitList(relations.closeGroupLinks),
+                  })))),
 
           html.tag('p',
             {[html.onlyIfContent]: true},

--- a/src/content/dependencies/generateGroupInfoPage.js
+++ b/src/content/dependencies/generateGroupInfoPage.js
@@ -1,5 +1,6 @@
 export default {
   contentDependencies: [
+    'generateColorStyleAttribute',
     'generateGroupInfoPageAlbumsSection',
     'generateGroupNavLinks',
     'generateGroupSecondaryNav',
@@ -15,6 +16,9 @@ export default {
   sprawl: ({wikiInfo}) => ({
     enableGroupUI:
       wikiInfo.enableGroupUI,
+
+    wikiColor:
+      wikiInfo.color,
   }),
 
   relations: (relation, sprawl, group) => ({
@@ -33,6 +37,9 @@ export default {
       (sprawl.enableGroupUI
         ? relation('generateGroupSidebar', group)
         : null),
+
+    wikiColorAttribute:
+      relation('generateColorStyleAttribute', sprawl.wikiColor),
 
     closeArtistLinks:
       group.closelyLinkedArtists
@@ -68,17 +75,26 @@ export default {
           html.tag('p',
             {[html.onlyIfContent]: true},
 
-            language.encapsulate(pageCapsule, 'closelyLinkedArtists', capsule =>
-              (relations.closeArtistLinks.length === 0
-                ? html.blank()
-             : relations.closeArtistLinks.length === 1
-                ? language.$(capsule, 'one', {
-                    artist: relations.closeArtistLinks,
-                  })
-                : language.$(capsule, 'multiple', {
-                    artists:
-                      language.formatUnitList(relations.closeArtistLinks),
-                  })))),
+            language.encapsulate(pageCapsule, 'closelyLinkedArtists', capsule => {
+              let option;
+              [capsule, option] =
+                (relations.closeArtistLinks.length === 0
+                  ? [null, null]
+               : relations.closeArtistLinks.length === 1
+                  ? [language.encapsulate(capsule, 'one'), 'artist']
+                  : [language.encapsulate(capsule, 'multiple'), 'artists']);
+
+              if (!capsule) return html.blank();
+
+              return language.$(capsule, {
+                [option]:
+                  language.formatUnitList(
+                    relations.closeArtistLinks
+                      .map(link => link.slots({
+                        attributes: [relations.wikiColorAttribute],
+                      }))),
+              });
+            })),
 
           html.tag('p',
             {[html.onlyIfContent]: true},

--- a/src/content/dependencies/generateGroupInfoPage.js
+++ b/src/content/dependencies/generateGroupInfoPage.js
@@ -5,6 +5,7 @@ export default {
     'generateGroupSecondaryNav',
     'generateGroupSidebar',
     'generatePageLayout',
+    'linkArtist',
     'linkExternal',
     'transformContent',
   ],
@@ -33,6 +34,10 @@ export default {
         ? relation('generateGroupSidebar', group)
         : null),
 
+    closeArtistLinks:
+      group.closelyLinkedArtists
+        .map(artist => relation('linkArtist', artist)),
+
     visitLinks:
       group.urls
         .map(url => relation('linkExternal', url)),
@@ -60,6 +65,21 @@ export default {
         color: data.color,
 
         mainContent: [
+          html.tag('p',
+            {[html.onlyIfContent]: true},
+
+            language.encapsulate(pageCapsule, 'closelyLinkedArtists', capsule =>
+              (relations.closeArtistLinks.length === 0
+                ? html.blank()
+             : relations.closeArtistLinks.length === 1
+                ? language.$(capsule, 'one', {
+                    artist: relations.closeArtistLinks,
+                  })
+                : language.$(capsule, 'multiple', {
+                    artists:
+                      language.formatUnitList(relations.closeArtistLinks),
+                  })))),
+
           html.tag('p',
             {[html.onlyIfContent]: true},
 

--- a/src/data/composite/control-flow/helpers/performAvailabilityCheck.js
+++ b/src/data/composite/control-flow/helpers/performAvailabilityCheck.js
@@ -1,0 +1,19 @@
+import {empty} from '#sugar';
+
+export default function performAvailabilityCheck(value, mode) {
+  switch (mode) {
+    case 'null':
+      return value !== undefined && value !== null;
+
+    case 'empty':
+      return value !== undefined && !empty(value);
+
+    case 'falsy':
+      return !!value && (!Array.isArray(value) || !empty(value));
+
+    case 'index':
+      return typeof value === 'number' && value >= 0;
+  }
+
+  return undefined;
+}

--- a/src/data/composite/control-flow/index.js
+++ b/src/data/composite/control-flow/index.js
@@ -12,4 +12,5 @@ export {default as exposeUpdateValueOrContinue} from './exposeUpdateValueOrConti
 export {default as exposeWhetherDependencyAvailable} from './exposeWhetherDependencyAvailable.js';
 export {default as raiseOutputWithoutDependency} from './raiseOutputWithoutDependency.js';
 export {default as raiseOutputWithoutUpdateValue} from './raiseOutputWithoutUpdateValue.js';
+export {default as withAvailabilityFilter} from './withAvailabilityFilter.js';
 export {default as withResultOfAvailabilityCheck} from './withResultOfAvailabilityCheck.js';

--- a/src/data/composite/control-flow/withAvailabilityFilter.js
+++ b/src/data/composite/control-flow/withAvailabilityFilter.js
@@ -1,0 +1,40 @@
+// Performs the same availability check across all items of a list, providing
+// a list that's suitable anywhere a filter is expected.
+//
+// Accepts the same mode options as withResultOfAvailabilityCheck.
+//
+// See also:
+//  - withFilteredList
+//  - withResultOfAvailabilityCheck
+//
+
+import {input, templateCompositeFrom} from '#composite';
+
+import inputAvailabilityCheckMode from './inputAvailabilityCheckMode.js';
+
+import performAvailabilityCheck from './helpers/performAvailabilityCheck.js';
+
+export default templateCompositeFrom({
+  annotation: `withAvailabilityFilter`,
+
+  inputs: {
+    from: input({type: 'array'}),
+    mode: inputAvailabilityCheckMode(),
+  },
+
+  outputs: ['#availabilityFilter'],
+
+  steps: () => [
+    {
+      dependencies: [input('from'), input('mode')],
+      compute: (continuation, {
+        [input('from')]: list,
+        [input('mode')]: mode,
+      }) => continuation({
+        ['#availabilityFilter']:
+          list.map(value =>
+            performAvailabilityCheck(value, mode)),
+      }),
+    },
+  ],
+});

--- a/src/data/composite/control-flow/withResultOfAvailabilityCheck.js
+++ b/src/data/composite/control-flow/withResultOfAvailabilityCheck.js
@@ -23,9 +23,10 @@
 //
 
 import {input, templateCompositeFrom} from '#composite';
-import {empty} from '#sugar';
 
 import inputAvailabilityCheckMode from './inputAvailabilityCheckMode.js';
+
+import performAvailabilityCheck from './helpers/performAvailabilityCheck.js';
 
 export default templateCompositeFrom({
   annotation: `withResultOfAvailabilityCheck`,
@@ -40,33 +41,13 @@ export default templateCompositeFrom({
   steps: () => [
     {
       dependencies: [input('from'), input('mode')],
-
       compute: (continuation, {
         [input('from')]: value,
         [input('mode')]: mode,
-      }) => {
-        let availability;
-
-        switch (mode) {
-          case 'null':
-            availability = value !== undefined && value !== null;
-            break;
-
-          case 'empty':
-            availability = value !== undefined && !empty(value);
-            break;
-
-          case 'falsy':
-            availability = !!value && (!Array.isArray(value) || !empty(value));
-            break;
-
-          case 'index':
-            availability = typeof value === 'number' && value >= 0;
-            break;
-        }
-
-        return continuation({'#availability': availability});
-      },
+      }) => continuation({
+        ['#availability']:
+          performAvailabilityCheck(value, mode),
+      }),
     },
   ],
 });

--- a/src/data/composite/control-flow/withResultOfAvailabilityCheck.js
+++ b/src/data/composite/control-flow/withResultOfAvailabilityCheck.js
@@ -20,6 +20,7 @@
 //  - exposeWhetherDependencyAvailable
 //  - raiseOutputWithoutDependency
 //  - raiseOutputWithoutUpdateValue
+//  - withAvailabilityFilter
 //
 
 import {input, templateCompositeFrom} from '#composite';

--- a/src/data/composite/data/index.js
+++ b/src/data/composite/data/index.js
@@ -18,6 +18,7 @@ export {default as withUniqueItemsOnly} from './withUniqueItemsOnly.js';
 export {default as withFilteredList} from './withFilteredList.js';
 export {default as withMappedList} from './withMappedList.js';
 export {default as withSortedList} from './withSortedList.js';
+export {default as withStretchedList} from './withStretchedList.js';
 
 export {default as withPropertyFromList} from './withPropertyFromList.js';
 export {default as withPropertiesFromList} from './withPropertiesFromList.js';

--- a/src/data/composite/data/withFilteredList.js
+++ b/src/data/composite/data/withFilteredList.js
@@ -5,17 +5,11 @@
 // If the flip option is set, only items corresponding with a *falsy* value in
 // the filter are kept.
 //
-// TODO: It would be neat to apply an availability check here, e.g. to allow
-// not providing a filter at all and performing the check on the contents of
-// the list (though on the filter, if present, is fine too). But that's best
-// done by some shmancy-fancy mapping support in composite.js, so a bit out
-// of reach for now (apart from proving uses built on top of a more boring
-// implementation).
-//
 // TODO: There should be two outputs - one for the items included according to
 // the filter, and one for the items excluded.
 //
 // See also:
+//  - withAvailabilityFilter
 //  - withMappedList
 //  - withSortedList
 //

--- a/src/data/composite/data/withStretchedList.js
+++ b/src/data/composite/data/withStretchedList.js
@@ -1,0 +1,36 @@
+// Repeats each item in a list in-place by a corresponding length.
+
+import {input, templateCompositeFrom} from '#composite';
+import {repeat, stitchArrays} from '#sugar';
+import {isNumber, validateArrayItems} from '#validators';
+
+export default templateCompositeFrom({
+  annotation: `withStretchedList`,
+
+  inputs: {
+    list: input({type: 'array'}),
+
+    lengths: input({
+      validate: validateArrayItems(isNumber),
+    }),
+  },
+
+  outputs: ['#stretchedList'],
+
+  steps: () => [
+    {
+      dependencies: [input('list'), input('lengths')],
+      compute: (continuation, {
+        [input('list')]: list,
+        [input('lengths')]: lengths,
+      }) => continuation({
+        ['#stretchedList']:
+          stitchArrays({
+            item: list,
+            length: lengths,
+          }).map(({item, length}) => repeat(length, [item]))
+            .flat(),
+      }),
+    },
+  ],
+});

--- a/src/data/composite/wiki-data/index.js
+++ b/src/data/composite/wiki-data/index.js
@@ -19,6 +19,7 @@ export {default as withResolvedContribs} from './withResolvedContribs.js';
 export {default as withResolvedReference} from './withResolvedReference.js';
 export {default as withResolvedReferenceList} from './withResolvedReferenceList.js';
 export {default as withResolvedSeriesList} from './withResolvedSeriesList.js';
+export {default as withReverseAnnotatedReferenceList} from './withReverseAnnotatedReferenceList.js';
 export {default as withReverseContributionList} from './withReverseContributionList.js';
 export {default as withReverseReferenceList} from './withReverseReferenceList.js';
 export {default as withReverseSingleReferenceList} from './withReverseSingleReferenceList.js';

--- a/src/data/composite/wiki-data/index.js
+++ b/src/data/composite/wiki-data/index.js
@@ -5,6 +5,7 @@
 //
 
 export {default as exitWithoutContribs} from './exitWithoutContribs.js';
+export {default as inputNotFoundMode} from './inputNotFoundMode.js';
 export {default as inputWikiData} from './inputWikiData.js';
 export {default as withClonedThings} from './withClonedThings.js';
 export {default as withContributionListSums} from './withContributionListSums.js';

--- a/src/data/composite/wiki-data/index.js
+++ b/src/data/composite/wiki-data/index.js
@@ -14,7 +14,7 @@ export {default as withDirectory} from './withDirectory.js';
 export {default as withParsedCommentaryEntries} from './withParsedCommentaryEntries.js';
 export {default as withRecontextualizedContributionList} from './withRecontextualizedContributionList.js';
 export {default as withRedatedContributionList} from './withRedatedContributionList.js';
-export {default as withResolvedArtworkReferenceList} from './withResolvedArtworkReferenceList.js';
+export {default as withResolvedAnnotatedReferenceList} from './withResolvedAnnotatedReferenceList.js';
 export {default as withResolvedContribs} from './withResolvedContribs.js';
 export {default as withResolvedReference} from './withResolvedReference.js';
 export {default as withResolvedReferenceList} from './withResolvedReferenceList.js';

--- a/src/data/composite/wiki-data/inputNotFoundMode.js
+++ b/src/data/composite/wiki-data/inputNotFoundMode.js
@@ -1,0 +1,9 @@
+import {input} from '#composite';
+import {is} from '#validators';
+
+export default function inputNotFoundMode() {
+  return input({
+    validate: is('exit', 'filter', 'null'),
+    defaultValue: 'filter',
+  });
+}

--- a/src/data/composite/wiki-data/raiseResolvedReferenceList.js
+++ b/src/data/composite/wiki-data/raiseResolvedReferenceList.js
@@ -19,8 +19,6 @@ export default templateCompositeFrom({
     outputs: input.staticValue({type: 'string'}),
   },
 
-  // TODO: Is it even necessary to specify outputs if you're using
-  // raiseOutputAbove??
   outputs: ({
     [input.staticValue('outputs')]: outputs,
   }) => [outputs],

--- a/src/data/composite/wiki-data/raiseResolvedReferenceList.js
+++ b/src/data/composite/wiki-data/raiseResolvedReferenceList.js
@@ -1,0 +1,98 @@
+// Concludes compositions like withResolvedReferenceList, which share behavior
+// in processing the resolved results before continuing further.
+
+import {input, templateCompositeFrom} from '#composite';
+
+import {withFilteredList} from '#composite/data';
+
+import inputNotFoundMode from './inputNotFoundMode.js';
+
+export default templateCompositeFrom({
+  inputs: {
+    notFoundMode: inputNotFoundMode(),
+
+    results: input({type: 'array'}),
+    filter: input({type: 'array'}),
+
+    exitValue: input({defaultValue: []}),
+
+    outputs: input.staticValue({type: 'string'}),
+  },
+
+  // TODO: Is it even necessary to specify outputs if you're using
+  // raiseOutputAbove??
+  outputs: ({
+    [input.staticValue('outputs')]: outputs,
+  }) => [outputs],
+
+  steps: () => [
+    {
+      dependencies: [
+        input('results'),
+        input('filter'),
+        input('outputs'),
+      ],
+
+      compute: (continuation, {
+        [input('results')]: results,
+        [input('filter')]: filter,
+        [input('outputs')]: outputs,
+      }) =>
+        (filter.every(keep => keep)
+          ? continuation.raiseOutput({[outputs]: results})
+          : continuation()),
+    },
+
+    {
+      dependencies: [
+        input('notFoundMode'),
+        input('exitValue'),
+      ],
+
+      compute: (continuation, {
+        [input('notFoundMode')]: notFoundMode,
+        [input('exitValue')]: exitValue,
+      }) =>
+        (notFoundMode === 'exit'
+          ? continuation.exit(exitValue)
+          : continuation()),
+    },
+
+    {
+      dependencies: [
+        input('results'),
+        input('notFoundMode'),
+        input('outputs'),
+      ],
+
+      compute: (continuation, {
+        [input('results')]: results,
+        [input('notFoundMode')]: notFoundMode,
+        [input('outputs')]: outputs,
+      }) =>
+        (notFoundMode === 'null'
+          ? continuation.raiseOutput({[outputs]: results})
+          : continuation()),
+    },
+
+    withFilteredList({
+      list: input('results'),
+      filter: input('filter'),
+    }),
+
+    {
+      dependencies: [
+        '#filteredList',
+        input('outputs'),
+      ],
+
+      compute: (continuation, {
+        ['#filteredList']: filteredList,
+        [input('outputs')]: outputs,
+      }) => continuation({
+        [outputs]:
+          filteredList,
+      }),
+    },
+  ],
+});

--- a/src/data/composite/wiki-data/withResolvedAnnotatedReferenceList.js
+++ b/src/data/composite/wiki-data/withResolvedAnnotatedReferenceList.js
@@ -12,7 +12,7 @@ import raiseResolvedReferenceList from './raiseResolvedReferenceList.js';
 import withResolvedReferenceList from './withResolvedReferenceList.js';
 
 export default templateCompositeFrom({
-  annotation: `withResolvedArtworkReferenceList`,
+  annotation: `withResolvedAnnotatedReferenceList`,
 
   inputs: {
     list: input({
@@ -32,7 +32,7 @@ export default templateCompositeFrom({
     notFoundMode: inputNotFoundMode(),
   },
 
-  outputs: ['#resolvedArtworkReferenceList'],
+  outputs: ['#resolvedAnnotatedReferenceList'],
 
   steps: () => [
     withPropertiesFromList({
@@ -76,7 +76,7 @@ export default templateCompositeFrom({
       notFoundMode: input('notFoundMode'),
       results: '#matches',
       filter: '#availabilityFilter',
-      outputs: input.value('#resolvedArtworkReferenceList'),
+      outputs: input.value('#resolvedAnnotatedReferenceList'),
     }),
   ],
 })

--- a/src/data/composite/wiki-data/withResolvedAnnotatedReferenceList.js
+++ b/src/data/composite/wiki-data/withResolvedAnnotatedReferenceList.js
@@ -3,8 +3,13 @@ import {stitchArrays} from '#sugar';
 import {isString, optional, validateArrayItems, validateProperties}
   from '#validators';
 
-import {withAvailabilityFilter} from '#composite/control-flow';
 import {withPropertiesFromList} from '#composite/data';
+
+import {
+  exitWithoutDependency,
+  raiseOutputWithoutDependency,
+  withAvailabilityFilter,
+} from '#composite/control-flow';
 
 import inputNotFoundMode from './inputNotFoundMode.js';
 import inputWikiData from './inputWikiData.js';
@@ -35,6 +40,19 @@ export default templateCompositeFrom({
   outputs: ['#resolvedAnnotatedReferenceList'],
 
   steps: () => [
+    exitWithoutDependency({
+      dependency: input('data'),
+      value: input.value([]),
+    }),
+
+    raiseOutputWithoutDependency({
+      dependency: input('list'),
+      mode: input.value('empty'),
+      output: input.value({
+        ['#resolvedAnnotatedReferenceList']: [],
+      }),
+    }),
+
     withPropertiesFromList({
       list: input('list'),
       properties: input.value([

--- a/src/data/composite/wiki-data/withResolvedArtworkReferenceList.js
+++ b/src/data/composite/wiki-data/withResolvedArtworkReferenceList.js
@@ -3,11 +3,12 @@ import {stitchArrays} from '#sugar';
 import {isString, optional, validateArrayItems, validateProperties}
   from '#validators';
 
-import {withFilteredList, withMappedList, withPropertiesFromList}
-  from '#composite/data';
+import {withAvailabilityFilter} from '#composite/control-flow';
+import {withPropertiesFromList} from '#composite/data';
 
 import inputNotFoundMode from './inputNotFoundMode.js';
 import inputWikiData from './inputWikiData.js';
+import raiseResolvedReferenceList from './raiseResolvedReferenceList.js';
 import withResolvedReferenceList from './withResolvedReferenceList.js';
 
 export default templateCompositeFrom({
@@ -67,59 +68,15 @@ export default templateCompositeFrom({
       }),
     },
 
-    {
-      dependencies: ['#matches'],
-      compute: (continuation, {'#matches': matches}) =>
-        (matches.every(match => match)
-          ? continuation.raiseOutput({
-              ['#resolvedArtworkReferenceList']:
-                matches,
-            })
-          : continuation()),
-    },
-
-    {
-      dependencies: [input('notFoundMode')],
-      compute: (continuation, {
-        [input('notFoundMode')]: notFoundMode,
-      }) =>
-        (notFoundMode === 'exit'
-          ? continuation.exit([])
-          : continuation()),
-    },
-
-    {
-      dependencies: ['#matches', input('notFoundMode')],
-      compute: (continuation, {
-        ['#matches']: matches,
-        [input('notFoundMode')]: notFoundMode,
-      }) =>
-        (notFoundMode === 'null'
-          ? continuation.raiseOutput({
-              ['#resolvedArtworkReferenceList']:
-                matches,
-            })
-          : continuation()),
-    },
-
-    withMappedList({
-      list: '#resolvedReferenceList',
-      map: input.value(thing => thing !== null),
+    withAvailabilityFilter({
+      from: '#resolvedReferenceList',
     }),
 
-    withFilteredList({
-      list: '#matches',
-      filter: '#mappedList',
+    raiseResolvedReferenceList({
+      notFoundMode: input('notFoundMode'),
+      results: '#matches',
+      filter: '#availabilityFilter',
+      outputs: input.value('#resolvedArtworkReferenceList'),
     }),
-
-    {
-      dependencies: ['#filteredList'],
-      compute: (continuation, {
-        ['#filteredList']: filteredList,
-      }) => continuation({
-        ['#resolvedArtworkReferenceList']:
-          filteredList,
-      }),
-    },
   ],
 })

--- a/src/data/composite/wiki-data/withResolvedArtworkReferenceList.js
+++ b/src/data/composite/wiki-data/withResolvedArtworkReferenceList.js
@@ -1,11 +1,12 @@
 import {input, templateCompositeFrom} from '#composite';
 import {stitchArrays} from '#sugar';
-import {is, isString, optional, validateArrayItems, validateProperties}
+import {isString, optional, validateArrayItems, validateProperties}
   from '#validators';
 
 import {withFilteredList, withMappedList, withPropertiesFromList}
   from '#composite/data';
 
+import inputNotFoundMode from './inputNotFoundMode.js';
 import inputWikiData from './inputWikiData.js';
 import withResolvedReferenceList from './withResolvedReferenceList.js';
 
@@ -27,10 +28,7 @@ export default templateCompositeFrom({
     data: inputWikiData({allowMixedTypes: true}),
     find: input({type: 'function'}),
 
-    notFoundMode: input({
-      validate: is('exit', 'filter', 'null'),
-      defaultValue: 'filter',
-    }),
+    notFoundMode: inputNotFoundMode(),
   },
 
   outputs: ['#resolvedArtworkReferenceList'],

--- a/src/data/composite/wiki-data/withResolvedContribs.js
+++ b/src/data/composite/wiki-data/withResolvedContribs.js
@@ -8,10 +8,12 @@ import {input, templateCompositeFrom} from '#composite';
 import find from '#find';
 import {filterMultipleArrays, stitchArrays} from '#sugar';
 import thingConstructors from '#things';
-import {is, isContributionList, isDate, isStringNonEmpty} from '#validators';
+import {isContributionList, isDate, isStringNonEmpty} from '#validators';
 
 import {raiseOutputWithoutDependency} from '#composite/control-flow';
 import {withPropertiesFromList} from '#composite/data';
+
+import inputNotFoundMode from './inputNotFoundMode.js';
 
 export default templateCompositeFrom({
   annotation: `withResolvedContribs`,
@@ -27,10 +29,7 @@ export default templateCompositeFrom({
       acceptsNull: true,
     }),
 
-    notFoundMode: input({
-      validate: is('exit', 'filter', 'null'),
-      defaultValue: 'null',
-    }),
+    notFoundMode: inputNotFoundMode(),
 
     thingProperty: input({
       validate: isStringNonEmpty,

--- a/src/data/composite/wiki-data/withResolvedContribs.js
+++ b/src/data/composite/wiki-data/withResolvedContribs.js
@@ -5,15 +5,16 @@
 // any artist.
 
 import {input, templateCompositeFrom} from '#composite';
-import find from '#find';
 import {filterMultipleArrays, stitchArrays} from '#sugar';
 import thingConstructors from '#things';
 import {isContributionList, isDate, isStringNonEmpty} from '#validators';
 
-import {raiseOutputWithoutDependency} from '#composite/control-flow';
-import {withPropertiesFromList} from '#composite/data';
+import {raiseOutputWithoutDependency, withAvailabilityFilter}
+  from '#composite/control-flow';
+import {withPropertyFromList, withPropertiesFromList} from '#composite/data';
 
 import inputNotFoundMode from './inputNotFoundMode.js';
+import raiseResolvedReferenceList from './raiseResolvedReferenceList.js';
 
 export default templateCompositeFrom({
   annotation: `withResolvedContribs`,
@@ -133,16 +134,20 @@ export default templateCompositeFrom({
       }),
     },
 
-    {
-      dependencies: ['#contributions'],
+    withPropertyFromList({
+      list: '#contributions',
+      property: input.value('thing'),
+    }),
 
-      compute: (continuation, {
-        ['#contributions']: contributions,
-      }) => continuation({
-        ['#resolvedContribs']:
-          contributions
-            .filter(contrib => contrib.artist),
-      }),
-    },
+    withAvailabilityFilter({
+      from: '#contributions.thing',
+    }),
+
+    raiseResolvedReferenceList({
+      notFoundMode: input('notFoundMode'),
+      results: '#contributions',
+      filter: '#availabilityFilter',
+      outputs: input.value('#resolvedContribs'),
+    }),
   ],
 });

--- a/src/data/composite/wiki-data/withResolvedReferenceList.js
+++ b/src/data/composite/wiki-data/withResolvedReferenceList.js
@@ -5,13 +5,12 @@
 // to early exit ({notFoundMode: 'exit'}) or leave null in place ('null').
 
 import {input, templateCompositeFrom} from '#composite';
-import {is, isString, validateArrayItems} from '#validators';
+import {isString, validateArrayItems} from '#validators';
 
-import {
-  exitWithoutDependency,
-  raiseOutputWithoutDependency,
-} from '#composite/control-flow';
+import {exitWithoutDependency, raiseOutputWithoutDependency}
+  from '#composite/control-flow';
 
+import inputNotFoundMode from './inputNotFoundMode.js';
 import inputWikiData from './inputWikiData.js';
 
 export default templateCompositeFrom({
@@ -26,10 +25,7 @@ export default templateCompositeFrom({
     data: inputWikiData({allowMixedTypes: true}),
     find: input({type: 'function'}),
 
-    notFoundMode: input({
-      validate: is('exit', 'filter', 'null'),
-      defaultValue: 'filter',
-    }),
+    notFoundMode: inputNotFoundMode(),
   },
 
   outputs: ['#resolvedReferenceList'],

--- a/src/data/composite/wiki-data/withReverseAnnotatedReferenceList.js
+++ b/src/data/composite/wiki-data/withReverseAnnotatedReferenceList.js
@@ -1,0 +1,81 @@
+// Analogous implementation for withReverseReferenceList, for annotated
+// references.
+//
+// Unlike withReverseContributionList, this composition is responsible for
+// "flipping" the directionality of references: in a forward reference list,
+// `thing` points to the thing being referenced, while here, it points to the
+// referencing thing.
+
+import withReverseList_template from './helpers/withReverseList-template.js';
+
+import {input} from '#composite';
+import {stitchArrays} from '#sugar';
+
+import {
+  withFlattenedList,
+  withMappedList,
+  withPropertyFromList,
+  withStretchedList,
+} from '#composite/data';
+
+export default withReverseList_template({
+  annotation: `withReverseAnnotatedReferenceList`,
+
+  propertyInputName: 'list',
+  outputName: '#reverseAnnotatedReferenceList',
+
+  customCompositionSteps: () => [
+    withPropertyFromList({
+      list: input('data'),
+      property: input('list'),
+    }).outputs({
+      '#values': '#referenceLists',
+    }),
+
+    withPropertyFromList({
+      list: '#referenceLists',
+      property: input.value('length'),
+    }),
+
+    withFlattenedList({
+      list: '#referenceLists',
+    }).outputs({
+      '#flattenedList': '#references',
+    }),
+
+    withStretchedList({
+      list: input('data'),
+      lengths: '#referenceLists.length',
+    }).outputs({
+      '#stretchedList': '#things',
+    }),
+
+    withPropertyFromList({
+      list: '#references',
+      property: input.value('annotation'),
+    }).outputs({
+      '#references.annotation': '#annotations',
+    }),
+
+    {
+      dependencies: ['#things', '#annotations'],
+      compute: (continuation, {
+        ['#things']: things,
+        ['#annotations']: annotations,
+      }) => continuation({
+        ['#referencingThings']:
+          stitchArrays({
+            thing: things,
+            annotation: annotations,
+          }),
+      }),
+    },
+
+    withMappedList({
+      list: '#references',
+      map: input.value(reference => [reference.thing]),
+    }).outputs({
+      '#mappedList': '#referencedThings',
+    }),
+  ],
+});

--- a/src/data/composite/wiki-data/withReverseContributionList.js
+++ b/src/data/composite/wiki-data/withReverseContributionList.js
@@ -4,7 +4,8 @@ import withReverseList_template from './helpers/withReverseList-template.js';
 
 import {input} from '#composite';
 
-import {withFlattenedList, withMappedList} from '#composite/data';
+import {withFlattenedList, withMappedList, withPropertyFromList}
+  from '#composite/data';
 
 export default withReverseList_template({
   annotation: `withReverseContributionList`,
@@ -13,21 +14,11 @@ export default withReverseList_template({
   outputName: '#reverseContributionList',
 
   customCompositionSteps: () => [
-    {
-      dependencies: [input('list')],
-      compute: (continuation, {
-        [input('list')]: list,
-      }) => continuation({
-        ['#contributionListMap']:
-          thing => thing[list],
-      }),
-    },
-
-    withMappedList({
+    withPropertyFromList({
       list: input('data'),
-      map: '#contributionListMap',
+      property: input('list'),
     }).outputs({
-      '#mappedList': '#contributionLists',
+      '#values': '#contributionLists',
     }),
 
     withFlattenedList({

--- a/src/data/composite/wiki-properties/annotatedReferenceList.js
+++ b/src/data/composite/wiki-properties/annotatedReferenceList.js
@@ -1,23 +1,17 @@
-// Stores and exposes a list of references to other data objects; all items
-// must be references to the same type, which is either implied from the class
-// input, or explicitly set on the referenceType input.
-//
-// See also:
-//  - singleReference
-//  - withResolvedReferenceList
-//
-
 import {input, templateCompositeFrom} from '#composite';
-import {validateReferenceList} from '#validators';
+import find from '#find';
+import {validateAnnotatedReferenceList} from '#validators';
+import {combineWikiDataArrays} from '#wiki-data';
 
 import {exposeDependency} from '#composite/control-flow';
-import {inputWikiData, withResolvedReferenceList} from '#composite/wiki-data';
+import {inputWikiData, withResolvedAnnotatedReferenceList}
+  from '#composite/wiki-data';
 
 import {referenceListInputDescriptions, referenceListUpdateDescription}
   from './helpers/reference-list-helpers.js';
 
 export default templateCompositeFrom({
-  annotation: `referenceList`,
+  annotation: `referencedArtworkList`,
 
   compose: false,
 
@@ -30,16 +24,16 @@ export default templateCompositeFrom({
 
   update:
     referenceListUpdateDescription({
-      validateReferenceList: validateReferenceList,
+      validateReferenceList: validateAnnotatedReferenceList,
     }),
 
   steps: () => [
-    withResolvedReferenceList({
+    withResolvedAnnotatedReferenceList({
       list: input.updateValue(),
       data: input('data'),
       find: input('find'),
     }),
 
-    exposeDependency({dependency: '#resolvedReferenceList'}),
+    exposeDependency({dependency: '#resolvedAnnotatedReferenceList'}),
   ],
 });

--- a/src/data/composite/wiki-properties/helpers/reference-list-helpers.js
+++ b/src/data/composite/wiki-properties/helpers/reference-list-helpers.js
@@ -1,0 +1,44 @@
+import {input} from '#composite';
+import {anyOf, isString, isThingClass, validateArrayItems} from '#validators';
+
+export function referenceListInputDescriptions() {
+  return {
+    class: input.staticValue({
+      validate:
+        anyOf(
+          isThingClass,
+          validateArrayItems(isThingClass)),
+
+      acceptsNull: true,
+      defaultValue: null,
+    }),
+
+    referenceType: input.staticValue({
+      validate:
+        anyOf(
+          isString,
+          validateArrayItems(isString)),
+
+      acceptsNull: true,
+      defaultValue: null,
+    }),
+  };
+}
+
+export function referenceListUpdateDescription({
+  validateReferenceList,
+}) {
+  return ({
+    [input.staticValue('class')]: thingClass,
+    [input.staticValue('referenceType')]: referenceType,
+  }) => ({
+    validate:
+      validateReferenceList(
+        (Array.isArray(thingClass)
+          ? thingClass.map(thingClass =>
+              thingClass[Symbol.for('Thing.referenceType')])
+       : thingClass
+          ? thingClass[Symbol.for('Thing.referenceType')]
+          : referenceType)),
+  });
+}

--- a/src/data/composite/wiki-properties/index.js
+++ b/src/data/composite/wiki-properties/index.js
@@ -5,6 +5,7 @@
 
 export {default as additionalFiles} from './additionalFiles.js';
 export {default as additionalNameList} from './additionalNameList.js';
+export {default as annotatedReferenceList} from './annotatedReferenceList.js';
 export {default as color} from './color.js';
 export {default as commentary} from './commentary.js';
 export {default as commentatorArtists} from './commentatorArtists.js';

--- a/src/data/composite/wiki-properties/index.js
+++ b/src/data/composite/wiki-properties/index.js
@@ -21,6 +21,7 @@ export {default as flag} from './flag.js';
 export {default as name} from './name.js';
 export {default as referenceList} from './referenceList.js';
 export {default as referencedArtworkList} from './referencedArtworkList.js';
+export {default as reverseAnnotatedReferenceList} from './reverseAnnotatedReferenceList.js';
 export {default as reverseContributionList} from './reverseContributionList.js';
 export {default as reverseReferenceList} from './reverseReferenceList.js';
 export {default as reverseSingleReferenceList} from './reverseSingleReferenceList.js';

--- a/src/data/composite/wiki-properties/referencedArtworkList.js
+++ b/src/data/composite/wiki-properties/referencedArtworkList.js
@@ -4,18 +4,15 @@ import {validateAnnotatedReferenceList} from '#validators';
 import {combineWikiDataArrays} from '#wiki-data';
 
 import {exposeDependency} from '#composite/control-flow';
-import {withResolvedArtworkReferenceList} from '#composite/wiki-data';
+import {withResolvedAnnotatedReferenceList} from '#composite/wiki-data';
 
 export default templateCompositeFrom({
   annotation: `referencedArtworkList`,
 
-  update: ({
-    [input.staticValue('class')]: thingClass,
-    [input.staticValue('referenceType')]: referenceType,
-  }) => ({
+  update: {
     validate:
       validateAnnotatedReferenceList(['album', 'track']),
-  }),
+  },
 
   steps: () => [
     {
@@ -46,12 +43,12 @@ export default templateCompositeFrom({
       }),
     },
 
-    withResolvedArtworkReferenceList({
+    withResolvedAnnotatedReferenceList({
       list: input.updateValue(),
       data: '#data',
       find: '#find',
     }),
 
-    exposeDependency({dependency: '#resolvedArtworkReferenceList'}),
+    exposeDependency({dependency: '#resolvedAnnotatedReferenceList'}),
   ],
 });

--- a/src/data/composite/wiki-properties/referencedArtworkList.js
+++ b/src/data/composite/wiki-properties/referencedArtworkList.js
@@ -1,18 +1,13 @@
 import {input, templateCompositeFrom} from '#composite';
 import find from '#find';
-import {validateAnnotatedReferenceList} from '#validators';
 import {combineWikiDataArrays} from '#wiki-data';
 
-import {exposeDependency} from '#composite/control-flow';
-import {withResolvedAnnotatedReferenceList} from '#composite/wiki-data';
+import annotatedReferenceList from './annotatedReferenceList.js';
 
 export default templateCompositeFrom({
   annotation: `referencedArtworkList`,
 
-  update: {
-    validate:
-      validateAnnotatedReferenceList(['album', 'track']),
-  },
+  compose: false,
 
   steps: () => [
     {
@@ -43,12 +38,10 @@ export default templateCompositeFrom({
       }),
     },
 
-    withResolvedAnnotatedReferenceList({
-      list: input.updateValue(),
+    annotatedReferenceList({
+      referenceType: input.value(['album', 'track']),
       data: '#data',
       find: '#find',
     }),
-
-    exposeDependency({dependency: '#resolvedAnnotatedReferenceList'}),
   ],
 });

--- a/src/data/composite/wiki-properties/reverseAnnotatedReferenceList.js
+++ b/src/data/composite/wiki-properties/reverseAnnotatedReferenceList.js
@@ -1,0 +1,25 @@
+import {input, templateCompositeFrom} from '#composite';
+
+import {exposeDependency} from '#composite/control-flow';
+import {inputWikiData, withReverseAnnotatedReferenceList}
+  from '#composite/wiki-data';
+
+export default templateCompositeFrom({
+  annotation: `reverseAnnotatedReferenceList`,
+
+  compose: false,
+
+  inputs: {
+    data: inputWikiData({allowMixedTypes: false}),
+    list: input({type: 'string'}),
+  },
+
+  steps: () => [
+    withReverseAnnotatedReferenceList({
+      data: input('data'),
+      list: input('list'),
+    }),
+
+    exposeDependency({dependency: '#reverseAnnotatedReferenceList'}),
+  ],
+});

--- a/src/data/things/album.js
+++ b/src/data/things/album.js
@@ -16,10 +16,10 @@ import {isColor, isDate, isDirectory, validateWikiData} from '#validators';
 import {
   parseAdditionalFiles,
   parseAdditionalNames,
+  parseAnnotatedReferences,
   parseContributors,
   parseDate,
   parseDimensions,
-  parseReferencedArtworks,
 } from '#yaml';
 
 import {exitWithoutDependency, exposeDependency, exposeUpdateValueOrContinue}
@@ -414,7 +414,7 @@ export class Album extends Thing {
 
       'Referenced Artworks': {
         property: 'referencedArtworks',
-        transform: parseReferencedArtworks,
+        transform: parseAnnotatedReferences,
       },
 
       'Franchises': {ignore: true},

--- a/src/data/things/artist.js
+++ b/src/data/things/artist.js
@@ -21,6 +21,7 @@ import {
   fileExtension,
   flag,
   name,
+  reverseAnnotatedReferenceList,
   reverseContributionList,
   reverseReferenceList,
   singleReference,
@@ -139,7 +140,7 @@ export class Artist extends Thing {
       list: input.value('commentatorArtists'),
     }),
 
-    closelyLinkedGroups: reverseReferenceList({
+    closelyLinkedGroups: reverseAnnotatedReferenceList({
       data: 'groupData',
       list: input.value('closelyLinkedArtists'),
     }),

--- a/src/data/things/artist.js
+++ b/src/data/things/artist.js
@@ -34,7 +34,7 @@ export class Artist extends Thing {
   static [Thing.referenceType] = 'artist';
   static [Thing.wikiDataArray] = 'artistData';
 
-  static [Thing.getPropertyDescriptors] = ({Album, Flash, Track}) => ({
+  static [Thing.getPropertyDescriptors] = ({Album, Flash, Group, Track}) => ({
     // Update & expose
 
     name: name('Unnamed Artist'),
@@ -72,6 +72,10 @@ export class Artist extends Thing {
 
     flashData: wikiData({
       class: input.value(Flash),
+    }),
+
+    groupData: wikiData({
+      class: input.value(Group),
     }),
 
     trackData: wikiData({
@@ -133,6 +137,11 @@ export class Artist extends Thing {
     flashesAsCommentator: reverseReferenceList({
       data: 'flashData',
       list: input.value('commentatorArtists'),
+    }),
+
+    closelyLinkedGroups: reverseReferenceList({
+      data: 'groupData',
+      list: input.value('closelyLinkedArtists'),
     }),
 
     totalDuration: artistTotalDuration(),

--- a/src/data/things/group.js
+++ b/src/data/things/group.js
@@ -3,9 +3,10 @@ export const GROUP_DATA_FILE = 'groups.yaml';
 import {input} from '#composite';
 import find from '#find';
 import Thing from '#thing';
-import {parseSerieses} from '#yaml';
+import {parseAnnotatedReferences, parseSerieses} from '#yaml';
 
 import {
+  annotatedReferenceList,
   color,
   contentString,
   directory,
@@ -29,7 +30,7 @@ export class Group extends Thing {
 
     urls: urls(),
 
-    closelyLinkedArtists: referenceList({
+    closelyLinkedArtists: annotatedReferenceList({
       class: input.value(Artist),
       find: input.value(find.artist),
       data: 'artistData',
@@ -120,7 +121,10 @@ export class Group extends Thing {
       'Description': {property: 'description'},
       'URLs': {property: 'urls'},
 
-      'Closely Linked Artists': {property: 'closelyLinkedArtists'},
+      'Closely Linked Artists': {
+        property: 'closelyLinkedArtists',
+        transform: parseAnnotatedReferences,
+      },
 
       'Featured Albums': {property: 'featuredAlbums'},
 

--- a/src/data/things/group.js
+++ b/src/data/things/group.js
@@ -19,7 +19,7 @@ import {
 export class Group extends Thing {
   static [Thing.referenceType] = 'group';
 
-  static [Thing.getPropertyDescriptors] = ({Album}) => ({
+  static [Thing.getPropertyDescriptors] = ({Album, Artist}) => ({
     // Update & expose
 
     name: name('Unnamed Group'),
@@ -28,6 +28,12 @@ export class Group extends Thing {
     description: contentString(),
 
     urls: urls(),
+
+    closelyLinkedArtists: referenceList({
+      class: input.value(Artist),
+      find: input.value(find.artist),
+      data: 'artistData',
+    }),
 
     featuredAlbums: referenceList({
       class: input.value(Album),
@@ -43,6 +49,10 @@ export class Group extends Thing {
 
     albumData: wikiData({
       class: input.value(Album),
+    }),
+
+    artistData: wikiData({
+      class: input.value(Artist),
     }),
 
     groupCategoryData: wikiData({
@@ -109,6 +119,8 @@ export class Group extends Thing {
       'Directory': {property: 'directory'},
       'Description': {property: 'description'},
       'URLs': {property: 'urls'},
+
+      'Closely Linked Artists': {property: 'closelyLinkedArtists'},
 
       'Featured Albums': {property: 'featuredAlbums'},
 

--- a/src/data/things/track.js
+++ b/src/data/things/track.js
@@ -11,11 +11,11 @@ import {isBoolean, isColor, isContributionList, isDate, isFileExtension}
 import {
   parseAdditionalFiles,
   parseAdditionalNames,
+  parseAnnotatedReferences,
   parseContributors,
   parseDate,
   parseDimensions,
   parseDuration,
-  parseReferencedArtworks,
 } from '#yaml';
 
 import {withPropertyFromObject} from '#composite/data';
@@ -526,7 +526,7 @@ export class Track extends Thing {
 
       'Referenced Artworks': {
         property: 'referencedArtworks',
-        transform: parseReferencedArtworks,
+        transform: parseAnnotatedReferences,
       },
 
       'Franchises': {ignore: true},

--- a/src/data/yaml.js
+++ b/src/data/yaml.js
@@ -1224,6 +1224,7 @@ export function linkWikiDataArrays(wikiData) {
       'albumData',
       'artistData',
       'flashData',
+      'groupData',
       'trackData',
     ]],
 
@@ -1245,6 +1246,7 @@ export function linkWikiDataArrays(wikiData) {
 
     [wikiData.groupData, [
       'albumData',
+      'artistData',
       'groupCategoryData',
     ]],
 

--- a/src/data/yaml.js
+++ b/src/data/yaml.js
@@ -569,7 +569,7 @@ export function parseContributionPresets(list) {
   });
 }
 
-export function parseReferencedArtworks(entries) {
+export function parseAnnotatedReferences(entries) {
   return parseArrayEntries(entries, item => {
     if (typeof item === 'object' && item['References'])
       return {

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -1077,6 +1077,10 @@ artistPage:
     one: "This artist has a group page: {GROUP}."
     multiple: "This artist has group pages: {GROUPS}."
 
+    group:
+      _: "{GROUP}"
+      withAnnotation: "{GROUP} ({ANNOTATION})"
+
   creditList:
 
     # album:
@@ -1313,6 +1317,10 @@ groupInfoPage:
   closelyLinkedArtists:
     one: "View artist page: {ARTIST}."
     multiple: "View artist pages: {ARTISTS}."
+
+    artist:
+      _: "{ARTIST}"
+      withAnnotation: "{ARTIST} ({ANNOTATION})"
 
   viewAlbumGallery:
     _: >-

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -1073,6 +1073,10 @@ artistPage:
   nav:
     artist: "Artist: {ARTIST}"
 
+  closelyLinkedGroups:
+    one: "This artist has a group page: {GROUP}."
+    multiple: "This artist has group pages: {GROUPS}."
+
   creditList:
 
     # album:
@@ -1305,6 +1309,10 @@ groupPage:
 #
 groupInfoPage:
   title: "{GROUP}"
+
+  closelyLinkedArtists:
+    one: "View artist page: {ARTIST}."
+    multiple: "View artist pages: {ARTISTS}."
 
   viewAlbumGallery:
     _: >-

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -1081,6 +1081,8 @@ artistPage:
       _: "{GROUP}"
       withAnnotation: "{GROUP} ({ANNOTATION})"
 
+    alias: "This artist is an alias of {GROUPS}."
+
   creditList:
 
     # album:
@@ -1317,6 +1319,8 @@ groupInfoPage:
   closelyLinkedArtists:
     one: "View artist page: {ARTIST}."
     multiple: "View artist pages: {ARTISTS}."
+
+    aliases: "View alias pages: {ALIASES}."
 
     artist:
       _: "{ARTIST}"


### PR DESCRIPTION
Adds a new field to groups, `Closely Linked Artists`, which shows at the top of the group's info page:

> <img width="435" alt="Xszelor's group info page, with a new paragraph reading: 'View artist page: Xszelor. (line break) View alias pages: Dvojka, Highblood, and Realmite.' The links are colored blue, instead of orange, differentiating from other generic links on this page." src="https://github.com/user-attachments/assets/d4da0de3-c4ec-499a-875e-8aa4ebcf578e">

A backlink to the group also shows on the corresponding artist pages:

> <img width="371" alt="Highblood's artist page. The short existing 'Notes' section is missing, and replaced by a short line linking to the group page: 'This artist is an alias of Xszelor.'" src="https://github.com/user-attachments/assets/9d1bc520-16d5-4ebb-ba6a-91a9bfb6208f">
>
> <img width="671" alt="Xszelor's artist page. The context notes still link to the usual pages, but there is also a line beneath linking to the group: 'This artist has a group page: Xszelor.'" src="https://github.com/user-attachments/assets/cf2ba66d-82d4-4708-a1e8-72e43f6f4e22">

Closely Linked Artists is an annotated reference list—a new basic data structure. The "alias" annotation gets a custom presentation, following along #550 and #568.

The implementation for annotated reference lists mostly stems from annotated artwork reference lists (no PR), which are now coded in terms annotated reference lists. This PR however introduces reverse annotated reference lists. It also factors out some code common in forward reference lists, and introduces related handy data utilities.

* `inputNotFoundMode`: Now a utility function (ala `inputWikiData`), instead of hard-coded for each use.
* `raiseResolvedReferenceList`: Now a composition of its own, factoring out behavior related to applying a specified `notFoundMode`. This is sufficiently generic for use in all forward reference lists (and similar data). It's also a bit nicer of an implementation compared to the existing code in `withResolvedReferenceList`.
    * Rather than check non-nullness of results itself, this takes a `filter` input, which (of course) may be computed separately from the `results` input where relevant.
* `performAvailabilityCheck`: Now a standalone utility function. Only accessible as a helper in `#composite/control-flow`.
* `withAvailabilityFilter`: New control-flow compositional step. This is just like `withResultOfAvailabilityCheck` (which underlies many control flow steps), but operates on a data list. It's typically more useful as a compositional step, combining nicely with `withFilteredList` and anything that takes a filter as an input—including `raiseResolvedReferenceList`.
* `referenceListInputDescriptions` and `referenceListUpdateDescription`: Now utility functions, bundled together in a `reference-list-helpers.js` helper. These are closely related and responsible together for conveniently building the custom `update` descriptions that reference lists use.
    * These newly include support for providing multiple classes or reference types (as in mixed reference lists), and reflecting those in the update description.
    * These are relevant to reference list *property* compositions (`#composite/wiki-properties`), not `withResolved...` compositions (`#composite/wiki-data`).
* `annotatedReferenceList` and `withResolvedAnnotatedReferenceList`: Like normal reference lists, but with an `annotation` property for each item. At the moment the reference itself is always specified in a `reference` property, and exposed (transformed) in `thing`.
    * Implementation derives from `referencedArtworkList`, which is now in terms of this, and still includes the relevant `find.mixed` / `combineWikiDataArrays` stuff.
* `reverseAnnotatedReferenceList` and `withReverseAnnotatedReferenceList`: The usual. Spiritually these are similar to reverse contribution lists, because they're reversing based on a property, but they are also responsible for flipping the directionality of the reference: `thing` points forward in a forward list, backward in a reverse list.
    * We might change this to align with contribution lists, where every in-between node points in both directions and is identity/value-equal whether you found it forwards or backwards. For now we're letting these differently shaped data structures coexist, though.
* `withStretchedList`: New generic data composition that underlies the flipping behavior in reverse annotated reference lists. It repeats each item in a list by a corresponding length.