### PR TITLE
Drop searching

### DIFF
--- a/src/static/js/client/dragged-link.js
+++ b/src/static/js/client/dragged-link.js
@@ -1,0 +1,62 @@
+/* eslint-env browser */
+
+export const info = {
+  id: `draggedLinkInfo`,
+
+  state: {
+    latestDraggedLink: null,
+    observedLinks: new WeakSet(),
+  },
+};
+
+export function getPageReferences() {
+  // First start handling all the links that currently exist.
+
+  for (const a of document.getElementsByTagName('a')) {
+    observeLink(a);
+    addDragListener(a);
+  }
+
+  // Then add a mutation observer to track new links.
+
+  const observer = new MutationObserver(records => {
+    for (const record of records) {
+      for (const node of record.addedNodes) {
+        if (node.nodeName !== 'A') continue;
+        observeLink(node);
+      }
+    }
+  });
+
+  observer.observe(document.body, {
+    subtree: true,
+    childList: true,
+  });
+}
+
+export function getLatestDraggedLink() {
+  const {state} = info;
+
+  if (state.latestDraggedLink) {
+    return state.latestDraggedLink.deref() ?? null;
+  } else {
+    return null;
+  }
+}
+
+function observeLink(link) {
+  const {state} = info;
+
+  if (state.observedLinks.has(link)) return;
+
+  state.observedLinks.add(link);
+  addDragListener(link);
+}
+
+function addDragListener(link) {
+  const {state} = info;
+
+  link.addEventListener('dragstart', _domEvent => {
+    state.latestDraggedLink = new WeakRef(link);
+  });
+}

--- a/src/static/js/client/index.js
+++ b/src/static/js/client/index.js
@@ -7,6 +7,7 @@ import * as albumCommentarySidebarModule from './album-commentary-sidebar.js';
 import * as artistExternalLinkTooltipModule from './artist-external-link-tooltip.js';
 import * as cssCompatibilityAssistantModule from './css-compatibility-assistant.js';
 import * as datetimestampTooltipModule from './datetimestamp-tooltip.js';
+import * as draggedLinkModule from './dragged-link.js';
 import * as hashLinkModule from './hash-link.js';
 import * as hoverableTooltipModule from './hoverable-tooltip.js';
 import * as imageOverlayModule from './image-overlay.js';
@@ -26,6 +27,7 @@ export const modules = [
   artistExternalLinkTooltipModule,
   cssCompatibilityAssistantModule,
   datetimestampTooltipModule,
+  draggedLinkModule,
   hashLinkModule,
   hoverableTooltipModule,
   imageOverlayModule,


### PR DESCRIPTION
Lets you drop stuff into the search input.

* A search is immediately performed with the query that the code figures out from what you dropped (replacing whatever was in the search input previously).
* If you just dropped some ordinary text, that text is the query.
* If you dropped a URL and that URL comes from the last `<a>` element you started dragging, the text of the `<a>` is the query.
* Otherwise if you dropped a URL then that URL is the query (and you probably won't get any useful results, sorry).

The previous behavior was the browser default, which is just to insert the grabbed text in-place (not replacing the contents of the input), and is basically useless (for a search input).