### PR TITLE
Album commentary stub pages + secondary nav!

### DIFF
--- a/src/content/dependencies/generateAlbumCommentaryPage.js
+++ b/src/content/dependencies/generateAlbumCommentaryPage.js
@@ -146,14 +146,24 @@ export default {
         mainClasses: ['long-content'],
         mainContent: [
           html.tag('p',
-            language.$(pageCapsule, 'infoLine', {
-              words:
-                html.tag('b',
-                  language.formatWordCount(data.wordCount, {unit: true})),
+            language.encapsulate(pageCapsule, 'infoLine', workingCapsule => {
+              const workingOptions = {};
 
-              entries:
-                html.tag('b',
-                  language.countCommentaryEntries(data.entryCount, {unit: true})),
+              if (data.entryCount >= 1) {
+                workingOptions.words =
+                  html.tag('b',
+                    language.formatWordCount(data.wordCount, {unit: true}));
+
+                workingOptions.entries =
+                  html.tag('b',
+                    language.countCommentaryEntries(data.entryCount, {unit: true}));
+              }
+
+              if (data.entryCount === 0) {
+                workingCapsule += '.withoutCommentary';
+              }
+
+              return language.$(workingCapsule, workingOptions);
             })),
 
           relations.albumCommentaryEntries &&

--- a/src/content/dependencies/generateAlbumCommentaryPage.js
+++ b/src/content/dependencies/generateAlbumCommentaryPage.js
@@ -5,6 +5,7 @@ export default {
     'generateAlbumCommentarySidebar',
     'generateAlbumCoverArtwork',
     'generateAlbumNavAccent',
+    'generateAlbumSecondaryNav',
     'generateAlbumStyleRules',
     'generateCommentaryEntry',
     'generateContentHeading',
@@ -22,6 +23,9 @@ export default {
 
     relations.layout =
       relation('generatePageLayout');
+
+    relations.secondaryNav =
+      relation('generateAlbumSecondaryNav', album);
 
     relations.sidebar =
       relation('generateAlbumCommentarySidebar', album);
@@ -264,6 +268,11 @@ export default {
               }),
           },
         ],
+
+        secondaryNav:
+          relations.secondaryNav.slots({
+            alwaysVisible: true,
+          }),
 
         leftSidebar: relations.sidebar,
       })),

--- a/src/content/dependencies/generateAlbumCommentaryPage.js
+++ b/src/content/dependencies/generateAlbumCommentaryPage.js
@@ -97,6 +97,7 @@ export default {
 
     data.name = album.name;
     data.color = album.color;
+    data.date = album.date;
 
     const tracksWithCommentary =
       album.tracks
@@ -150,25 +151,37 @@ export default {
         mainClasses: ['long-content'],
         mainContent: [
           html.tag('p',
-            language.encapsulate(pageCapsule, 'infoLine', workingCapsule => {
-              const workingOptions = {};
+            {[html.joinChildren]: html.tag('br')},
 
-              if (data.entryCount >= 1) {
-                workingOptions.words =
-                  html.tag('b',
-                    language.formatWordCount(data.wordCount, {unit: true}));
+            [
+              data.date &&
+              data.entryCount >= 1 &&
+                language.$('releaseInfo.albumReleased', {
+                  date:
+                    html.tag('b',
+                      language.formatDate(data.date)),
+                }),
 
-                workingOptions.entries =
-                  html.tag('b',
-                    language.countCommentaryEntries(data.entryCount, {unit: true}));
-              }
+              language.encapsulate(pageCapsule, 'infoLine', workingCapsule => {
+                const workingOptions = {};
 
-              if (data.entryCount === 0) {
-                workingCapsule += '.withoutCommentary';
-              }
+                if (data.entryCount >= 1) {
+                  workingOptions.words =
+                    html.tag('b',
+                      language.formatWordCount(data.wordCount, {unit: true}));
 
-              return language.$(workingCapsule, workingOptions);
-            })),
+                  workingOptions.entries =
+                    html.tag('b',
+                      language.countCommentaryEntries(data.entryCount, {unit: true}));
+                }
+
+                if (data.entryCount === 0) {
+                  workingCapsule += '.withoutCommentary';
+                }
+
+                return language.$(workingCapsule, workingOptions);
+              })
+            ]),
 
           relations.albumCommentaryEntries &&
             language.encapsulate(pageCapsule, 'entry', entryCapsule => [

--- a/src/content/dependencies/generateAlbumCommentaryPage.js
+++ b/src/content/dependencies/generateAlbumCommentaryPage.js
@@ -121,6 +121,10 @@ export default {
         .split(' ')
         .length;
 
+    data.trackCommentaryTrackDates =
+      tracksWithCommentary
+        .map(track => track.dateFirstReleased);
+
     data.trackCommentaryDirectories =
       tracksWithCommentary
         .map(track => track.directory);
@@ -228,6 +232,7 @@ export default {
             cover: relations.trackCommentaryCovers,
             entries: relations.trackCommentaryEntries,
             color: data.trackCommentaryColors,
+            trackDate: data.trackCommentaryTrackDates,
           }).map(({
               heading,
               link,
@@ -236,6 +241,7 @@ export default {
               cover,
               entries,
               color,
+              trackDate,
             }) =>
               language.encapsulate(pageCapsule, 'entry', entryCapsule => [
                 language.encapsulate(entryCapsule, 'title.trackCommentary', titleCapsule =>
@@ -260,6 +266,13 @@ export default {
                   })),
 
               cover?.slots({mode: 'commentary'}),
+
+              trackDate &&
+              trackDate !== data.date &&
+                html.tag('p', {class: 'track-info'},
+                  language.$('releaseInfo.trackReleased', {
+                    date: language.formatDate(trackDate),
+                  })),
 
               entries.map(entry => entry.slot('color', color)),
             ])),

--- a/src/content/dependencies/generateAlbumCommentarySidebar.js
+++ b/src/content/dependencies/generateAlbumCommentarySidebar.js
@@ -6,7 +6,7 @@ export default {
     'linkAlbum',
   ],
 
-  extraDependencies: ['html'],
+  extraDependencies: ['html', 'language'],
 
   relations: (relation, album) => ({
     sidebar:
@@ -26,22 +26,46 @@ export default {
           trackSection)),
   }),
 
-  generate: (relations, {html}) =>
-    relations.sidebar.slots({
-      stickyMode: 'column',
-      boxes: [
-        relations.sidebarBox.slots({
-          attributes: {class: 'commentary-track-list-sidebar-box'},
-          content: [
-            html.tag('h1', relations.albumLink),
-            relations.trackSections.map(section =>
-              section.slots({
-                anchor: true,
-                open: true,
-                mode: 'commentary',
-              })),
-          ],
-        }),
-      ]
-    }),
+  data: (album) => ({
+    albumHasCommentary:
+      !!album.commentary,
+
+    anyTrackHasCommentary:
+      album.tracks.some(track => track.commentary),
+  }),
+
+  generate: (data, relations, {html, language}) =>
+    language.encapsulate('albumCommentaryPage', pageCapsule =>
+      relations.sidebar.slots({
+        stickyMode: 'column',
+        boxes: [
+          relations.sidebarBox.slots({
+            attributes: {class: 'commentary-track-list-sidebar-box'},
+            content: [
+              html.tag('h1', relations.albumLink),
+
+              html.tag('p', {[html.onlyIfContent]: true},
+                language.encapsulate(pageCapsule, 'sidebar', workingCapsule => {
+                  if (data.anyTrackHasCommentary) return html.blank();
+
+                  if (data.albumHasCommentary) {
+                    workingCapsule += '.noTrackCommentary';
+                  } else {
+                    workingCapsule += '.noCommentary';
+                  }
+
+                  return language.$(workingCapsule);
+                })),
+
+              data.anyTrackHasCommentary &&
+                relations.trackSections.map(section =>
+                  section.slots({
+                    anchor: true,
+                    open: true,
+                    mode: 'commentary',
+                  })),
+            ],
+          }),
+        ]
+      })),
 }

--- a/src/content/dependencies/generateAlbumNavAccent.js
+++ b/src/content/dependencies/generateAlbumNavAccent.js
@@ -30,10 +30,6 @@ export default {
         ? atOffset(album.tracks, index, +1)
         : null);
 
-    query.albumHasAnyCommentary =
-      !!(album.commentary ||
-         album.tracks.some(t => t.commentary));
-
     return query;
   },
 
@@ -61,14 +57,16 @@ export default {
       relation('linkAlbumGallery', album),
 
     albumCommentaryLink:
-      (query.albumHasAnyCommentary
-        ? relation('linkAlbumCommentary', album)
-        : null),
+      relation('linkAlbumCommentary', album),
   }),
 
   data: (query, album, track) => ({
     hasMultipleTracks:
       album.tracks.length > 1,
+
+    commentaryPageIsStub:
+      !album.commentary &&
+      album.tracks.every(t => !t.commentary),
 
     galleryIsStub:
       album.tracks.every(t => !t.hasUniqueCoverArt),
@@ -106,10 +104,11 @@ export default {
         });
 
     const commentaryLink =
-      relations.albumCommentaryLink?.slots({
-        attributes: {class: slots.currentExtra === 'commentary' && 'current'},
-        content: language.$(albumNavCapsule, 'commentary'),
-      });
+      (!data.commentaryPageIsStub || slots.currentExtra === 'commentary') &&
+        relations.albumCommentaryLink.slots({
+          attributes: {class: slots.currentExtra === 'commentary' && 'current'},
+          content: language.$(albumNavCapsule, 'commentary'),
+        });
 
     const randomLink =
       data.hasMultipleTracks &&

--- a/src/content/dependencies/generateAlbumSecondaryNav.js
+++ b/src/content/dependencies/generateAlbumSecondaryNav.js
@@ -75,6 +75,11 @@ export default {
       validate: v => v.is('album', 'track'),
       default: 'album',
     },
+
+    alwaysVisible: {
+      type: 'boolean',
+      default: false,
+    },
   },
 
   generate(relations, slots, {html}) {
@@ -102,6 +107,8 @@ export default {
     ];
 
     return relations.secondaryNav.slots({
+      alwaysVisible: slots.alwaysVisible,
+
       class: [
         'album-secondary-nav',
 

--- a/src/content/dependencies/generateAlbumSecondaryNav.js
+++ b/src/content/dependencies/generateAlbumSecondaryNav.js
@@ -109,11 +109,11 @@ export default {
     return relations.secondaryNav.slots({
       alwaysVisible: slots.alwaysVisible,
 
-      class: [
-        'album-secondary-nav',
+      attributes: [
+        {class: 'album-secondary-nav'},
 
         slots.mode === 'album' &&
-          'with-previous-next',
+          {class: 'with-previous-next'},
       ],
 
       content:

--- a/src/content/dependencies/generateAlbumSecondaryNavGroupPart.js
+++ b/src/content/dependencies/generateAlbumSecondaryNavGroupPart.js
@@ -71,8 +71,20 @@ export default {
 
       colorStyle: relations.colorStyle,
       mainLink: relations.groupLink,
-      previousLink: relations.previousAlbumLink,
-      nextLink: relations.nextAlbumLink,
+
+      previousLink:
+        (relations.previousAlbumLink
+          ? relations.previousAlbumLink.slots({
+              linkCommentaryPages: true,
+            })
+          : null),
+
+      nextLink:
+        (relations.nextAlbumLink
+          ? relations.nextAlbumLink.slots({
+              linkCommentaryPages: true,
+            })
+          : null),
 
       stringsKey: 'albumSecondaryNav.group',
       mainLinkOption: 'group',

--- a/src/content/dependencies/generateAlbumSecondaryNavSeriesPart.js
+++ b/src/content/dependencies/generateAlbumSecondaryNavSeriesPart.js
@@ -74,8 +74,19 @@ export default {
           content: language.sanitize(data.name),
         }),
 
-      previousLink: relations.previousAlbumLink,
-      nextLink: relations.nextAlbumLink,
+      previousLink:
+        (relations.previousAlbumLink
+          ? relations.previousAlbumLink.slots({
+              linkCommentaryPages: true,
+            })
+          : null),
+
+      nextLink:
+        (relations.nextAlbumLink
+          ? relations.nextAlbumLink.slots({
+              linkCommentaryPages: true,
+            })
+          : null),
 
       stringsKey: 'albumSecondaryNav.series',
       mainLinkOption: 'series',

--- a/src/content/dependencies/generateGroupSecondaryNav.js
+++ b/src/content/dependencies/generateGroupSecondaryNav.js
@@ -14,7 +14,7 @@ export default {
 
   generate: (relations) =>
     relations.secondaryNav.slots({
-      class: 'nav-links-groups',
+      attributes: {class: 'nav-links-groups'},
       content: relations.categoryPart,
     }),
 };

--- a/src/content/dependencies/generatePreviousNextLink.js
+++ b/src/content/dependencies/generatePreviousNextLink.js
@@ -44,13 +44,15 @@ export default {
       }
     }
 
-    return slots.link.slots({
-      tooltipStyle: 'browser',
-      color: false,
-      attributes,
+    return html.resolve(slots.link, {
+      slots: {
+        tooltipStyle: 'browser',
+        color: false,
+        attributes,
 
-      content:
-        language.$('misc.nav', slots.direction),
+        content:
+          language.$('misc.nav', slots.direction),
+      }
     });
   },
 };

--- a/src/content/dependencies/generateSecondaryNav.js
+++ b/src/content/dependencies/generateSecondaryNav.js
@@ -10,11 +10,20 @@ export default {
     class: {
       validate: v => v.anyOf(v.isString, v.sparseArrayOf(v.isString)),
     },
+
+    alwaysVisible: {
+      type: 'boolean',
+      default: false,
+    },
   },
 
   generate: (slots, {html}) =>
     html.tag('nav', {id: 'secondary-nav'},
       {[html.onlyIfContent]: true},
       {class: slots.class},
+
+      slots.alwaysVisible &&
+        {class: 'always-visible'},
+
       slots.content),
 };

--- a/src/content/dependencies/generateSecondaryNav.js
+++ b/src/content/dependencies/generateSecondaryNav.js
@@ -7,8 +7,9 @@ export default {
       mutable: false,
     },
 
-    class: {
-      validate: v => v.anyOf(v.isString, v.sparseArrayOf(v.isString)),
+    attributes: {
+      type: 'attributes',
+      mutable: false,
     },
 
     alwaysVisible: {
@@ -20,7 +21,7 @@ export default {
   generate: (slots, {html}) =>
     html.tag('nav', {id: 'secondary-nav'},
       {[html.onlyIfContent]: true},
-      {class: slots.class},
+      slots.attributes,
 
       slots.alwaysVisible &&
         {class: 'always-visible'},

--- a/src/content/dependencies/linkAlbumDynamically.js
+++ b/src/content/dependencies/linkAlbumDynamically.js
@@ -1,10 +1,21 @@
 export default {
-  contentDependencies: ['linkAlbumGallery', 'linkAlbum'],
-  extraDependencies: ['pagePath'],
+  contentDependencies: [
+    'linkAlbumCommentary',
+    'linkAlbumGallery',
+    'linkAlbum',
+  ],
+
+  extraDependencies: ['html', 'pagePath'],
 
   relations: (relation, album) => ({
-    galleryLink: relation('linkAlbumGallery', album),
-    infoLink: relation('linkAlbum', album),
+    galleryLink:
+      relation('linkAlbumGallery', album),
+
+    infoLink:
+      relation('linkAlbum', album),
+
+    commentaryLink:
+      relation('linkAlbumCommentary', album),
   }),
 
   data: (album) => ({
@@ -15,7 +26,17 @@ export default {
       !!album.commentary,
   }),
 
-  generate: (data, relations, {pagePath}) =>
+  slots: {
+    linkCommentaryPages: {
+      type: 'boolean',
+      default: false,
+    },
+  },
+
+  generate: (data, relations, slots, {pagePath}) =>
+     // When linking to an album *from* an album commentary page,
+     // if the link is to the *same* album, then the effective target
+     // of the link is really the album's commentary, so scroll to it.
     (pagePath[0] === 'albumCommentary' &&
      pagePath[1] === data.albumDirectory &&
      data.albumHasCommentary
@@ -24,7 +45,15 @@ export default {
           hash: 'album-commentary',
         })
 
+     // When linking to *another* album from an album commentary page,
+     // the target is (by default) still just the album (its info page).
+     // But this can be customized per-link!
+   : pagePath[0] === 'albumCommentary' &&
+     slots.linkCommentaryPages
+      ? relations.commentaryLink
+
    : pagePath[0] === 'albumGallery'
       ? relations.galleryLink
+
       : relations.infoLink),
 };

--- a/src/content/dependencies/transformContent.js
+++ b/src/content/dependencies/transformContent.js
@@ -368,7 +368,15 @@ export default {
               return {type: 'text', data: nodeFromRelations.data};
             }
 
-            const {link, label, hash} = nodeFromRelations;
+            // TODO: This is a bit hacky, like the stuff below,
+            // but since we dressed it up in a utility function
+            // maybe it's okay...
+            const link =
+              html.resolve(
+                nodeFromRelations.link,
+                {slots: ['content', 'hash']});
+
+            const {label, hash} = nodeFromRelations;
 
             // These are removed from the typical combined slots({})-style
             // because we don't want to override slots that were already set

--- a/src/page/album.js
+++ b/src/page/album.js
@@ -7,8 +7,6 @@ export function targets({wikiData}) {
 }
 
 export function pathsForTarget(album) {
-  const hasCommentaryPage = !!album.commentary || album.tracks.some(t => t.commentary);
-
   return [
     {
       type: 'page',
@@ -30,7 +28,7 @@ export function pathsForTarget(album) {
       },
     },
 
-    hasCommentaryPage && {
+    {
       type: 'page',
       path: ['albumCommentary', album.directory],
 

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -2952,7 +2952,7 @@ html[data-language-code="preview-en"][data-url-key="localized.home"] #content
 
 @media (min-width: 900px) {
   #page-container.showing-sidebar-left #secondary-nav,
-  #page-container.showing-sidebar-left #secondary-nav {
+  #page-container.showing-sidebar-right #secondary-nav {
     display: none;
   }
 }

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -1834,6 +1834,10 @@ html[data-url-key="localized.albumCommentary"] .content-heading-accent {
   display: inline-block;
 }
 
+html[data-url-key="localized.albumCommentary"] p.track-info {
+  margin-left: 20px;
+}
+
 html[data-url-key="localized.groupInfo"] .by a {
   color: var(--page-primary-color);
 }

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -2951,8 +2951,8 @@ html[data-language-code="preview-en"][data-url-key="localized.home"] #content
 /* Layout - Wide (most computers) */
 
 @media (min-width: 900px) {
-  #page-container.showing-sidebar-left #secondary-nav,
-  #page-container.showing-sidebar-right #secondary-nav {
+  #page-container.showing-sidebar-left #secondary-nav:not(.always-visible),
+  #page-container.showing-sidebar-right #secondary-nav:not(.always-visible) {
     display: none;
   }
 }

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -1064,8 +1064,18 @@ albumCommentaryPage:
   nav:
     album: "Album: {ALBUM}"
 
+  sidebar:
+    noTrackCommentary: >-
+      No track commentary.
+
+    noCommentary: >-
+      No album or track commentary.
+
   infoLine: >-
     {WORDS} across {ENTRIES}.
+
+  infoLine.withoutCommentary: >-
+    This album does not have any commentary.
 
   entry:
     title:

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -260,6 +260,7 @@ releaseInfo:
   bannerArtBy: "Banner art by {ARTISTS}."
 
   released: "Released {DATE}."
+  albumReleased: "Album released {DATE}."
   artReleased: "Art released {DATE}."
   addedToWiki: "Added to wiki {DATE}."
 

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -262,6 +262,7 @@ releaseInfo:
   released: "Released {DATE}."
   albumReleased: "Album released {DATE}."
   artReleased: "Art released {DATE}."
+  trackReleased: "Track released {DATE}."
   addedToWiki: "Added to wiki {DATE}."
 
   duration: "Duration: {DURATION}."


### PR DESCRIPTION
Spiritual follow-up to #292, but this time it's for commentary pages!

Like for gallery pages, this entails "stub" commentary pages. This means the existence of an album commentary page *at all* is no longer dynamic. Of course, the stub page isn't linked from anywhere except the chronological (or by-series!) secondary nav now present on album commentary pages!

There are some substnatial internal changes, mostly to support having a slot on `linkAlbumDynamically` which controls whether (different-album) commentary pages are linked together, instead of just linking to an album's info page (still the desired behavior in commentary content itself).

This includes a new `html.resolve(template, {slots: ...})` utility (aka `Template.resolveForSlots`), which canonizes some not-so-slightly cursed behavior we've used or wanted basically all over. ✨ 

Some content changes besides the above:

* Any album commentary page will now show "No track commentary." in the sidebar, if that's the case.
* Stub pages show "No album or track commentary." in the sidebar (and of course a message in the content area).
* Album commentary pages now show the album's date at the top, by the entry and word counts (since date matters when you're following a chronology).
* Album commentary pages now show *track* dates, for the tracks whose dates differ from the album's date (or if the album just has no date).