### PR TITLE
Amorphize annotated reference lists

### DIFF
--- a/src/content/dependencies/generateArtistInfoPage.js
+++ b/src/content/dependencies/generateArtistInfoPage.js
@@ -81,13 +81,11 @@ export default {
 
     closeGroupLinks:
       query.generalLinkedGroups
-        .map(({thing: group}) =>
-          relation('linkGroup', group)),
+        .map(({group}) => relation('linkGroup', group)),
 
     aliasGroupLinks:
       query.aliasLinkedGroups
-        .map(({thing: group}) =>
-          relation('linkGroup', group)),
+        .map(({group}) => relation('linkGroup', group)),
 
     visitLinks:
       artist.urls

--- a/src/content/dependencies/generateGroupInfoPage.js
+++ b/src/content/dependencies/generateGroupInfoPage.js
@@ -57,13 +57,11 @@ export default {
 
     closeArtistLinks:
       query.generalLinkedArtists
-        .map(({thing: artist}) =>
-          relation('linkArtist', artist)),
+        .map(({artist}) => relation('linkArtist', artist)),
 
     aliasArtistLinks:
       query.aliasLinkedArtists
-        .map(({thing: artist}) =>
-          relation('linkArtist', artist)),
+        .map(({artist}) => relation('linkArtist', artist)),
 
     visitLinks:
       group.urls

--- a/src/data/composite/wiki-data/helpers/withReverseList-template.js
+++ b/src/data/composite/wiki-data/helpers/withReverseList-template.js
@@ -33,6 +33,8 @@ export default function withReverseList_template({
   propertyInputName,
   outputName,
 
+  additionalInputs = {},
+
   customCompositionSteps,
 }) {
   // Mapping of reference list property to WeakMap.
@@ -52,6 +54,8 @@ export default function withReverseList_template({
       [propertyInputName]: input({
         type: 'string',
       }),
+
+      ...additionalInputs,
     },
 
     outputs: [outputName],

--- a/src/data/composite/wiki-properties/reverseAnnotatedReferenceList.js
+++ b/src/data/composite/wiki-properties/reverseAnnotatedReferenceList.js
@@ -12,12 +12,20 @@ export default templateCompositeFrom({
   inputs: {
     data: inputWikiData({allowMixedTypes: false}),
     list: input({type: 'string'}),
+
+    forward: input({type: 'string', defaultValue: 'thing'}),
+    backward: input({type: 'string', defaultValue: 'thing'}),
+    annotation: input({type: 'string', defaultValue: 'annotation'}),
   },
 
   steps: () => [
     withReverseAnnotatedReferenceList({
       data: input('data'),
       list: input('list'),
+
+      forward: input('forward'),
+      backward: input('backward'),
+      annotation: input('annotation'),
     }),
 
     exposeDependency({dependency: '#reverseAnnotatedReferenceList'}),

--- a/src/data/things/artist.js
+++ b/src/data/things/artist.js
@@ -143,6 +143,9 @@ export class Artist extends Thing {
     closelyLinkedGroups: reverseAnnotatedReferenceList({
       data: 'groupData',
       list: input.value('closelyLinkedArtists'),
+
+      forward: input.value('artist'),
+      backward: input.value('group'),
     }),
 
     totalDuration: artistTotalDuration(),

--- a/src/data/things/group.js
+++ b/src/data/things/group.js
@@ -34,6 +34,9 @@ export class Group extends Thing {
       class: input.value(Artist),
       find: input.value(find.artist),
       data: 'artistData',
+
+      reference: input.value('artist'),
+      thing: input.value('artist'),
     }),
 
     featuredAlbums: referenceList({
@@ -123,7 +126,11 @@ export class Group extends Thing {
 
       'Closely Linked Artists': {
         property: 'closelyLinkedArtists',
-        transform: parseAnnotatedReferences,
+        transform: value =>
+          parseAnnotatedReferences(value, {
+            referenceField: 'Artist',
+            referenceProperty: 'artist',
+          }),
       },
 
       'Featured Albums': {property: 'featuredAlbums'},

--- a/src/data/validators.js
+++ b/src/data/validators.js
@@ -828,17 +828,6 @@ export function validateReferenceList(type) {
   return validateArrayItems(validateReference(type));
 }
 
-export function validateAnnotatedReference(type) {
-  return validateProperties({
-    reference: validateReference(type),
-    annotation: optional(isContentString),
-  });
-}
-
-export function validateAnnotatedReferenceList(type) {
-  return validateArrayItems(validateAnnotatedReference(type));
-}
-
 export function validateThing({
   referenceType: expectedReferenceType = '',
 } = {}) {

--- a/src/data/yaml.js
+++ b/src/data/yaml.js
@@ -569,27 +569,31 @@ export function parseContributionPresets(list) {
   });
 }
 
-export function parseAnnotatedReferences(entries) {
+export function parseAnnotatedReferences(entries, {
+  referenceField = 'References',
+  annotationField = 'Annotation',
+  referenceProperty = 'reference',
+  annotationProperty = 'annotation',
+} = {}) {
   return parseArrayEntries(entries, item => {
-    if (typeof item === 'object' && item['References'])
+    if (typeof item === 'object' && item[referenceField])
       return {
-        reference: item['References'],
-        annotation: item['Annotation'] ?? null,
+        [referenceProperty]: item[referenceField],
+        [annotationProperty]: item[annotationField] ?? null,
       };
 
     if (typeof item !== 'string') return item;
 
     const match = item.match(extractAccentRegex);
-    if (!match) {
+    if (!match)
       return {
-        reference: item,
-        annotation: null,
-      }
-    }
+        [referenceProperty]: item,
+        [annotationProperty]: null,
+      };
 
     return {
-      reference: match.groups.main,
-      annotation: match.groups.accent,
+      [referenceProperty]: match.groups.main,
+      [annotationProperty]: match.groups.accent ?? null,
     };
   });
 }


### PR DESCRIPTION
Spiritual (and practical) follow-up to #580. This PR makes annotated reference lists (and corresponding reverse lists) easily adaptable to whatever property names are convenient for a given use case.

As a demo, this PR changes these properties:

* `Group.closelyLinkedArtists`:
  * Old: `{thing, annotation}`
  * New: `{artist, annotation}`
* `Artist.closelyLinkedGroups`:
  * Old: `{thing, annotation}`
  * New: `{group, annotation}`

Artwork reference lists are left with the default generic labels (`thing`, `annotation`).

Reverse lists need an awareness not just of the desired exposed format, but also the format of the data they're processing, so both are new inputs there. The `annotation` property is also renamable in both properties (and must be the same in both directions).

The behavior differences between annotated reference lists and contribution lists helped elucidate (to us) the real difference—it's not just a difference in property names, nor that contribution lists handle stuff like contribution presets and "count in duration" properties... but that the actual structure is different!

Nodes in a contribution list point *forwards and backwards,* and the nodes in a forward list *are identity-equal* to those in a reverse list.

Nodes in an annotated reference list point *in one direction,* and consequently the nodes in a forward and a reverse list are neither identity- nor value-equal.