### PR TITLE
Wallpaper parts!

### DIFF
--- a/src/content/dependencies/generatePageLayout.js
+++ b/src/content/dependencies/generatePageLayout.js
@@ -1,5 +1,5 @@
 import {openAggregate} from '#aggregate';
-import {empty} from '#sugar';
+import {empty, repeat} from '#sugar';
 
 export default {
   contentDependencies: [
@@ -578,6 +578,18 @@ export default {
           ])),
       ]));
 
+    const numWallpaperParts =
+      html.resolve(slots.styleRules, {normalize: 'string'})
+        .match(/\.wallpaper-part:nth-child/g)
+        ?.length ?? 0;
+
+    const wallpaperPartsHTML =
+      html.tag('div', {class: 'wallpaper-parts'},
+        {[html.onlyIfContent]: true},
+
+        repeat(numWallpaperParts, () =>
+          html.tag('div', {class: 'wallpaper-part'})));
+
     const layoutHTML = [
       navHTML,
 
@@ -734,6 +746,8 @@ export default {
 
           html.tag('body',
             [
+              wallpaperPartsHTML,
+
               html.tag('div', {id: 'page-container'},
                 showingSidebarLeft &&
                   {class: 'showing-sidebar-left'},

--- a/src/data/composite/wiki-properties/index.js
+++ b/src/data/composite/wiki-properties/index.js
@@ -33,4 +33,5 @@ export {default as singleReference} from './singleReference.js';
 export {default as thing} from './thing.js';
 export {default as thingList} from './thingList.js';
 export {default as urls} from './urls.js';
+export {default as wallpaperParts} from './wallpaperParts.js';
 export {default as wikiData} from './wikiData.js';

--- a/src/data/composite/wiki-properties/wallpaperParts.js
+++ b/src/data/composite/wiki-properties/wallpaperParts.js
@@ -1,0 +1,9 @@
+import {isWallpaperPartList} from '#validators';
+
+export default function() {
+  return {
+    flags: {update: true, expose: true},
+    update: {validate: isWallpaperPartList},
+    expose: {transform: value => value ?? []},
+  };
+}

--- a/src/data/things/album.js
+++ b/src/data/things/album.js
@@ -20,6 +20,7 @@ import {
   parseContributors,
   parseDate,
   parseDimensions,
+  parseWallpaperParts,
 } from '#yaml';
 
 import {exitWithoutDependency, exposeDependency, exposeUpdateValueOrContinue}
@@ -56,6 +57,7 @@ import {
   thing,
   thingList,
   urls,
+  wallpaperParts,
   wikiData,
 } from '#composite/wiki-properties';
 
@@ -141,6 +143,11 @@ export class Album extends Thing {
     wallpaperStyle: [
       exitWithoutContribs({contribs: 'wallpaperArtistContribs'}),
       simpleString(),
+    ],
+
+    wallpaperParts: [
+      exitWithoutContribs({contribs: 'wallpaperArtistContribs'}),
+      wallpaperParts(),
     ],
 
     bannerStyle: [
@@ -440,6 +447,11 @@ export class Album extends Thing {
       'Wallpaper Style': {property: 'wallpaperStyle'},
       'Wallpaper File Extension': {property: 'wallpaperFileExtension'},
 
+      'Wallpaper Parts': {
+        property: 'wallpaperParts',
+        transform: parseWallpaperParts,
+      },
+
       'Banner Artists': {
         property: 'bannerArtistContribs',
         transform: parseContributors,
@@ -488,6 +500,18 @@ export class Album extends Thing {
 
       'Review Points': {ignore: true},
     },
+
+    invalidFieldCombinations: [
+      {message: `Specify one wallpaper style or multiple wallpaper parts, not both`, fields: [
+        'Wallpaper Parts',
+        'Wallpaper Style',
+      ]},
+
+      {message: `Wallpaper file extensions are specified on asset, per part`, fields: [
+        'Wallpaper Parts',
+        'Wallpaper File Extension',
+      ]},
+    ],
   };
 
   static [Thing.getYamlLoadingSpec] = ({

--- a/src/data/validators.js
+++ b/src/data/validators.js
@@ -724,6 +724,13 @@ export const isSeries = validateProperties({
 
 export const isSeriesList = validateArrayItems(isSeries);
 
+export const isWallpaperPart = validateProperties({
+  asset: optional(isString),
+  style: optional(isString),
+});
+
+export const isWallpaperPartList = validateArrayItems(isWallpaperPart);
+
 export function isDimensions(dimensions) {
   isArray(dimensions);
 

--- a/src/data/yaml.js
+++ b/src/data/yaml.js
@@ -479,6 +479,21 @@ export function parseSerieses(entries) {
   });
 }
 
+export function parseWallpaperParts(entries) {
+  return parseArrayEntries(entries, item => {
+    if (typeof item !== 'object') return item;
+
+    return {
+      asset:
+        (item['Asset'] === 'none'
+          ? null
+          : item['Asset'] ?? null),
+
+      style: item['Style'] ?? null,
+    };
+  });
+}
+
 export function parseDimensions(string) {
   // It's technically possible to pass an array like [30, 40] through here.
   // That's not really an issue because if it isn't of the appropriate shape,

--- a/src/gen-thumbs.js
+++ b/src/gen-thumbs.js
@@ -1264,11 +1264,28 @@ export function getExpectedImagePaths(mediaPath, {urls, wikiData}) {
 
   const paths = [
     wikiData.albumData
-      .flatMap(album => [
-        album.hasCoverArt && fromRoot.to('media.albumCover', album.directory, album.coverArtFileExtension),
-        !empty(CacheableObject.getUpdateValue(album, 'bannerArtistContribs')) && fromRoot.to('media.albumBanner', album.directory, album.bannerFileExtension),
-        !empty(CacheableObject.getUpdateValue(album, 'wallpaperArtistContribs')) && fromRoot.to('media.albumWallpaper', album.directory, album.wallpaperFileExtension),
+      .map(album => [
+        album.hasCoverArt && [
+          fromRoot.to('media.albumCover', album.directory, album.coverArtFileExtension),
+        ],
+
+        !empty(CacheableObject.getUpdateValue(album, 'bannerArtistContribs')) && [
+          fromRoot.to('media.albumBanner', album.directory, album.bannerFileExtension),
+        ],
+
+        !empty(CacheableObject.getUpdateValue(album, 'wallpaperArtistContribs')) &&
+        empty(album.wallpaperParts) && [
+          fromRoot.to('media.albumWallpaper', album.directory, album.wallpaperFileExtension),
+        ],
+
+        !empty(CacheableObject.getUpdateValue(album, 'wallpaperArtistContribs')) &&
+        !empty(album.wallpaperParts) &&
+          album.wallpaperParts.flatMap(part => [
+            part.asset &&
+              fromRoot.to('media.albumWallpaperPart', album.directory, part.asset),
+          ]),
       ])
+      .flat(2)
       .filter(Boolean),
 
     wikiData.artistData

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -40,6 +40,9 @@ body {
 
 body::before {
   content: "";
+}
+
+body::before, .wallpaper-part {
   position: fixed;
   top: 0;
   left: 0;
@@ -231,6 +234,9 @@ body {
 
 body::before {
   background-image: url("../../media/bg.jpg");
+}
+
+body::before, .wallpaper-part {
   background-position: center;
   background-size: cover;
   opacity: 0.5;

--- a/src/url-spec.js
+++ b/src/url-spec.js
@@ -114,6 +114,7 @@ const urlSpec = {
       albumBanner: 'album-art/<>/banner.<>',
       albumCover: 'album-art/<>/cover.<>',
       albumWallpaper: 'album-art/<>/bg.<>',
+      albumWallpaperPart: 'album-art/<>/<>',
 
       artistAvatar: 'artist-avatar/<>.<>',
 

--- a/src/util/sugar.js
+++ b/src/util/sugar.js
@@ -48,15 +48,22 @@ export function empty(value) {
 
 // Repeats all the items of an array a number of times.
 export function repeat(times, array) {
-  if (typeof array === 'string') return repeat(times, [array]);
-  if (empty(array)) return [];
   if (times === 0) return [];
-  if (times === 1) return array.slice();
+  if (array === null || array === undefined) return [];
+  if (Array.isArray(array) && empty(array)) return [];
 
   const out = [];
+
   for (let n = 1; n <= times; n++) {
-    out.push(...array);
+    const value =
+      (typeof array === 'function'
+        ? array()
+        : array);
+
+    if (Array.isArray(value)) out.push(...value);
+    else out.push(value);
   }
+
   return out;
 }
 


### PR DESCRIPTION
Dead simple implementation to enable composing album wallpapers out of a bunch of different assets (and parts with no assets at all). At the end of the day this is an alternative to just using multiple backgrounds (and stuff like `background-attachment`), but we figured this approach not only makes for easier editing, but simpler asset specifying too. (No need to parse the accessed assets out of `url` parts within CSS code, just to count those as expected media files!!)
