### PR TITLE
Simplify forward references with soupyFind

### DIFF
--- a/src/data/composite/things/contribution/withContributionArtist.js
+++ b/src/data/composite/things/contribution/withContributionArtist.js
@@ -1,8 +1,8 @@
 import {input, templateCompositeFrom} from '#composite';
 import find from '#find';
 
-import {withPropertyFromObject} from '#composite/data';
 import {withResolvedReference} from '#composite/wiki-data';
+import {soupyFind} from '#composite/wiki-properties';
 
 export default templateCompositeFrom({
   annotation: `withContributionArtist`,
@@ -17,16 +17,9 @@ export default templateCompositeFrom({
   outputs: ['#artist'],
 
   steps: () => [
-    withPropertyFromObject({
-      object: 'thing',
-      property: input.value('artistData'),
-      internal: input.value(true),
-    }),
-
     withResolvedReference({
       ref: input('ref'),
-      data: '#thing.artistData',
-      find: input.value(find.artist),
+      find: soupyFind.input('artist'),
     }).outputs({
       '#resolvedReference': '#artist',
     }),

--- a/src/data/composite/things/track/withAlwaysReferenceByDirectory.js
+++ b/src/data/composite/things/track/withAlwaysReferenceByDirectory.js
@@ -9,6 +9,7 @@ import {isBoolean} from '#validators';
 
 import {withPropertyFromObject} from '#composite/data';
 import {withResolvedReference} from '#composite/wiki-data';
+import {soupyFind} from '#composite/wiki-properties';
 
 import {
   exitWithoutDependency,
@@ -31,8 +32,7 @@ export default templateCompositeFrom({
     // recurse back into alwaysReferenceByDirectory!
     withResolvedReference({
       ref: 'dataSourceAlbum',
-      data: 'albumData',
-      find: input.value(find.album),
+      find: soupyFind.input('album'),
     }).outputs({
       '#resolvedReference': '#album',
     }),

--- a/src/data/composite/things/track/withOriginalRelease.js
+++ b/src/data/composite/things/track/withOriginalRelease.js
@@ -11,18 +11,13 @@ import {validateWikiData} from '#validators';
 import {exitWithoutDependency, withResultOfAvailabilityCheck}
   from '#composite/control-flow';
 import {withResolvedReference} from '#composite/wiki-data';
+import {soupyFind} from '#composite/wiki-properties';
 
 export default templateCompositeFrom({
   annotation: `withOriginalRelease`,
 
   inputs: {
     selfIfOriginal: input({type: 'boolean', defaultValue: false}),
-
-    data: input({
-      validate: validateWikiData({referenceType: 'track'}),
-      defaultDependency: 'trackData',
-    }),
-
     notFoundValue: input({defaultValue: null}),
   },
 
@@ -55,8 +50,7 @@ export default templateCompositeFrom({
 
     withResolvedReference({
       ref: 'originalReleaseTrack',
-      data: input('data'),
-      find: input.value(find.track),
+      find: soupyFind.input('track'),
     }),
 
     exitWithoutDependency({

--- a/src/data/composite/wiki-data/gobbleSoupyFind.js
+++ b/src/data/composite/wiki-data/gobbleSoupyFind.js
@@ -1,0 +1,39 @@
+import {input, templateCompositeFrom} from '#composite';
+
+import {withPropertyFromObject} from '#composite/data';
+
+import inputSoupyFind, {getSoupyFindInputKey} from './inputSoupyFind.js';
+
+export default templateCompositeFrom({
+  annotation: `gobbleSoupyFind`,
+
+  inputs: {
+    find: inputSoupyFind(),
+  },
+
+  outputs: ['#find'],
+
+  steps: () => [
+    {
+      dependencies: [input('find')],
+      compute: (continuation, {
+        [input('find')]: find,
+      }) =>
+        (typeof find === 'function'
+          ? continuation.raiseOutput({
+              ['#find']: find,
+            })
+          : continuation({
+              ['#key']:
+                getSoupyFindInputKey(find),
+            })),
+    },
+
+    withPropertyFromObject({
+      object: 'find',
+      property: '#key',
+    }).outputs({
+      '#value': '#find',
+    }),
+  ],
+});

--- a/src/data/composite/wiki-data/index.js
+++ b/src/data/composite/wiki-data/index.js
@@ -5,7 +5,9 @@
 //
 
 export {default as exitWithoutContribs} from './exitWithoutContribs.js';
+export {default as gobbleSoupyFind} from './gobbleSoupyFind.js';
 export {default as inputNotFoundMode} from './inputNotFoundMode.js';
+export {default as inputSoupyFind} from './inputSoupyFind.js';
 export {default as inputWikiData} from './inputWikiData.js';
 export {default as withClonedThings} from './withClonedThings.js';
 export {default as withContributionListSums} from './withContributionListSums.js';

--- a/src/data/composite/wiki-data/inputSoupyFind.js
+++ b/src/data/composite/wiki-data/inputSoupyFind.js
@@ -1,8 +1,8 @@
 import {input} from '#composite';
 import {anyOf, isFunction, isString} from '#validators';
 
-export default () =>
-  input({
+function inputSoupyFind() {
+  return input({
     validate:
       anyOf(
         isFunction,
@@ -16,6 +16,12 @@ export default () =>
           return true;
         }),
   });
+}
+
+inputSoupyFind.input = key =>
+  input.value('_soupyFind:' + key);
+
+export default inputSoupyFind;
 
 export function getSoupyFindInputKey(value) {
   return value.slice('_soupyFind:'.length);

--- a/src/data/composite/wiki-data/inputSoupyFind.js
+++ b/src/data/composite/wiki-data/inputSoupyFind.js
@@ -1,0 +1,22 @@
+import {input} from '#composite';
+import {anyOf, isFunction, isString} from '#validators';
+
+export default () =>
+  input({
+    validate:
+      anyOf(
+        isFunction,
+        val => {
+          isString(val);
+
+          if (!val.startsWith('_soupyFind:')) {
+            throw new Error(`Expected soupyFind.input() token`);
+          }
+
+          return true;
+        }),
+  });
+
+export function getSoupyFindInputKey(value) {
+  return value.slice('_soupyFind:'.length);
+}

--- a/src/data/composite/wiki-data/inputWikiData.js
+++ b/src/data/composite/wiki-data/inputWikiData.js
@@ -12,6 +12,6 @@ export default function inputWikiData({
 } = {}) {
   return input({
     validate: validateWikiData({referenceType, allowMixedTypes}),
-    acceptsNull: true,
+    defaultValue: null,
   });
 }

--- a/src/data/composite/wiki-data/withParsedCommentaryEntries.js
+++ b/src/data/composite/wiki-data/withParsedCommentaryEntries.js
@@ -11,6 +11,7 @@ import {
   withUnflattenedList,
 } from '#composite/data';
 
+import inputSoupyFind from './inputSoupyFind.js';
 import withResolvedReferenceList from './withResolvedReferenceList.js';
 
 export default templateCompositeFrom({
@@ -122,8 +123,7 @@ export default templateCompositeFrom({
 
     withResolvedReferenceList({
       list: '#flattenedList',
-      data: 'artistData',
-      find: input.value(find.artist),
+      find: inputSoupyFind.input('artist'),
       notFoundMode: input.value('null'),
     }),
 

--- a/src/data/composite/wiki-data/withResolvedAnnotatedReferenceList.js
+++ b/src/data/composite/wiki-data/withResolvedAnnotatedReferenceList.js
@@ -10,6 +10,7 @@ import {
   withAvailabilityFilter,
 } from '#composite/control-flow';
 
+import inputSoupyFind from './inputSoupyFind.js';
 import inputNotFoundMode from './inputNotFoundMode.js';
 import inputWikiData from './inputWikiData.js';
 import raiseResolvedReferenceList from './raiseResolvedReferenceList.js';
@@ -34,7 +35,7 @@ export default templateCompositeFrom({
     thing: input({type: 'string', defaultValue: 'thing'}),
 
     data: inputWikiData({allowMixedTypes: true}),
-    find: input({type: 'function'}),
+    find: inputSoupyFind(),
 
     notFoundMode: inputNotFoundMode(),
   },
@@ -42,11 +43,6 @@ export default templateCompositeFrom({
   outputs: ['#resolvedAnnotatedReferenceList'],
 
   steps: () => [
-    exitWithoutDependency({
-      dependency: input('data'),
-      value: input.value([]),
-    }),
-
     raiseOutputWithoutDependency({
       dependency: input('list'),
       mode: input.value('empty'),

--- a/src/data/composite/wiki-data/withResolvedContribs.js
+++ b/src/data/composite/wiki-data/withResolvedContribs.js
@@ -110,6 +110,7 @@ export default templateCompositeFrom({
         '#thingProperty',
         input('artistProperty'),
         input.myself(),
+        'find',
       ],
 
       compute: (continuation, {
@@ -117,6 +118,7 @@ export default templateCompositeFrom({
         ['#thingProperty']: thingProperty,
         [input('artistProperty')]: artistProperty,
         [input.myself()]: myself,
+        ['find']: find,
       }) => continuation({
         ['#contributions']:
           details.map(details => {
@@ -127,6 +129,7 @@ export default templateCompositeFrom({
               thing: myself,
               thingProperty: thingProperty,
               artistProperty: artistProperty,
+              find: find,
             });
 
             return contrib;

--- a/src/data/composite/wiki-data/withResolvedReference.js
+++ b/src/data/composite/wiki-data/withResolvedReference.js
@@ -1,7 +1,6 @@
 // Resolves a reference by using the provided find function to match it
-// within the provided thingData dependency. This will early exit if the
-// data dependency is null. Otherwise, the data object is provided on the
-// output dependency, or null, if the reference doesn't match anything or
+// within the provided thingData dependency. The data object is provided on
+// the output dependency, or null, if the reference doesn't match anything or
 // itself was null to begin with.
 
 import {input, templateCompositeFrom} from '#composite';
@@ -11,6 +10,8 @@ import {
   raiseOutputWithoutDependency,
 } from '#composite/control-flow';
 
+import gobbleSoupyFind from './gobbleSoupyFind.js';
+import inputSoupyFind from './inputSoupyFind.js';
 import inputWikiData from './inputWikiData.js';
 
 export default templateCompositeFrom({
@@ -20,7 +21,7 @@ export default templateCompositeFrom({
     ref: input({type: 'string', acceptsNull: true}),
 
     data: inputWikiData({allowMixedTypes: false}),
-    find: input({type: 'function'}),
+    find: inputSoupyFind(),
   },
 
   outputs: ['#resolvedReference'],
@@ -33,24 +34,26 @@ export default templateCompositeFrom({
       }),
     }),
 
-    exitWithoutDependency({
-      dependency: input('data'),
+    gobbleSoupyFind({
+      find: input('find'),
     }),
 
     {
       dependencies: [
         input('ref'),
         input('data'),
-        input('find'),
+        '#find',
       ],
 
       compute: (continuation, {
         [input('ref')]: ref,
         [input('data')]: data,
-        [input('find')]: findFunction,
+        ['#find']: findFunction,
       }) => continuation({
         ['#resolvedReference']:
-          findFunction(ref, data, {mode: 'quiet'}) ?? null,
+          (data
+            ? findFunction(ref, data, {mode: 'quiet'}) ?? null
+            : findFunction(ref, {mode: 'quiet'}) ?? null),
       }),
     },
   ],

--- a/src/data/composite/wiki-data/withResolvedReferenceList.js
+++ b/src/data/composite/wiki-data/withResolvedReferenceList.js
@@ -1,8 +1,7 @@
 // Resolves a list of references, with each reference matched with provided
-// data in the same way as withResolvedReference. This will early exit if the
-// data dependency is null (even if the reference list is empty). By default
-// it will filter out references which don't match, but this can be changed
-// to early exit ({notFoundMode: 'exit'}) or leave null in place ('null').
+// data in the same way as withResolvedReference. By default it will filter
+// out references which don't match, but this can be changed to early exit
+// ({notFoundMode: 'exit'}) or leave null in place ('null').
 
 import {input, templateCompositeFrom} from '#composite';
 import {isString, validateArrayItems} from '#validators';
@@ -37,11 +36,6 @@ export default templateCompositeFrom({
   outputs: ['#resolvedReferenceList'],
 
   steps: () => [
-    exitWithoutDependency({
-      dependency: input('data'),
-      value: input.value([]),
-    }),
-
     raiseOutputWithoutDependency({
       dependency: input('list'),
       mode: input.value('empty'),
@@ -57,7 +51,9 @@ export default templateCompositeFrom({
         [input('find')]: findFunction,
       }) => continuation({
         ['#map']:
-          ref => findFunction(ref, data, {mode: 'quiet'}),
+          (data
+            ? ref => findFunction(ref, data, {mode: 'quiet'})
+            : ref => findFunction(ref, {mode: 'quiet'})),
       }),
     },
 

--- a/src/data/composite/wiki-data/withResolvedReferenceList.js
+++ b/src/data/composite/wiki-data/withResolvedReferenceList.js
@@ -14,7 +14,9 @@ import {
   withAvailabilityFilter,
 } from '#composite/control-flow';
 
+import gobbleSoupyFind from './gobbleSoupyFind.js';
 import inputNotFoundMode from './inputNotFoundMode.js';
+import inputSoupyFind from './inputSoupyFind.js';
 import inputWikiData from './inputWikiData.js';
 import raiseResolvedReferenceList from './raiseResolvedReferenceList.js';
 
@@ -28,7 +30,7 @@ export default templateCompositeFrom({
     }),
 
     data: inputWikiData({allowMixedTypes: true}),
-    find: input({type: 'function'}),
+    find: inputSoupyFind(),
 
     notFoundMode: inputNotFoundMode(),
   },
@@ -44,11 +46,15 @@ export default templateCompositeFrom({
       }),
     }),
 
+    gobbleSoupyFind({
+      find: input('find'),
+    }),
+
     {
-      dependencies: [input('data'), input('find')],
+      dependencies: [input('data'), '#find'],
       compute: (continuation, {
         [input('data')]: data,
-        [input('find')]: findFunction,
+        ['#find']: findFunction,
       }) => continuation({
         ['#map']:
           (data

--- a/src/data/composite/wiki-data/withResolvedReferenceList.js
+++ b/src/data/composite/wiki-data/withResolvedReferenceList.js
@@ -7,6 +7,8 @@
 import {input, templateCompositeFrom} from '#composite';
 import {isString, validateArrayItems} from '#validators';
 
+import {withMappedList} from '#composite/data';
+
 import {
   exitWithoutDependency,
   raiseOutputWithoutDependency,
@@ -49,16 +51,22 @@ export default templateCompositeFrom({
     }),
 
     {
-      dependencies: [input('list'), input('data'), input('find')],
+      dependencies: [input('data'), input('find')],
       compute: (continuation, {
-        [input('list')]: list,
         [input('data')]: data,
         [input('find')]: findFunction,
-      }) =>
-        continuation({
-          '#matches': list.map(ref => findFunction(ref, data, {mode: 'quiet'})),
-        }),
+      }) => continuation({
+        ['#map']:
+          ref => findFunction(ref, data, {mode: 'quiet'}),
+      }),
     },
+
+    withMappedList({
+      list: input('list'),
+      map: '#map',
+    }).outputs({
+      '#mappedList': '#matches',
+    }),
 
     withAvailabilityFilter({
       from: '#matches',

--- a/src/data/composite/wiki-data/withResolvedSeriesList.js
+++ b/src/data/composite/wiki-data/withResolvedSeriesList.js
@@ -12,6 +12,7 @@ import {
   withPropertiesFromList,
 } from '#composite/data';
 
+import inputSoupyFind from './inputSoupyFind.js';
 import withResolvedReferenceList from './withResolvedReferenceList.js';
 
 export default templateCompositeFrom({
@@ -62,8 +63,7 @@ export default templateCompositeFrom({
 
     withResolvedReferenceList({
       list: '#flattenedList',
-      data: 'albumData',
-      find: input.value(find.album),
+      find: inputSoupyFind.input('album'),
       notFoundMode: input.value('null'),
     }),
 

--- a/src/data/composite/wiki-properties/annotatedReferenceList.js
+++ b/src/data/composite/wiki-properties/annotatedReferenceList.js
@@ -12,7 +12,7 @@ import {
 } from '#validators';
 
 import {exposeDependency} from '#composite/control-flow';
-import {inputWikiData, withResolvedAnnotatedReferenceList}
+import {inputSoupyFind, inputWikiData, withResolvedAnnotatedReferenceList}
   from '#composite/wiki-data';
 
 import {referenceListInputDescriptions, referenceListUpdateDescription}
@@ -27,7 +27,7 @@ export default templateCompositeFrom({
     ...referenceListInputDescriptions(),
 
     data: inputWikiData({allowMixedTypes: true}),
-    find: input({type: 'function'}),
+    find: inputSoupyFind(),
 
     date: input({
       validate: isDate,

--- a/src/data/composite/wiki-properties/index.js
+++ b/src/data/composite/wiki-properties/index.js
@@ -30,6 +30,7 @@ export {default as seriesList} from './seriesList.js';
 export {default as simpleDate} from './simpleDate.js';
 export {default as simpleString} from './simpleString.js';
 export {default as singleReference} from './singleReference.js';
+export {default as soupyFind} from './soupyFind.js';
 export {default as thing} from './thing.js';
 export {default as thingList} from './thingList.js';
 export {default as urls} from './urls.js';

--- a/src/data/composite/wiki-properties/referenceList.js
+++ b/src/data/composite/wiki-properties/referenceList.js
@@ -11,7 +11,8 @@ import {input, templateCompositeFrom} from '#composite';
 import {validateReferenceList} from '#validators';
 
 import {exposeDependency} from '#composite/control-flow';
-import {inputWikiData, withResolvedReferenceList} from '#composite/wiki-data';
+import {inputSoupyFind, inputWikiData, withResolvedReferenceList}
+  from '#composite/wiki-data';
 
 import {referenceListInputDescriptions, referenceListUpdateDescription}
   from './helpers/reference-list-helpers.js';
@@ -25,7 +26,7 @@ export default templateCompositeFrom({
     ...referenceListInputDescriptions(),
 
     data: inputWikiData({allowMixedTypes: true}),
-    find: input({type: 'function'}),
+    find: inputSoupyFind(),
   },
 
   update:

--- a/src/data/composite/wiki-properties/singleReference.js
+++ b/src/data/composite/wiki-properties/singleReference.js
@@ -11,7 +11,8 @@ import {input, templateCompositeFrom} from '#composite';
 import {isThingClass, validateReference} from '#validators';
 
 import {exposeDependency} from '#composite/control-flow';
-import {inputWikiData, withResolvedReference} from '#composite/wiki-data';
+import {inputSoupyFind, inputWikiData, withResolvedReference}
+  from '#composite/wiki-data';
 
 export default templateCompositeFrom({
   annotation: `singleReference`,
@@ -21,8 +22,7 @@ export default templateCompositeFrom({
   inputs: {
     class: input.staticValue({validate: isThingClass}),
 
-    find: input({type: 'function'}),
-
+    find: inputSoupyFind(),
     data: inputWikiData({allowMixedTypes: false}),
   },
 

--- a/src/data/composite/wiki-properties/soupyFind.js
+++ b/src/data/composite/wiki-properties/soupyFind.js
@@ -1,6 +1,8 @@
 import {input} from '#composite';
 import {isObject} from '#validators';
 
+import {inputSoupyFind} from '#composite/wiki-data';
+
 function soupyFind() {
   return {
     flags: {update: true},
@@ -8,7 +10,6 @@ function soupyFind() {
   };
 }
 
-soupyFind.input = key =>
-  input.value('_soupyFind:' + key);
+soupyFind.input = inputSoupyFind.input;
 
 export default soupyFind;

--- a/src/data/composite/wiki-properties/soupyFind.js
+++ b/src/data/composite/wiki-properties/soupyFind.js
@@ -1,0 +1,10 @@
+import {isObject} from '#validators';
+
+function soupyFind() {
+  return {
+    flags: {update: true},
+    update: {validate: isObject},
+  };
+}
+
+export default soupyFind;

--- a/src/data/composite/wiki-properties/soupyFind.js
+++ b/src/data/composite/wiki-properties/soupyFind.js
@@ -1,3 +1,4 @@
+import {input} from '#composite';
 import {isObject} from '#validators';
 
 function soupyFind() {
@@ -6,5 +7,8 @@ function soupyFind() {
     update: {validate: isObject},
   };
 }
+
+soupyFind.input = key =>
+  input.value('_soupyFind:' + key);
 
 export default soupyFind;

--- a/src/data/things/album.js
+++ b/src/data/things/album.js
@@ -230,8 +230,7 @@ export class Album extends Thing {
 
     groups: referenceList({
       class: input.value(Group),
-      find: input.value(find.group),
-      data: 'groupData',
+      find: soupyFind.input('group'),
     }),
 
     artTags: [
@@ -242,8 +241,7 @@ export class Album extends Thing {
 
       referenceList({
         class: input.value(ArtTag),
-        find: input.value(find.artTag),
-        data: 'artTagData',
+        find: soupyFind.input('artTag'),
       }),
     ],
 
@@ -273,26 +271,17 @@ export class Album extends Thing {
 
     find: soupyFind(),
 
+    // used for referencedArtworkList (mixedFind)
     albumData: wikiData({
       class: input.value(Album),
     }),
 
-    artistData: wikiData({
-      class: input.value(Artist),
-    }),
-
-    artTagData: wikiData({
-      class: input.value(ArtTag),
-    }),
-
-    groupData: wikiData({
-      class: input.value(Group),
-    }),
-
+    // used for referencedArtworkList (mixedFind)
     trackData: wikiData({
       class: input.value(Track),
     }),
 
+    // used for withMatchingContributionPresets (indirectly by Contribution)
     wikiInfo: thing({
       class: input.value(WikiInfo),
     }),
@@ -643,6 +632,7 @@ export class TrackSection extends Thing {
 
     // Update only
 
+    // used for withAlbum
     albumData: wikiData({
       class: input.value(Album),
     }),

--- a/src/data/things/album.js
+++ b/src/data/things/album.js
@@ -54,6 +54,7 @@ import {
   simpleDate,
   simpleString,
   singleReference,
+  soupyFind,
   thing,
   thingList,
   urls,
@@ -269,6 +270,8 @@ export class Album extends Thing {
     ],
 
     // Update only
+
+    find: soupyFind(),
 
     albumData: wikiData({
       class: input.value(Album),

--- a/src/data/things/art-tag.js
+++ b/src/data/things/art-tag.js
@@ -41,10 +41,12 @@ export class ArtTag extends Thing {
 
     // Update only
 
+    // used for taggedInThings (reverse)
     albumData: wikiData({
       class: input.value(Album),
     }),
 
+    // used for taggedInThings (reverse)
     trackData: wikiData({
       class: input.value(Track),
     }),

--- a/src/data/things/artist.js
+++ b/src/data/things/artist.js
@@ -25,6 +25,7 @@ import {
   reverseContributionList,
   reverseReferenceList,
   singleReference,
+  soupyFind,
   urls,
   wikiData,
 } from '#composite/wiki-properties';
@@ -57,28 +58,29 @@ export class Artist extends Thing {
 
     aliasedArtist: singleReference({
       class: input.value(Artist),
-      find: input.value(find.artist),
-      data: 'artistData',
+      find: soupyFind.input('artist'),
     }),
 
     // Update only
 
+    find: soupyFind(),
+
+    // used for reverse contribution lists
     albumData: wikiData({
       class: input.value(Album),
     }),
 
-    artistData: wikiData({
-      class: input.value(Artist),
-    }),
-
+    // used for reverse contribution lists
     flashData: wikiData({
       class: input.value(Flash),
     }),
 
+    // used for closelyLinkedGroups
     groupData: wikiData({
       class: input.value(Group),
     }),
 
+    // used for reverse contribution lists
     trackData: wikiData({
       class: input.value(Track),
     }),

--- a/src/data/things/contribution.js
+++ b/src/data/things/contribution.js
@@ -9,7 +9,7 @@ import {isStringNonEmpty, isThing, validateReference} from '#validators';
 
 import {exitWithoutDependency, exposeDependency} from '#composite/control-flow';
 import {withResolvedReference} from '#composite/wiki-data';
-import {flag, simpleDate} from '#composite/wiki-properties';
+import {flag, simpleDate, soupyFind} from '#composite/wiki-properties';
 
 import {
   withFilteredList,
@@ -81,6 +81,10 @@ export class Contribution extends Thing {
 
       flag(true),
     ],
+
+    // Update only
+
+    find: soupyFind(),
 
     // Expose only
 

--- a/src/data/things/flash.js
+++ b/src/data/things/flash.js
@@ -30,6 +30,7 @@ import {
   name,
   referenceList,
   simpleDate,
+  soupyFind,
   thing,
   urls,
   wikiData,
@@ -115,6 +116,8 @@ export class Flash extends Thing {
     creditSources: commentary(),
 
     // Update only
+
+    find: soupyFind(),
 
     artistData: wikiData({
       class: input.value(Artist),
@@ -248,6 +251,8 @@ export class FlashAct extends Thing {
 
     // Update only
 
+    find: soupyFind(),
+
     flashData: wikiData({
       class: input.value(Flash),
     }),
@@ -303,6 +308,8 @@ export class FlashSide extends Thing {
     }),
 
     // Update only
+
+    find: soupyFind(),
 
     flashActData: wikiData({
       class: input.value(FlashAct),

--- a/src/data/things/flash.js
+++ b/src/data/things/flash.js
@@ -106,8 +106,7 @@ export class Flash extends Thing {
 
     featuredTracks: referenceList({
       class: input.value(Track),
-      find: input.value(find.track),
-      data: 'trackData',
+      find: soupyFind.input('track'),
     }),
 
     urls: urls(),
@@ -119,18 +118,12 @@ export class Flash extends Thing {
 
     find: soupyFind(),
 
-    artistData: wikiData({
-      class: input.value(Artist),
-    }),
-
-    trackData: wikiData({
-      class: input.value(Track),
-    }),
-
+    // used for withFlashAct (reverse)
     flashActData: wikiData({
       class: input.value(FlashAct),
     }),
 
+    // used for withMatchingContributionPresets (indirectly by Contribution)
     wikiInfo: thing({
       class: input.value(WikiInfo),
     }),
@@ -245,18 +238,14 @@ export class FlashAct extends Thing {
 
     flashes: referenceList({
       class: input.value(Flash),
-      find: input.value(find.flash),
-      data: 'flashData',
+      find: soupyFind.input('flash'),
     }),
 
     // Update only
 
     find: soupyFind(),
 
-    flashData: wikiData({
-      class: input.value(Flash),
-    }),
-
+    // used for withFlashSide
     flashSideData: wikiData({
       class: input.value(FlashSide),
     }),
@@ -303,17 +292,12 @@ export class FlashSide extends Thing {
 
     acts: referenceList({
       class: input.value(FlashAct),
-      find: input.value(find.flashAct),
-      data: 'flashActData',
+      find: soupyFind.input('flashAct'),
     }),
 
     // Update only
 
     find: soupyFind(),
-
-    flashActData: wikiData({
-      class: input.value(FlashAct),
-    }),
   });
 
   static [Thing.yamlDocumentSpec] = {

--- a/src/data/things/group.js
+++ b/src/data/things/group.js
@@ -13,6 +13,7 @@ import {
   name,
   referenceList,
   seriesList,
+  soupyFind,
   urls,
   wikiData,
 } from '#composite/wiki-properties';
@@ -32,8 +33,7 @@ export class Group extends Thing {
 
     closelyLinkedArtists: annotatedReferenceList({
       class: input.value(Artist),
-      find: input.value(find.artist),
-      data: 'artistData',
+      find: soupyFind.input('artist'),
 
       date: input.value(null),
 
@@ -43,8 +43,7 @@ export class Group extends Thing {
 
     featuredAlbums: referenceList({
       class: input.value(Album),
-      find: input.value(find.album),
-      data: 'albumData',
+      find: soupyFind.input('album'),
     }),
 
     serieses: seriesList({
@@ -53,14 +52,15 @@ export class Group extends Thing {
 
     // Update only
 
+    find: soupyFind(),
+
+    // used for albums (reverse)
     albumData: wikiData({
       class: input.value(Album),
     }),
 
-    artistData: wikiData({
-      class: input.value(Artist),
-    }),
-
+    // used for category (reverse)
+    // used for color (reverse)
     groupCategoryData: wikiData({
       class: input.value(GroupCategory),
     }),
@@ -210,15 +210,12 @@ export class GroupCategory extends Thing {
 
     groups: referenceList({
       class: input.value(Group),
-      find: input.value(find.group),
-      data: 'groupData',
+      find: soupyFind.input('group'),
     }),
 
     // Update only
 
-    groupData: wikiData({
-      class: input.value(Group),
-    }),
+    find: soupyFind(),
   });
 
   static [Thing.yamlDocumentSpec] = {

--- a/src/data/things/homepage-layout.js
+++ b/src/data/things/homepage-layout.js
@@ -17,7 +17,7 @@ import {
 
 import {exposeDependency} from '#composite/control-flow';
 import {withResolvedReference} from '#composite/wiki-data';
-import {color, contentString, name, referenceList, wikiData}
+import {color, contentString, name, referenceList, soupyFind}
   from '#composite/wiki-properties';
 
 export class HomepageLayout extends Thing {
@@ -74,17 +74,7 @@ export class HomepageLayoutRow extends Thing {
 
     // Update only
 
-    // These wiki data arrays aren't necessarily used by every subclass, but
-    // to the convenience of providing these, the superclass accepts all wiki
-    // data arrays depended upon by any subclass.
-
-    albumData: wikiData({
-      class: input.value(Album),
-    }),
-
-    groupData: wikiData({
-      class: input.value(Group),
-    }),
+    find: soupyFind(),
   });
 
   static [Thing.yamlDocumentSpec] = {
@@ -151,8 +141,7 @@ export class HomepageLayoutAlbumsRow extends HomepageLayoutRow {
 
       withResolvedReference({
         ref: input.updateValue(),
-        data: 'groupData',
-        find: input.value(find.group),
+        find: soupyFind.input('group'),
       }),
 
       exposeDependency({dependency: '#resolvedReference'}),
@@ -160,8 +149,7 @@ export class HomepageLayoutAlbumsRow extends HomepageLayoutRow {
 
     sourceAlbums: referenceList({
       class: input.value(Album),
-      find: input.value(find.album),
-      data: 'albumData',
+      find: soupyFind.input('album'),
     }),
 
     countAlbumsFromGroup: {

--- a/src/data/things/track.js
+++ b/src/data/things/track.js
@@ -54,6 +54,7 @@ import {
   simpleDate,
   simpleString,
   singleReference,
+  soupyFind,
   thing,
   urls,
   wikiData,
@@ -329,10 +330,14 @@ export class Track extends Thing {
         notFoundValue: input.value([]),
       }),
 
+      withPropertyFromObject({
+        object: 'find',
+        property: input.value('track'),
+      }),
+
       referenceList({
         class: input.value(Track),
-        find: input.value(find.track),
-        data: 'trackData',
+        find: '#find.track',
       }),
     ],
 
@@ -341,10 +346,14 @@ export class Track extends Thing {
         notFoundValue: input.value([]),
       }),
 
+      withPropertyFromObject({
+        object: 'find',
+        property: input.value('track'),
+      }),
+
       referenceList({
         class: input.value(Track),
-        find: input.value(find.track),
-        data: 'trackData',
+        find: '#find.track',
       }),
     ],
 
@@ -375,6 +384,8 @@ export class Track extends Thing {
     ],
 
     // Update only
+
+    find: soupyFind(),
 
     albumData: wikiData({
       class: input.value(Album),

--- a/src/data/things/track.js
+++ b/src/data/things/track.js
@@ -330,14 +330,9 @@ export class Track extends Thing {
         notFoundValue: input.value([]),
       }),
 
-      withPropertyFromObject({
-        object: 'find',
-        property: input.value('track'),
-      }),
-
       referenceList({
         class: input.value(Track),
-        find: '#find.track',
+        find: soupyFind.input('track'),
       }),
     ],
 
@@ -346,14 +341,9 @@ export class Track extends Thing {
         notFoundValue: input.value([]),
       }),
 
-      withPropertyFromObject({
-        object: 'find',
-        property: input.value('track'),
-      }),
-
       referenceList({
         class: input.value(Track),
-        find: '#find.track',
+        find: soupyFind.input('track'),
       }),
     ],
 

--- a/src/data/things/track.js
+++ b/src/data/things/track.js
@@ -222,8 +222,7 @@ export class Track extends Thing {
 
     originalReleaseTrack: singleReference({
       class: input.value(Track),
-      find: input.value(find.track),
-      data: 'trackData',
+      find: soupyFind.input('track'),
     }),
 
     // Internal use only - for directly identifying an album inside a track's
@@ -231,8 +230,7 @@ export class Track extends Thing {
     // included in an album's track list).
     dataSourceAlbum: singleReference({
       class: input.value(Album),
-      find: input.value(find.album),
-      data: 'albumData',
+      find: soupyFind.input('album'),
     }),
 
     artistContribs: [
@@ -354,8 +352,7 @@ export class Track extends Thing {
 
       referenceList({
         class: input.value(ArtTag),
-        find: input.value(find.artTag),
-        data: 'artTagData',
+        find: soupyFind.input('artTag'),
       }),
     ],
 
@@ -377,30 +374,29 @@ export class Track extends Thing {
 
     find: soupyFind(),
 
+    // used for referencedArtworkList (mixedFind)
+    // used for withAlbum (reverse)
     albumData: wikiData({
       class: input.value(Album),
     }),
 
-    artistData: wikiData({
-      class: input.value(Artist),
-    }),
-
-    artTagData: wikiData({
-      class: input.value(ArtTag),
-    }),
-
+    // used for featuredInFlashes (reverse)
     flashData: wikiData({
       class: input.value(Flash),
     }),
 
+    // used for referencedArtworkList (mixedFind)
+    // used for trackReverseReferenceList (reverse)
     trackData: wikiData({
       class: input.value(Track),
     }),
 
+    // used for withContainingTrackSection (reverse)
     trackSectionData: wikiData({
       class: input.value(TrackSection),
     }),
 
+    // used for withMatchingContributionPresets (indirectly by Contribution)
     wikiInfo: thing({
       class: input.value(WikiInfo),
     }),

--- a/src/data/things/wiki-info.js
+++ b/src/data/things/wiki-info.js
@@ -15,7 +15,7 @@ import {
 } from '#validators';
 
 import {exitWithoutDependency} from '#composite/control-flow';
-import {contentString, flag, name, referenceList, wikiData}
+import {contentString, flag, name, referenceList, soupyFind}
   from '#composite/wiki-properties';
 
 export class WikiInfo extends Thing {
@@ -71,8 +71,7 @@ export class WikiInfo extends Thing {
 
     divideTrackListsByGroups: referenceList({
       class: input.value(Group),
-      find: input.value(find.group),
-      data: 'groupData',
+      find: soupyFind.input('group'),
     }),
 
     contributionPresets: {
@@ -99,6 +98,8 @@ export class WikiInfo extends Thing {
 
     // Update only
 
+    find: soupyFind(),
+
     searchDataAvailable: {
       flags: {update: true},
       update: {
@@ -106,10 +107,6 @@ export class WikiInfo extends Thing {
         default: false,
       },
     },
-
-    groupData: wikiData({
-      class: input.value(Group),
-    }),
   });
 
   static [Thing.yamlDocumentSpec] = {

--- a/src/data/yaml.js
+++ b/src/data/yaml.js
@@ -1225,7 +1225,7 @@ export async function loadAndProcessDataDocuments(dataSteps, {dataPath}) {
 // Data linking! Basically, provide (portions of) wikiData to the Things which
 // require it - they'll expose dynamically computed properties as a result (many
 // of which are required for page HTML generation and other expected behavior).
-export function linkWikiDataArrays(wikiData) {
+export function linkWikiDataArrays(wikiData, {bindFind}) {
   const linkWikiDataSpec = new Map([
     [wikiData.albumData, [
       'albumData',
@@ -1299,19 +1299,37 @@ export function linkWikiDataArrays(wikiData) {
     ]],
   ]);
 
+  const constructorHasFindMap = new Map();
+  const boundFind = bindFind(wikiData);
+
   for (const [things, keys] of linkWikiDataSpec.entries()) {
     if (things === undefined) continue;
+
     for (const thing of things) {
       if (thing === undefined) continue;
+
+      let hasFind;
+      if (constructorHasFindMap.has(thing.constructor)) {
+        hasFind = constructorHasFindMap.get(thing.constructor);
+      } else {
+        hasFind = 'find' in thing;
+        constructorHasFindMap.set(thing.constructor, hasFind);
+      }
+
+      if (hasFind) {
+        thing.find = boundFind;
+      }
+
       for (const key of keys) {
         if (!(key in wikiData)) continue;
+
         thing[key] = wikiData[key];
       }
     }
   }
 }
 
-export function sortWikiDataArrays(dataSteps, wikiData) {
+export function sortWikiDataArrays(dataSteps, wikiData, {bindFind}) {
   for (const [key, value] of Object.entries(wikiData)) {
     if (!Array.isArray(value)) continue;
     wikiData[key] = value.slice();
@@ -1327,7 +1345,7 @@ export function sortWikiDataArrays(dataSteps, wikiData) {
   // slices instead of the original arrays) - this is so that the object
   // caching system understands that it's working with a new ordering.
   // We still need to actually provide those updated arrays over again!
-  linkWikiDataArrays(wikiData);
+  linkWikiDataArrays(wikiData, {bindFind});
 }
 
 // Utility function for loading all wiki data from the provided YAML data
@@ -1363,7 +1381,7 @@ export async function quickLoadAllFromYAML(dataPath, {
     }
   }
 
-  linkWikiDataArrays(wikiData);
+  linkWikiDataArrays(wikiData, {bindFind});
 
   try {
     reportDirectoryErrors(wikiData, {getAllFindSpecs});
@@ -1389,7 +1407,7 @@ export async function quickLoadAllFromYAML(dataPath, {
     logWarn`Content text errors found.`;
   }
 
-  sortWikiDataArrays(dataSteps, wikiData);
+  sortWikiDataArrays(dataSteps, wikiData, {bindFind});
 
   return wikiData;
 }

--- a/src/data/yaml.js
+++ b/src/data/yaml.js
@@ -1227,11 +1227,11 @@ export async function loadAndProcessDataDocuments(dataSteps, {dataPath}) {
 // of which are required for page HTML generation and other expected behavior).
 export function linkWikiDataArrays(wikiData, {bindFind}) {
   const linkWikiDataSpec = new Map([
+    // entries must be present here even without any properties to explicitly
+    // link if the 'find' property will be implicitly linked
+
     [wikiData.albumData, [
       'albumData',
-      'artTagData',
-      'artistData',
-      'groupData',
       'trackData',
       'wikiInfo',
     ]],
@@ -1243,47 +1243,33 @@ export function linkWikiDataArrays(wikiData, {bindFind}) {
 
     [wikiData.artistData, [
       'albumData',
-      'artistData',
       'flashData',
       'groupData',
       'trackData',
     ]],
 
     [wikiData.flashData, [
-      'artistData',
       'flashActData',
-      'trackData',
       'wikiInfo',
     ]],
 
     [wikiData.flashActData, [
-      'flashData',
       'flashSideData',
     ]],
 
-    [wikiData.flashSideData, [
-      'flashActData',
-    ]],
+    [wikiData.flashSideData, [/* find */]],
 
     [wikiData.groupData, [
       'albumData',
-      'artistData',
       'groupCategoryData',
     ]],
 
-    [wikiData.groupCategoryData, [
-      'groupData',
-    ]],
+    [wikiData.groupCategoryData, [/* find */]],
 
-    [wikiData.homepageLayout?.rows, [
-      'albumData',
-      'groupData',
-    ]],
+    [wikiData.homepageLayout.rows, [/* find */]],
 
     [wikiData.trackData, [
       'albumData',
-      'artTagData',
-      'artistData',
       'flashData',
       'trackData',
       'trackSectionData',
@@ -1294,13 +1280,13 @@ export function linkWikiDataArrays(wikiData, {bindFind}) {
       'albumData',
     ]],
 
-    [[wikiData.wikiInfo], [
-      'groupData',
-    ]],
+    [[wikiData.wikiInfo], [/* find */]],
   ]);
 
   const constructorHasFindMap = new Map();
   const boundFind = bindFind(wikiData);
+
+  for (const thing of Object.values(wikiData).flat());
 
   for (const [things, keys] of linkWikiDataSpec.entries()) {
     if (things === undefined) continue;

--- a/src/upd8.js
+++ b/src/upd8.js
@@ -1526,7 +1526,7 @@ async function main() {
     timeStart: Date.now(),
   });
 
-  linkWikiDataArrays(wikiData);
+  linkWikiDataArrays(wikiData, {bindFind});
 
   Object.assign(stepStatusSummary.linkWikiDataArrays, {
     status: STATUS_DONE_CLEAN,
@@ -1740,7 +1740,7 @@ async function main() {
     timeStart: Date.now(),
   });
 
-  sortWikiDataArrays(yamlDataSteps, wikiData);
+  sortWikiDataArrays(yamlDataSteps, wikiData, {bindFind});
 
   Object.assign(stepStatusSummary.sortWikiDataArrays, {
     status: STATUS_DONE_CLEAN,

--- a/test/unit/data/things/track.js
+++ b/test/unit/data/things/track.js
@@ -1,5 +1,6 @@
 import t from 'tap';
 
+import {bindFind} from '#find';
 import thingConstructors from '#things';
 
 import {
@@ -662,13 +663,13 @@ t.test(`Track.otherReleases`, t => {
     `otherReleases #2: otherReleases of original release are its rereleases`);
 
   wikiData.trackData = [track1, track3, track2, track4];
-  linkWikiDataArrays();
+  linkWikiDataArrays({bindFind});
 
   t.same(track1.otherReleases, [track3, track2, track4],
     `otherReleases #3: otherReleases matches trackData order`);
 
   wikiData.trackData = [track3, track2, track1, track4];
-  linkWikiDataArrays();
+  linkWikiDataArrays({bindFind});
 
   t.same(track2.otherReleases, [track1, track3, track4],
     `otherReleases #4: otherReleases of rerelease are original track then other rereleases (1/3)`);


### PR DESCRIPTION
Implements bog-simply providing `boundFind` to things with a `find` property.

Most of the "complex" looking code here is really just infrastructure to make the `soupyFind.input()` syntax sugar work, and to enable functions like `withResolvedReferenceList` to operate taking such a token *or* a normal `find` function. See `inputSoupyFind` and `gobbleSoupyFind` for details.

This is based on a "do it easy" approach proposed by Surge, to try out before diving into a deeper-integrated primordial soup. Refer to:

* Initial outline by Surge ([#code-quarantine](https://discord.com/channels/749042497610842152/854020929113423924/1270411252740657193), 8/6/2024)
* Passerby view from Tangle ([#code-quarantine](https://discord.com/channels/749042497610842152/854020929113423924/1306339067893514312), 11/13/2024)
* Live-coding by Whisper ([#code-quarantine](https://discord.com/channels/749042497610842152/854020929113423924/1327455207856017468), 1/10/2025)

Forward reference lists (and single references) no longer require direct access to `wikiData` properties. Wherever such a Thing property was *only* used for forward references, it's been removed from that Thing (and from `linkWikiDataSpec`).

Reverse reference lists, and for the moment *mixed* forward reference lists (#578), still require access to `wikiData` properties. Future work (also theoretically touched by Surge) will probably help cut those away too, but it's out of scope for this PR's very simple approach. The remaining reasons each `wikiData` property is kept are listed right above those property definitions, so we can readily sweep over everything later on.

This PR obviously doesn't touch anything outside of low-level data processing (and minor changes to make higher-level stuff tolerate skipping the now-optional `data` array, mostly). But we did navigate a bunch of different kinds of pages in the live-dev-server, and everything appears to be working just fine!