### PR TITLE
Save 1.3 GB of RAM with finalizeCacheableObjectPrototype

### DIFF
--- a/src/data/cacheable-object.js
+++ b/src/data/cacheable-object.js
@@ -1,79 +1,3 @@
-// Generally extendable class for caching properties and handling dependencies,
-// with a few key properties:
-//
-// 1) The behavior of every property is defined by its descriptor, which is a
-//    static value stored on the subclass (all instances share the same property
-//    descriptors).
-//
-//  1a) Additional properties may not be added past the time of object
-//      construction, and attempts to do so (including externally setting a
-//      property name which has no corresponding descriptor) will throw a
-//      TypeError. (This is done via an Object.seal(this) call after a newly
-//      created instance defines its own properties according to the descriptor
-//      on its constructor class.)
-//
-// 2) Properties may have two flags set: update and expose. Properties which
-//    update are provided values from the external. Properties which expose
-//    provide values to the external, generally dependent on other update
-//    properties (within the same object).
-//
-//  2a) Properties may be flagged as both updating and exposing. This is so
-//      that the same name may be used for both "output" and "input".
-//
-// 3) Exposed properties have values which are computations dependent on other
-//    properties, as described by a `compute` function on the descriptor.
-//    Depended-upon properties are explicitly listed on the descriptor next to
-//    this function, and are only provided as arguments to the function once
-//    listed.
-//
-//  3a) An exposed property may depend only upon updating properties, not other
-//      exposed properties (within the same object). This is to force the
-//      general complexity of a single object to be fairly simple: inputs
-//      directly determine outputs, with the only in-between step being the
-//      `compute` function, no multiple-layer dependencies. Note that this is
-//      only true within a given object - externally, values provided to one
-//      object's `update` may be (and regularly are) the exposed values of
-//      another object.
-//
-//  3b) If a property both updates and exposes, it is automatically regarded as
-//      a dependancy. (That is, its exposed value will depend on the value it is
-//      updated with.) Rather than a required `compute` function, these have an
-//      optional `transform` function, which takes the update value as its first
-//      argument and then the usual key-value dependencies as its second. If no
-//      `transform` function is provided, the expose value is the same as the
-//      update value.
-//
-// 4) Exposed properties are cached; that is, if no depended-upon properties are
-//    updated, the value of an exposed property is not recomputed.
-//
-//  4a) The cache for an exposed property is invalidated as soon as any of its
-//      dependencies are updated, but the cache itself is lazy: the exposed
-//      value will not be recomputed until it is again accessed. (Likewise, an
-//      exposed value won't be computed for the first time until it is first
-//      accessed.)
-//
-// 5) Updating a property may optionally apply validation checks before passing,
-//    declared by a `validate` function on the `update` block. This function
-//    should either throw an error (e.g. TypeError) or return false if the value
-//    is invalid.
-//
-// 6) Objects do not expect all updating properties to be provided at once.
-//    Incomplete objects are deliberately supported and enabled.
-//
-//  6a) The default value for every updating property is null; undefined is not
-//      accepted as a property value under any circumstances (it always errors).
-//      However, this default may be overridden by specifying a `default` value
-//      on a property's `update` block. (This value will be checked against
-//      the property's validate function.) Note that a property may always be
-//      updated to null, even if the default is non-null. (Null always bypasses
-//      the validate check.)
-//
-//  6b) It's required by the external consumer of an object to determine whether
-//      or not the object is ready for use (within the larger program). This is
-//      convenienced by the static CacheableObject.listAccessibleProperties()
-//      function, which provides a mapping of exposed property names to whether
-//      or not their dependencies are yet met.
-
 import {inspect as nodeInspect} from 'node:util';
 
 import {colors, ENABLE_COLOR} from '#cli';
@@ -283,24 +207,6 @@ export default class CacheableObject {
       }
 
       obj[property];
-    }
-  }
-
-  static DEBUG_SLOW_TRACK_INVALID_PROPERTIES = false;
-  static _invalidAccesses = new Set();
-
-  static showInvalidAccesses() {
-    if (!this.DEBUG_SLOW_TRACK_INVALID_PROPERTIES) {
-      return;
-    }
-
-    if (!this._invalidAccesses.size) {
-      return;
-    }
-
-    console.log(`${this._invalidAccesses.size} unique invalid accesses:`);
-    for (const line of this._invalidAccesses) {
-      console.log(` - ${line}`);
     }
   }
 

--- a/src/data/cacheable-object.js
+++ b/src/data/cacheable-object.js
@@ -392,8 +392,22 @@ export class CacheableObjectPropertyValueError extends Error {
   [Symbol.for('hsmusic.aggregate.translucent')] = true;
 
   constructor(property, oldValue, newValue, options) {
+    let inspectOldValue, inspectNewValue;
+
+    try {
+      inspectOldValue = inspect(oldValue);
+    } catch (error) {
+      inspectOldValue = colors.red(`(couldn't inspect)`);
+    }
+
+    try {
+      inspectNewValue = inspect(newValue);
+    } catch (error) {
+      inspectNewValue = colors.red(`(couldn't inspect)`);
+    }
+
     super(
-      `Error setting ${colors.green(property)} (${inspect(oldValue)} -> ${inspect(newValue)})`,
+      `Error setting ${colors.green(property)} (${inspectOldValue} -> ${inspectNewValue})`,
       options);
 
     this.property = property;

--- a/src/data/cacheable-object.js
+++ b/src/data/cacheable-object.js
@@ -84,53 +84,21 @@ function inspect(value) {
 
 export default class CacheableObject {
   static propertyDescriptors = Symbol.for('CacheableObject.propertyDescriptors');
+  static constructorFinalized = Symbol.for('CacheableObject.constructorFinalized');
+  static propertyDependants = Symbol.for('CacheableObject.propertyDependants');
 
-  #propertyUpdateValues = Object.create(null);
-  #propertyUpdateCacheInvalidators = Object.create(null);
-
-  // Note the constructor doesn't take an initial data source. Due to a quirk
-  // of JavaScript, private members can't be accessed before the superclass's
-  // constructor is finished processing - so if we call the overridden
-  // update() function from inside this constructor, it will error when
-  // writing to private members. Pretty bad!
-  //
-  // That means initial data must be provided by following up with update()
-  // after constructing the new instance of the Thing (sub)class.
+  static cacheValid = Symbol.for('CacheableObject.cacheValid');
+  static updateValue = Symbol.for('CacheableObject.updateValues');
 
   constructor() {
-    this.#defineProperties();
-    this.#initializeUpdatingPropertyValues();
+    this[CacheableObject.updateValue] = Object.create(null);
+    this[CacheableObject.cachedValue] = Object.create(null);
+    this[CacheableObject.cacheValid] = Object.create(null);
 
-    if (CacheableObject.DEBUG_SLOW_TRACK_INVALID_PROPERTIES) {
-      return new Proxy(this, {
-        get: (obj, key) => {
-          if (!Object.hasOwn(obj, key)) {
-            if (key !== 'constructor') {
-              CacheableObject._invalidAccesses.add(`(${obj.constructor.name}).${key}`);
-            }
-          }
-          return obj[key];
-        },
-      });
-    }
-  }
-
-  #withEachPropertyDescriptor(callback) {
-    const {[CacheableObject.propertyDescriptors]: propertyDescriptors} =
-      this.constructor;
-
+    const propertyDescriptors = this.constructor[CacheableObject.propertyDescriptors];
     for (const property of Reflect.ownKeys(propertyDescriptors)) {
-      callback(property, propertyDescriptors[property]);
-    }
-  }
-
-  #initializeUpdatingPropertyValues() {
-    this.#withEachPropertyDescriptor((property, descriptor) => {
-      const {flags, update} = descriptor;
-
-      if (!flags.update) {
-        return;
-      }
+      const {flags, update} = propertyDescriptors[property];
+      if (!flags.update) continue;
 
       if (
         typeof update === 'object' &&
@@ -141,188 +109,157 @@ export default class CacheableObject {
       } else {
         this[property] = null;
       }
-    });
+    }
   }
 
-  #defineProperties() {
-    if (!this.constructor[CacheableObject.propertyDescriptors]) {
-      throw new Error(`Expected constructor ${this.constructor.name} to provide CacheableObject.propertyDescriptors`);
+  static finalizeCacheableObjectPrototype() {
+    if (this[CacheableObject.constructorFinalized]) {
+      throw new Error(`Constructor ${this.name} already finalized`);
     }
 
-    this.#withEachPropertyDescriptor((property, descriptor) => {
-      const {flags} = descriptor;
+    if (!this[CacheableObject.propertyDescriptors]) {
+      throw new Error(`Expected constructor ${this.name} to provide CacheableObject.propertyDescriptors`);
+    }
+
+    this[CacheableObject.constructorFinalized] = true;
+    this[CacheableObject.propertyDependants] = Object.create(null);
+
+    const propertyDescriptors = this[CacheableObject.propertyDescriptors];
+    for (const property of Reflect.ownKeys(propertyDescriptors)) {
+      const {flags, update, expose} = propertyDescriptors[property];
 
       const definition = {
         configurable: false,
         enumerable: flags.expose,
       };
 
-      if (flags.update) {
-        definition.set = this.#getUpdateObjectDefinitionSetterFunction(property);
-      }
-
-      if (flags.expose) {
-        definition.get = this.#getExposeObjectDefinitionGetterFunction(property);
-      }
-
-      Object.defineProperty(this, property, definition);
-    });
-
-    Object.seal(this);
-  }
-
-  #getUpdateObjectDefinitionSetterFunction(property) {
-    const {update} = this.#getPropertyDescriptor(property);
-    const validate = update?.validate;
-
-    return (newValue) => {
-      const oldValue = this.#propertyUpdateValues[property];
-
-      if (newValue === undefined) {
-        throw new TypeError(`Properties cannot be set to undefined`);
-      }
-
-      if (newValue === oldValue) {
-        return;
-      }
-
-      if (newValue !== null && validate) {
-        try {
-          const result = validate(newValue);
-          if (result === undefined) {
-            throw new TypeError(`Validate function returned undefined`);
-          } else if (result !== true) {
-            throw new TypeError(`Validation failed for value ${newValue}`);
+      if (flags.update) setSetter: {
+        definition.set = function(newValue) {
+          if (newValue === undefined) {
+            throw new TypeError(`Properties cannot be set to undefined`);
           }
-        } catch (caughtError) {
-          throw new CacheableObjectPropertyValueError(
-            property, oldValue, newValue, {cause: caughtError});
+
+          const oldValue = this[CacheableObject.updateValue][property];
+
+          if (newValue === oldValue) {
+            return;
+          }
+
+          if (newValue !== null && update?.validate) {
+            try {
+              const result = update.validate(newValue);
+              if (result === undefined) {
+                throw new TypeError(`Validate function returned undefined`);
+              } else if (result !== true) {
+                throw new TypeError(`Validation failed for value ${newValue}`);
+              }
+            } catch (caughtError) {
+              throw new CacheableObjectPropertyValueError(
+                property, oldValue, newValue, {cause: caughtError});
+            }
+          }
+
+          this[CacheableObject.updateValue][property] = newValue;
+
+          const dependants = this.constructor[CacheableObject.propertyDependants][property];
+          if (dependants) {
+            for (const dependant of dependants) {
+              this[CacheableObject.cacheValid][dependant] = false;
+            }
+          }
+        };
+      }
+
+      if (flags.expose) setGetter: {
+        if (flags.update && !expose?.transform) {
+          definition.get = function() {
+            return this[CacheableObject.updateValue][property];
+          };
+
+          break setGetter;
+        }
+
+        if (flags.update && expose?.compute) {
+          throw new Error(`Updating property ${property} has compute function, should be formatted as transform`);
+        }
+
+        if (!flags.update && !expose?.compute) {
+          throw new Error(`Exposed property ${property} does not update and is missing compute function`);
+        }
+
+        definition.get = function() {
+          if (this[CacheableObject.cacheValid][property]) {
+            return this[CacheableObject.cachedValue][property];
+          }
+
+          this[CacheableObject.cacheValid][property] = true;
+
+          const dependencies = Object.create(null);
+          for (const key of expose.dependencies ?? []) {
+            switch (key) {
+              case 'this':
+                dependencies.this = this;
+                break;
+
+              case 'thisProperty':
+                dependencies.thisProperty = property;
+                break;
+
+              default:
+                dependencies[key] = this[CacheableObject.updateValue][key];
+                break;
+            }
+          }
+
+          const value =
+            (flags.update
+              ? expose.transform(this[CacheableObject.updateValue][property], dependencies)
+              : expose.compute(dependencies));
+
+          this[CacheableObject.cachedValue][property] = value;
+
+          return value;
+        };
+      }
+
+      if (flags.expose) recordAsDependant: {
+        const dependantsMap = this[CacheableObject.propertyDependants];
+
+        if (flags.update && expose?.transform) {
+          if (dependantsMap[property]) {
+            dependantsMap[property].push(property);
+          } else {
+            dependantsMap[property] = [property];
+          }
+        }
+
+        for (const dependency of expose?.dependencies ?? []) {
+          switch (dependency) {
+            case 'this':
+            case 'thisProperty':
+              continue;
+
+            default: {
+              if (dependantsMap[dependency]) {
+                dependantsMap[dependency].push(property);
+              } else {
+                dependantsMap[dependency] = [property];
+              }
+            }
+          }
         }
       }
 
-      this.#propertyUpdateValues[property] = newValue;
-      this.#invalidateCachesDependentUpon(property);
-    };
-  }
-
-  #getPropertyDescriptor(property) {
-    return this.constructor[CacheableObject.propertyDescriptors][property];
-  }
-
-  #invalidateCachesDependentUpon(property) {
-    const invalidators = this.#propertyUpdateCacheInvalidators[property];
-    if (!invalidators) {
-      return;
-    }
-
-    for (const invalidate of invalidators) {
-      invalidate();
+      Object.defineProperty(this.prototype, property, definition);
     }
   }
 
-  #getExposeObjectDefinitionGetterFunction(property) {
-    const {flags} = this.#getPropertyDescriptor(property);
-    const compute = this.#getExposeComputeFunction(property);
-
-    if (compute) {
-      let cachedValue;
-      const checkCacheValid = this.#getExposeCheckCacheValidFunction(property);
-      return () => {
-        if (checkCacheValid()) {
-          return cachedValue;
-        } else {
-          return (cachedValue = compute());
-        }
-      };
-    } else if (!flags.update && !compute) {
-      throw new Error(`Exposed property ${property} does not update and is missing compute function`);
-    } else {
-      return () => this.#propertyUpdateValues[property];
-    }
+  static getPropertyDescriptor(property) {
+    return this[CacheableObject.propertyDescriptors][property];
   }
 
-  #getExposeComputeFunction(property) {
-    const {flags, expose} = this.#getPropertyDescriptor(property);
-
-    const compute = expose?.compute;
-    const transform = expose?.transform;
-
-    if (flags.update && !transform) {
-      return null;
-    } else if (flags.update && compute) {
-      throw new Error(`Updating property ${property} has compute function, should be formatted as transform`);
-    } else if (!flags.update && !compute) {
-      throw new Error(`Exposed property ${property} does not update and is missing compute function`);
-    }
-
-    let getAllDependencies;
-
-    if (expose.dependencies?.length > 0) {
-      const dependencyKeys = expose.dependencies.slice();
-      const shouldReflectObject = dependencyKeys.includes('this');
-      const shouldReflectProperty = dependencyKeys.includes('thisProperty');
-
-      getAllDependencies = () => {
-        const dependencies = Object.create(null);
-
-        for (const key of dependencyKeys) {
-          dependencies[key] = this.#propertyUpdateValues[key];
-        }
-
-        if (shouldReflectObject) {
-          dependencies.this = this;
-        }
-
-        if (shouldReflectProperty) {
-          dependencies.thisProperty = property;
-        }
-
-        return dependencies;
-      };
-    } else {
-      const dependencies = Object.create(null);
-      Object.freeze(dependencies);
-      getAllDependencies = () => dependencies;
-    }
-
-    if (flags.update) {
-      return () => transform(this.#propertyUpdateValues[property], getAllDependencies());
-    } else {
-      return () => compute(getAllDependencies());
-    }
-  }
-
-  #getExposeCheckCacheValidFunction(property) {
-    const {flags, expose} = this.#getPropertyDescriptor(property);
-
-    let valid = false;
-
-    const invalidate = () => {
-      valid = false;
-    };
-
-    const dependencyKeys = new Set(expose?.dependencies);
-
-    if (flags.update) {
-      dependencyKeys.add(property);
-    }
-
-    for (const key of dependencyKeys) {
-      if (this.#propertyUpdateCacheInvalidators[key]) {
-        this.#propertyUpdateCacheInvalidators[key].push(invalidate);
-      } else {
-        this.#propertyUpdateCacheInvalidators[key] = [invalidate];
-      }
-    }
-
-    return () => {
-      if (!valid) {
-        valid = true;
-        return false;
-      } else {
-        return true;
-      }
-    };
+  static hasPropertyDescriptor(property) {
+    return Object.hasOwn(this[CacheableObject.propertyDescriptors], property);
   }
 
   static cacheAllExposedProperties(obj) {
@@ -368,11 +305,11 @@ export default class CacheableObject {
   }
 
   static getUpdateValue(object, key) {
-    if (!Object.hasOwn(object, key)) {
+    if (!object.constructor.hasPropertyDescriptor(key)) {
       return undefined;
     }
 
-    return object.#propertyUpdateValues[key] ?? null;
+    return object[CacheableObject.updateValue][key] ?? null;
   }
 
   static clone(object) {
@@ -384,7 +321,7 @@ export default class CacheableObject {
   }
 
   static copyUpdateValuesOnto(source, target) {
-    Object.assign(target, source.#propertyUpdateValues);
+    Object.assign(target, source[CacheableObject.updateValue]);
   }
 }
 

--- a/src/data/cacheable-object.js
+++ b/src/data/cacheable-object.js
@@ -45,7 +45,6 @@ export default class CacheableObject {
       throw new Error(`Expected constructor ${this.name} to provide CacheableObject.propertyDescriptors`);
     }
 
-    this[CacheableObject.constructorFinalized] = true;
     this[CacheableObject.propertyDependants] = Object.create(null);
 
     const propertyDescriptors = this[CacheableObject.propertyDescriptors];
@@ -116,8 +115,6 @@ export default class CacheableObject {
             return this[CacheableObject.cachedValue][property];
           }
 
-          this[CacheableObject.cacheValid][property] = true;
-
           const dependencies = Object.create(null);
           for (const key of expose.dependencies ?? []) {
             switch (key) {
@@ -141,6 +138,7 @@ export default class CacheableObject {
               : expose.compute(dependencies));
 
           this[CacheableObject.cachedValue][property] = value;
+          this[CacheableObject.cacheValid][property] = true;
 
           return value;
         };
@@ -176,6 +174,8 @@ export default class CacheableObject {
 
       Object.defineProperty(this.prototype, property, definition);
     }
+
+    this[CacheableObject.constructorFinalized] = true;
   }
 
   static getPropertyDescriptor(property) {

--- a/src/data/thing.js
+++ b/src/data/thing.js
@@ -28,14 +28,13 @@ export default class Thing extends CacheableObject {
   // Symbol.for('Thing.isThingConstructor') in constructor
   static [Symbol.for('Thing.isThingConstructor')] = NaN;
 
-  static [CacheableObject.propertyDescriptors] = {
+  constructor() {
+    super();
+
     // To detect:
     // Object.hasOwn(object, Symbol.for('Thing.isThing'))
-    [Symbol.for('Thing.isThing')]: {
-      flags: {expose: true},
-      expose: {compute: () => NaN},
-    },
-  };
+    this[Symbol.for('Thing.isThing')] = NaN;
+  }
 
   static [Symbol.for('Thing.selectAll')] = _wikiData => [];
 

--- a/src/data/things/index.js
+++ b/src/data/things/index.js
@@ -177,6 +177,16 @@ function evaluateSerializeDescriptors() {
   });
 }
 
+function finalizeCacheableObjectPrototypes() {
+  return descriptorAggregateHelper({
+    message: `Errors finalizing Thing class prototypes`,
+
+    op(constructor) {
+      constructor.finalizeCacheableObjectPrototype();
+    },
+  });
+}
+
 if (!errorDuplicateClassNames())
   process.exit(1);
 
@@ -186,6 +196,9 @@ if (!evaluatePropertyDescriptors())
   process.exit(1);
 
 if (!evaluateSerializeDescriptors())
+  process.exit(1);
+
+if (!finalizeCacheableObjectPrototypes())
   process.exit(1);
 
 Object.assign(allClasses, {Thing});

--- a/src/find.js
+++ b/src/find.js
@@ -34,7 +34,7 @@ export function processAvailableMatchesByName(data, {
   include = _thing => true,
 
   getMatchableNames = thing =>
-    (Object.hasOwn(thing, 'name')
+    (thing.constructor.hasPropertyDescriptor('name')
       ? [thing.name]
       : []),
 
@@ -72,7 +72,7 @@ export function processAvailableMatchesByDirectory(data, {
   include = _thing => true,
 
   getMatchableDirectories = thing =>
-    (Object.hasOwn(thing, 'directory')
+    (thing.constructor.hasPropertyDescriptor('directory')
       ? [thing.directory]
       : [null]),
 

--- a/src/listing-spec.js
+++ b/src/listing-spec.js
@@ -238,6 +238,27 @@ listingSpec.push({
   groupUnderOther: true,
 });
 
+// Dunkass mock. Listings should be Things! In the fuuuuture!
+class Listing {
+  static properties = {};
+
+  constructor() {
+    Object.assign(this, this.constructor.properties);
+  }
+
+  static hasPropertyDescriptor(key) {
+    return Object.hasOwn(this.properties, key);
+  }
+}
+
+for (const [index, listing] of listingSpec.entries()) {
+  class ListingSubclass extends Listing {
+    static properties = listing;
+  }
+
+  listingSpec.splice(index, 1, new ListingSubclass);
+}
+
 {
   const errors = [];
 

--- a/src/upd8.js
+++ b/src/upd8.js
@@ -124,6 +124,7 @@ const defaultStepStatus = {status: STATUS_NOT_STARTED, annotation: null};
 // This will be initialized and mutated over the course of main().
 let stepStatusSummary;
 let showStepStatusSummary = false;
+let showStepMemoryInSummary = false;
 
 async function main() {
   Error.stackTraceLimit = Infinity;
@@ -418,6 +419,11 @@ async function main() {
       type: 'flag',
     },
 
+    'show-step-memory': {
+      help: `Include total process memory usage traces at the time each top-level build step ends. Use with --show-step-summary. This is mostly useful for programmer debugging!`,
+      type: 'flag',
+    },
+
     'queue-size': {
       help: `Process more or fewer disk files at once to optimize performance or avoid I/O errors, unlimited if set to 0 (between 500 and 700 is usually a safe range for building HSMusic on Windows machines)\nDefaults to ${defaultQueueSize}`,
       type: 'value',
@@ -478,6 +484,7 @@ async function main() {
   });
 
   showStepStatusSummary = cliOptions['show-step-summary'] ?? false;
+  showStepMemoryInSummary = cliOptions['show-step-memory'] ?? false;
 
   if (cliOptions['help']) {
     console.log(
@@ -2608,14 +2615,16 @@ if (true || isMain(import.meta.url) || path.basename(process.argv[1]) === 'hsmus
       const stepMemories =
         stepDetails.map(({memory}) =>
           (memory
-            ? Math.round(memory["heapUsed"] / 1024 / 1024) + "MB"
-            : "-"));
+            ? Math.round(memory["heapUsed"] / 1024 / 1024) + 'MB'
+            : '-'));
 
-      const longestMemoryLength = 7;
+      const longestMemoryLength =
+        Math.max(...stepMemories.map(memory => memory.length));
 
       for (let index = 0; index < stepDetails.length; index++) {
         const {name, status, annotation} = stepDetails[index];
         const duration = stepDurations[index];
+        const memory = stepMemories[index];
 
         let message =
           (stepsNotClean[index]
@@ -2623,7 +2632,11 @@ if (true || isMain(import.meta.url) || path.basename(process.argv[1]) === 'hsmus
             : ` - `);
 
         message += `(${duration} `.padStart(longestDurationLength + 2, ' ');
-        message += ` ${stepMemories[index]})`.padStart(longestMemoryLength + 2, ' ');
+
+        if (showStepMemoryInSummary) {
+          message += ` ${memory})`.padStart(longestMemoryLength + 2, ' ');
+        }
+
         message += ` `;
         message += `${name}: `.padEnd(longestNameLength + 4, '.');
         message += ` `;

--- a/src/upd8.js
+++ b/src/upd8.js
@@ -1082,6 +1082,7 @@ async function main() {
           status: STATUS_FATAL_ERROR,
           annotation: `--new-thumbs provided but regeneration not needed`,
           timeEnd: Date.now(),
+          memory: process.memoryUsage(),
         });
 
         return false;
@@ -1097,6 +1098,7 @@ async function main() {
           status: STATUS_FATAL_ERROR,
           annotation: mediaCachePathAnnotation,
           timeEnd: Date.now(),
+          memory: process.memoryUsage(),
         });
 
         return false;
@@ -1163,6 +1165,7 @@ async function main() {
       status: STATUS_FATAL_ERROR,
       annotation: mediaCachePathAnnotation,
       timeEnd: Date.now(),
+      memory: process.memoryUsage(),
     });
 
     return false;
@@ -1174,6 +1177,7 @@ async function main() {
     status: STATUS_DONE_CLEAN,
     annotation: mediaCachePathAnnotation,
     timeEnd: Date.now(),
+    memory: process.memoryUsage(),
   });
 
   if (stepStatusSummary.migrateThumbnails.status === STATUS_NOT_STARTED) {
@@ -1193,6 +1197,7 @@ async function main() {
         status: STATUS_FATAL_ERROR,
         annotation: `view log for details`,
         timeEnd: Date.now(),
+        memory: process.memoryUsage(),
       });
 
       return false;
@@ -1204,6 +1209,7 @@ async function main() {
     Object.assign(stepStatusSummary.migrateThumbnails, {
       status: STATUS_DONE_CLEAN,
       timeEnd: Date.now(),
+      memory: process.memoryUsage(),
     });
 
     return true;
@@ -1247,6 +1253,7 @@ async function main() {
           status: STATUS_FATAL_ERROR,
           annotation: `cache does not exist`,
           timeEnd: Date.now(),
+          memory: process.memoryUsage(),
         });
 
         return false;
@@ -1264,6 +1271,7 @@ async function main() {
           status: STATUS_FATAL_ERROR,
           annotation: `cache malformed or unreadable`,
           timeEnd: Date.now(),
+          memory: process.memoryUsage(),
         });
 
         return false;
@@ -1275,6 +1283,7 @@ async function main() {
     Object.assign(stepStatusSummary.loadThumbnailCache, {
       status: STATUS_DONE_CLEAN,
       timeEnd: Date.now(),
+      memory: process.memoryUsage(),
     });
 
     logInfo`Skipping thumbnail generation.`;
@@ -1302,6 +1311,7 @@ async function main() {
         status: STATUS_FATAL_ERROR,
         annotation: `view log for details`,
         timeEnd: Date.now(),
+        memory: process.memoryUsage(),
       });
 
       return false;
@@ -1310,6 +1320,7 @@ async function main() {
     Object.assign(stepStatusSummary.generateThumbnails, {
       status: STATUS_DONE_CLEAN,
       timeEnd: Date.now(),
+      memory: process.memoryUsage(),
     });
 
     if (thumbsOnly) {
@@ -1347,6 +1358,7 @@ async function main() {
         status: STATUS_FATAL_ERROR,
         annotation: `javascript error - view log for details`,
         timeEnd: Date.now(),
+        memory: process.memoryUsage(),
       });
 
       return false;
@@ -1386,6 +1398,7 @@ async function main() {
         status: STATUS_FATAL_ERROR,
         annotation: `error loading data files`,
         timeEnd: Date.now(),
+        memory: process.memoryUsage(),
       });
 
       return false;
@@ -1488,6 +1501,7 @@ async function main() {
         status: STATUS_FATAL_ERROR,
         annotation: `wiki info object not available`,
         timeEnd: Date.now(),
+        memory: process.memoryUsage(),
       });
 
       return false;
@@ -1500,6 +1514,7 @@ async function main() {
       Object.assign(stepStatusSummary.loadDataFiles, {
         status: STATUS_DONE_CLEAN,
         timeEnd: Date.now(),
+        memory: process.memoryUsage(),
       });
     } else {
       logWarn`This might indicate some fields in the YAML data weren't formatted`;
@@ -1514,6 +1529,7 @@ async function main() {
         status: STATUS_HAS_WARNINGS,
         annotation: `view log for details`,
         timeEnd: Date.now(),
+        memory: process.memoryUsage(),
       });
     }
   }
@@ -1532,6 +1548,7 @@ async function main() {
   Object.assign(stepStatusSummary.linkWikiDataArrays, {
     status: STATUS_DONE_CLEAN,
     timeEnd: Date.now(),
+    memory: process.memoryUsage(),
   });
 
   if (precacheMode === 'common') {
@@ -1603,6 +1620,7 @@ async function main() {
         status: STATUS_FATAL_ERROR,
         annotation: `see log for details`,
         timeEnd: Date.now(),
+        memory: process.memoryUsage(),
       });
 
       return false;
@@ -1611,6 +1629,7 @@ async function main() {
     Object.assign(stepStatusSummary.precacheCommonData, {
       status: STATUS_DONE_CLEAN,
       timeEnd: Date.now(),
+      memory: process.memoryUsage(),
     });
   }
 
@@ -1633,6 +1652,7 @@ async function main() {
       Object.assign(stepStatusSummary.reportDirectoryErrors, {
         status: STATUS_DONE_CLEAN,
         timeEnd: Date.now(),
+        memory: process.memoryUsage(),
       });
     } catch (aggregate) {
       if (!paragraph) console.log('');
@@ -1650,6 +1670,7 @@ async function main() {
         status: STATUS_FATAL_ERROR,
         annotation: `duplicate directories found`,
         timeEnd: Date.now(),
+        memory: process.memoryUsage(),
       });
 
       return false;
@@ -1677,6 +1698,7 @@ async function main() {
       Object.assign(stepStatusSummary.filterReferenceErrors, {
         status: STATUS_DONE_CLEAN,
         timeEnd: Date.now(),
+        memory: process.memoryUsage(),
       });
     } catch (error) {
       if (!paragraph) console.log('');
@@ -1694,6 +1716,7 @@ async function main() {
         status: STATUS_HAS_WARNINGS,
         annotation: `view log for details`,
         timeEnd: Date.now(),
+        memory: process.memoryUsage(),
       });
     }
   }
@@ -1713,6 +1736,7 @@ async function main() {
       Object.assign(stepStatusSummary.reportContentTextErrors, {
         status: STATUS_DONE_CLEAN,
         timeEnd: Date.now(),
+        memory: process.memoryUsage(),
       });
     } catch (error) {
       if (!paragraph) console.log('');
@@ -1729,6 +1753,7 @@ async function main() {
         status: STATUS_HAS_WARNINGS,
         annotation: `view log for details`,
         timeEnd: Date.now(),
+        memory: process.memoryUsage(),
       });
     }
   }
@@ -1746,6 +1771,7 @@ async function main() {
   Object.assign(stepStatusSummary.sortWikiDataArrays, {
     status: STATUS_DONE_CLEAN,
     timeEnd: Date.now(),
+    memory: process.memoryUsage(),
   });
 
   if (precacheMode === 'all') {
@@ -1769,6 +1795,7 @@ async function main() {
     Object.assign(stepStatusSummary.precacheAllData, {
       status: STATUS_DONE_CLEAN,
       timeEnd: Date.now(),
+      memory: process.memoryUsage(),
     });
   }
 
@@ -1842,6 +1869,7 @@ async function main() {
       status: STATUS_FATAL_ERROR,
       annotation: `see log for details`,
       timeEnd: Date.now(),
+      memory: process.memoryUsage(),
     });
 
     return false;
@@ -1855,6 +1883,7 @@ async function main() {
   Object.assign(stepStatusSummary.loadInternalDefaultLanguage, {
     status: STATUS_DONE_CLEAN,
     timeEnd: Date.now(),
+    memory: process.memoryUsage(),
   });
 
   let customLanguageWatchers;
@@ -1934,6 +1963,7 @@ async function main() {
             status: STATUS_FATAL_ERROR,
             annotation: `see log for details`,
             timeEnd: Date.now(),
+            memory: process.memoryUsage(),
           });
 
           errorLoadingCustomLanguages = true;
@@ -1965,6 +1995,7 @@ async function main() {
       Object.assign(stepStatusSummary.watchLanguageFiles, {
         status: STATUS_DONE_CLEAN,
         timeEnd: Date.now(),
+        memory: process.memoryUsage(),
       });
     } else {
       languages = {};
@@ -1988,11 +2019,13 @@ async function main() {
           status: STATUS_FATAL_ERROR,
           annotation: `see log for details`,
           timeEnd: Date.now(),
+          memory: process.memoryUsage(),
         });
       } else {
         Object.assign(stepStatusSummary.loadLanguageFiles, {
           status: STATUS_DONE_CLEAN,
           timeEnd: Date.now(),
+          memory: process.memoryUsage(),
         });
       }
     }
@@ -2030,6 +2063,7 @@ async function main() {
         status: STATUS_FATAL_ERROR,
         annotation: `wiki specifies default language whose file is not available`,
         timeEnd: Date.now(),
+        memory: process.memoryUsage(),
       });
 
       return false;
@@ -2123,6 +2157,7 @@ async function main() {
     status: STATUS_DONE_CLEAN,
     annotation: finalDefaultLanguageAnnotation,
     timeEnd: Date.now(),
+    memory: process.memoryUsage(),
   });
 
   let missingImagePaths;
@@ -2145,24 +2180,28 @@ async function main() {
       Object.assign(stepStatusSummary.verifyImagePaths, {
         status: STATUS_DONE_CLEAN,
         timeEnd: Date.now(),
+        memory: process.memoryUsage(),
       });
     } else if (empty(missingImagePaths)) {
       Object.assign(stepStatusSummary.verifyImagePaths, {
         status: STATUS_HAS_WARNINGS,
         annotation: `misplaced images detected`,
         timeEnd: Date.now(),
+        memory: process.memoryUsage(),
       });
     } else if (empty(misplacedImagePaths)) {
       Object.assign(stepStatusSummary.verifyImagePaths, {
         status: STATUS_HAS_WARNINGS,
         annotation: `missing images detected`,
         timeEnd: Date.now(),
+        memory: process.memoryUsage(),
       });
     } else {
       Object.assign(stepStatusSummary.verifyImagePaths, {
         status: STATUS_HAS_WARNINGS,
         annotation: `missing and misplaced images detected`,
         timeEnd: Date.now(),
+        memory: process.memoryUsage(),
       });
     }
   }
@@ -2262,6 +2301,7 @@ async function main() {
         status: STATUS_HAS_WARNINGS,
         annotation: `see log for details`,
         timeEnd: Date.now(),
+        memory: process.memoryUsage(),
       });
     } else {
       logInfo`Done preloading filesizes without any errors - nice!`;
@@ -2270,6 +2310,7 @@ async function main() {
       Object.assign(stepStatusSummary.preloadFileSizes, {
         status: STATUS_DONE_CLEAN,
         timeEnd: Date.now(),
+        memory: process.memoryUsage(),
       });
     }
   }
@@ -2294,6 +2335,7 @@ async function main() {
       Object.assign(stepStatusSummary.buildSearchIndex, {
         status: STATUS_DONE_CLEAN,
         timeEnd: Date.now(),
+        memory: process.memoryUsage(),
       });
     } catch (error) {
       if (!paragraph) console.log('');
@@ -2311,6 +2353,7 @@ async function main() {
         status: STATUS_HAS_WARNINGS,
         annotation: `see log for details`,
         timeEnd: Date.now(),
+        memory: process.memoryUsage(),
       });
     }
   }
@@ -2358,6 +2401,7 @@ async function main() {
         status: STATUS_FATAL_ERROR,
         message: `JavaScript error - view log for details`,
         timeEnd: Date.now(),
+        memory: process.memoryUsage(),
       });
 
       return false;
@@ -2369,6 +2413,7 @@ async function main() {
     Object.assign(stepStatusSummary.identifyWebRoutes, {
       status: STATUS_DONE_CLEAN,
       timeEnd: Date.now(),
+      memory: process.memoryUsage(),
     });
   }
 
@@ -2465,6 +2510,7 @@ async function main() {
       status: STATUS_FATAL_ERROR,
       message: `javascript error - view log for details`,
       timeEnd: Date.now(),
+      memory: process.memoryUsage(),
     });
 
     return false;
@@ -2475,6 +2521,7 @@ async function main() {
       status: STATUS_HAS_WARNINGS,
       annotation: `may not have completed - view log for details`,
       timeEnd: Date.now(),
+      memory: process.memoryUsage(),
     });
 
     return false;
@@ -2483,6 +2530,7 @@ async function main() {
   Object.assign(stepStatusSummary.performBuild, {
     status: STATUS_DONE_CLEAN,
     timeEnd: Date.now(),
+    memory: process.memoryUsage(),
   });
 
   return true;
@@ -2570,6 +2618,14 @@ if (true || isMain(import.meta.url) || path.basename(process.argv[1]) === 'hsmus
       const longestDurationLength =
         Math.max(...stepDurations.map(duration => duration.length));
 
+      const stepMemories =
+        stepDetails.map(({memory}) =>
+          (memory
+            ? Math.round(memory["heapUsed"] / 1024 / 1024) + "MB"
+            : "-"));
+
+      const longestMemoryLength = 7;
+
       for (let index = 0; index < stepDetails.length; index++) {
         const {name, status, annotation} = stepDetails[index];
         const duration = stepDurations[index];
@@ -2579,7 +2635,8 @@ if (true || isMain(import.meta.url) || path.basename(process.argv[1]) === 'hsmus
             ? `!! `
             : ` - `);
 
-        message += `(${duration})`.padStart(longestDurationLength + 2, ' ');
+        message += `(${duration} `.padStart(longestDurationLength + 2, ' ');
+        message += ` ${stepMemories[index]})`.padStart(longestMemoryLength + 2, ' ');
         message += ` `;
         message += `${name}: `.padEnd(longestNameLength + 4, '.');
         message += ` `;

--- a/src/upd8.js
+++ b/src/upd8.js
@@ -440,14 +440,6 @@ async function main() {
     },
     magick: {alias: 'magick-threads'},
 
-    // This option is super slow and has the potential for bugs! It puts
-    // CacheableObject in a mode where every instance is a Proxy which will
-    // keep track of invalid property accesses.
-    'show-invalid-property-accesses': {
-      help: `Report accesses at runtime to nonexistant properties on wiki data objects, at a dramatic performance cost\n(Internal/development use only)`,
-      type: 'flag',
-    },
-
     'precache-mode': {
       help:
         `Change the way certain runtime-computed values are preemptively evaluated and cached\n\n` +
@@ -566,7 +558,6 @@ async function main() {
   const showAggregateTraces = cliOptions['show-traces'] ?? false;
 
   const precacheMode = cliOptions['precache-mode'] ?? 'common';
-  const showInvalidPropertyAccesses = cliOptions['show-invalid-property-accesses'] ?? false;
 
   // Makes writing nicer on the CPU and file I/O parts of the OS, with a
   // marginal performance deficit while waiting for file writes to finish
@@ -1330,10 +1321,6 @@ async function main() {
     thumbsCache = result.cache;
   } else {
     thumbsCache = {};
-  }
-
-  if (showInvalidPropertyAccesses) {
-    CacheableObject.DEBUG_SLOW_TRACK_INVALID_PROPERTIES = true;
   }
 
   Object.assign(stepStatusSummary.loadDataFiles, {
@@ -2694,7 +2681,6 @@ if (true || isMain(import.meta.url) || path.basename(process.argv[1]) === 'hsmus
     }
 
     decorateTime.displayTime();
-    CacheableObject.showInvalidAccesses();
 
     process.exit(0);
   })();

--- a/src/util/search-spec.js
+++ b/src/util/search-spec.js
@@ -134,14 +134,14 @@ export const searchSpec = {
         thing.color;
 
       fields.artTags =
-        (Object.hasOwn(thing, 'artTags')
+        (thing.constructor.hasPropertyDescriptor('artTags')
           ? thing.artTags.map(artTag => artTag.nameShort)
           : []);
 
       fields.additionalNames =
-        (Object.hasOwn(thing, 'additionalNames')
+        (thing.constructor.hasPropertyDescriptor('additionalNames')
           ? thing.additionalNames.map(entry => entry.name)
-       : Object.hasOwn(thing, 'aliasNames')
+       : thing.constructor.hasPropertyDescriptor('aliasNames')
           ? thing.aliasNames
           : []);
 


### PR DESCRIPTION
Rewrites the guts of CacheableObject so that property setters/getters are configured on each subclass' prototype, rather than on each instance. In practice this obliterates many hundreds of thousands of thin wrappers around `compute`/`transform` behavior defined in properties' descriptors. That saves a lot of memory! There also appear to be speed improvements (in general around 20s to boot live-dev-server, against 30s, on miniminimini/M1).

This approach was suggested by natalias posting. She also wrote the code for tracking total process memory usage at each step, which we've put behind `--show-step-memory` (used alongside `--show-step-summary`).

We have generally replaced `Object.hasOwn(thing, 'key')` behavior with `thing.constructor.hasPropertyDescriptor('key')`. Listings need a bit of mockery to make this work, until they're made into proper things. (Nudge nudge #424)

External behavior and interfacing for CacheableObject is otherwise identical... except that we now only mark a cached value as, you know, cached, if we were successfully able to compute it. That means if `foo.x` throws an error, accessing `foo.x` *again* will throw the same error again, instead of just returning `undefined` (the "successfully" cached value). This has no bearing on general wiki code but should make debugging on the REPL a bit nicer.