### PR TITLE
Add "Always Reference by Directory" to Albums for mixed find

### DIFF
--- a/src/data/things/album.js
+++ b/src/data/things/album.js
@@ -86,6 +86,7 @@ export class Album extends Thing {
       }),
     ],
 
+    alwaysReferenceByDirectory: flag(false),
     alwaysReferenceTracksByDirectory: flag(false),
     suffixTrackDirectories: flag(false),
 
@@ -349,6 +350,11 @@ export class Album extends Thing {
     album: {
       referenceTypes: ['album', 'album-commentary', 'album-gallery'],
       bindTo: 'albumData',
+
+      getMatchableNames: album =>
+        (album.alwaysReferenceByDirectory 
+          ? [] 
+          : [album.name]),
     },
 
     albumWithArtwork: {
@@ -357,6 +363,11 @@ export class Album extends Thing {
 
       include: album =>
         album.hasCoverArt,
+
+      getMatchableNames: album =>
+        (album.alwaysReferenceByDirectory 
+          ? [] 
+          : [album.name]),
     },
   };
 
@@ -417,6 +428,7 @@ export class Album extends Thing {
       'Directory Suffix': {property: 'directorySuffix'},
       'Suffix Track Directories': {property: 'suffixTrackDirectories'},
 
+      'Always Reference By Directory': {property: 'alwaysReferenceByDirectory'},
       'Always Reference Tracks By Directory': {
         property: 'alwaysReferenceTracksByDirectory',
       },


### PR DESCRIPTION
First `hsmusic-wiki` commit, keeping it simple, even though the issue https://github.com/hsmusic/hsmusic-wiki/issues/579 is about adding it to artists and groups too. I'll do that later maybe.

This fixes the following issue:
```
Referenced Artworks:
- Black (minor edit)
```
Failing like this:
```
[Errors validating between-thing references in data]
 ╿ [Reference errors in wikiData.trackData]
 │  ╿ [Reference errors in Track "Harmonize" (track:harmonize-canmt) (#79 in cool and new volume s*x: hair transplant)]
 │  ╎  ╿ [Reference errors in field Referenced Artworks]
 │  ╎  │  ╿ (#1) Multiple matches for reference "Black". Please resolve:
 │  ╎  │  ╎ - Album "Black" (album:black-raid-remix)
 │  ╎  │  ╎ - Track "Black" (track:black) (#13 in Homestuck Vol. 4)
 ```
 Now, we can simply add `Always Reference By Directory: true` to RichaadEB and Raid's albums, and avoid using a directory in artworks. By itself, this is niche, but it's also a good first step for referencing albums by name in commentary (though I believe mixed find doesn't apply there yet?).

![image](https://github.com/user-attachments/assets/8f9949fe-95dd-4ca5-baba-4e219000a908)
