### PR TITLE
Static pages w/ absolute links

### DIFF
--- a/src/data/things/static-page.js
+++ b/src/data/things/static-page.js
@@ -7,7 +7,7 @@ import {sortAlphabetically} from '#sort';
 import Thing from '#thing';
 import {isName} from '#validators';
 
-import {contentString, directory, name, simpleString}
+import {contentString, directory, flag, name, simpleString}
   from '#composite/wiki-properties';
 
 export class StaticPage extends Thing {
@@ -30,9 +30,12 @@ export class StaticPage extends Thing {
     },
 
     directory: directory(),
-    content: contentString(),
+
     stylesheet: simpleString(),
     script: simpleString(),
+    content: contentString(),
+
+    absoluteLinks: flag(),
   });
 
   static [Thing.findSpecs] = {
@@ -47,6 +50,8 @@ export class StaticPage extends Thing {
       'Name': {property: 'name'},
       'Short Name': {property: 'nameShort'},
       'Directory': {property: 'directory'},
+
+      'Absolute Links': {property: 'absoluteLinks'},
 
       'Style': {property: 'stylesheet'},
       'Script': {property: 'script'},

--- a/src/page/static.js
+++ b/src/page/static.js
@@ -12,6 +12,7 @@ export function pathsForTarget(staticPage) {
     {
       type: 'page',
       path: ['staticPage', staticPage.directory],
+      absoluteLinks: staticPage.absoluteLinks,
 
       contentFunction: {
         name: 'generateStaticPage',

--- a/src/urls.js
+++ b/src/urls.js
@@ -303,11 +303,9 @@ export function getURLsFromRoot({
     return (
       '/' +
       (groupKey === 'localized' && baseDirectory
-        ? to(
-            'localizedWithBaseDirectory.' + subKey,
-            baseDirectory,
-            ...args
-          )
+        ? to('localizedWithBaseDirectory.' + subKey, baseDirectory, ...args)
+     : groupKey === 'localizedDefaultLanguage'
+        ? to('localized.' + subKey, ...args)
         : to(targetFullKey, ...args))
     );
   };

--- a/src/write/build-modes/live-dev-server.js
+++ b/src/write/build-modes/live-dev-server.js
@@ -458,7 +458,7 @@ export async function go({
         language,
         pagePath: servePath,
         pagePathStringFromRoot: pathname.replace(/^\//, ''),
-        to,
+        to: page.absoluteLinks ? absoluteTo : to,
       });
 
       const topLevelResult =

--- a/src/write/build-modes/static-build.js
+++ b/src/write/build-modes/static-build.js
@@ -322,7 +322,7 @@ export async function go({
           language,
           pagePath,
           pagePathStringFromRoot: pathname,
-          to,
+          to: page.absoluteLinks ? absoluteTo : to,
         });
 
         let pageHTML, oEmbedJSON;


### PR DESCRIPTION
Resolves #435, except without overengineering everything. Whaaaat?

> We'd probably, for now, hard-code `to` as a "special" extra dependency which automatically becomes absolute-routed if the appropriate HTML context is available.

We did this part, but instead of overriding `to` per relation according to HTML context (#434), we override `to` per page(!) according to the page's write spec (a new `absoluteLinks` property).

That property can be applied on any page (individually), but we currently expose it only for static pages, via a new `Absolute Links` YAML flag. Unsurprisingly, we're using this to make a 404 page!!