### PR TITLE
Extend check/transform to support nearly all types of [[Link]] shortcuts in Commentary

### DIFF
--- a/src/content/dependencies/transformContent.js
+++ b/src/content/dependencies/transformContent.js
@@ -1,5 +1,5 @@
 import {bindFind} from '#find';
-import {replacerSpec, parseInput} from '#replacer';
+import {replacerSpec, keylessReplacerOrder, parseInput} from '#replacer';
 
 import {Marked} from 'marked';
 
@@ -59,94 +59,137 @@ export default {
 
   sprawl(wikiData, content) {
     const find = bindFind(wikiData);
-
     const parsedNodes = parseInput(content ?? '');
-
+  
     return {
-      nodes: parsedNodes
-        .map(node => {
-          if (node.type !== 'tag') {
-            return node;
-          }
-
-          const placeholder = getPlaceholder(node, content);
-
-          const replacerKeyImplied = !node.data.replacerKey;
-          const replacerKey = replacerKeyImplied ? 'track' : node.data.replacerKey.data;
-
-          // TODO: We don't support recursive nodes like before, at the moment. Sorry!
-          // const replacerValue = transformNodes(node.data.replacerValue, opts);
-          const replacerValue = node.data.replacerValue[0].data;
-
-          const spec = replacerSpec[replacerKey];
-
-          if (!spec) {
+      nodes: parsedNodes.map(node => {
+        if (node.type !== 'tag') {
+          return node;
+        }
+  
+        const placeholder = getPlaceholder(node, content);
+  
+        // The user-supplied text inside the [[ brackets ]].
+        // e.g., in [[track:whatever]] => node.data.replacerValue[0].data is "whatever"
+        // If it’s just [[Whatever]] => there's no .replacerKey, so we must fallback.
+        const replacerValue = node.data.replacerValue[0].data;
+        const replacerKeyMissing = !node.data.replacerKey;
+  
+        // ------------------------------------------------------------------------------
+        // 1) If the user did NOT supply a key (i.e. "track:", "album:", etc.),
+        //    we'll try Things in the order defined in keylessReplacerOrder
+        // ------------------------------------------------------------------------------
+        if (replacerKeyMissing) {
+          if (!replacerValue || replacerValue === '-') {
             return placeholder;
           }
-
-          if (spec.link) {
-            let data = {link: spec.link};
-
-            determineData: {
-              // No value at all: this is an index link.
-              if (!replacerValue || replacerValue === '-') {
-                break determineData;
-              }
-
-              // Nothing to find: the link operates on a path or string, not a data object.
-              if (!spec.find) {
-                data.value = replacerValue;
-                break determineData;
-              }
-
-              const thing =
-                find[spec.find](
-                  (replacerKeyImplied
-                    ? replacerValue
-                    : replacerKey + `:` + replacerValue),
-                  wikiData);
-
-              // Nothing was found: this is unexpected, so return placeholder.
-              if (!thing) {
-                return placeholder;
-              }
-
-              // Something was found: the link operates on that thing.
-              data.thing = thing;
+  
+          // Go through each findable Thing 
+          let foundThing = null;
+          let foundSpec = null;
+  
+          for (const tryKey of keylessReplacerOrder) {
+            const attempt = find[tryKey](replacerValue, {mode: 'quiet'});
+            if (attempt) {
+              foundThing = attempt;
+              foundSpec = replacerSpec[tryKey];
+              break;
             }
-
-            const {transformName} = spec;
-
-            // TODO: Again, no recursive nodes. Sorry!
-            // const enteredLabel = node.data.label && transformNode(node.data.label, opts);
-            const enteredLabel = node.data.label?.data;
-            const enteredHash = node.data.hash?.data;
-
-            data.label =
-              enteredLabel ??
-                (transformName && data.thing.name
-                  ? transformName(data.thing.name, node, content)
-                  : null);
-
-            data.hash = enteredHash ?? null;
-
-            return {i: node.i, iEnd: node.iEnd, type: 'internal-link', data};
           }
-
-          // This will be another {type: 'tag'} node which gets processed in
-          // generate. Extract replacerKey and replacerValue now, since it'd
-          // be a pain to deal with later.
-          return {
-            ...node,
-            data: {
-              ...node.data,
-              replacerKey: node.data.replacerKey.data,
-              replacerValue: node.data.replacerValue[0].data,
-            },
-          };
-        }),
+  
+          // If nothing matched, we have no link to generate, so just bail out.
+          if (!foundThing || !foundSpec) {
+            return placeholder;
+          }
+  
+          // We found a match. Construct the data for an internal link node:
+          const data = { link: foundSpec.link, thing: foundThing };
+  
+          // If the replacerSpec for that type had, e.g., transformName, we can do that:
+          const {transformName} = foundSpec;
+          const enteredLabel = node.data.label?.data;
+          const enteredHash = node.data.hash?.data;
+  
+          data.label =
+            enteredLabel ??
+            (transformName && data.thing.name
+              ? transformName(data.thing.name, node, content)
+              : null);
+  
+          data.hash = enteredHash ?? null;
+  
+          return {i: node.i, iEnd: node.iEnd, type: 'internal-link', data};
+        }
+  
+        // ------------------------------------------------------------------------------
+        // 2) If we DO have a key, (e.g. [[album:whatever]]),
+        //    we use the find defined in its spec.
+        // ------------------------------------------------------------------------------
+        const replacerKey = node.data.replacerKey.data;
+        const spec = replacerSpec[replacerKey];
+  
+        if (!spec) {
+          return placeholder;
+        }
+  
+        // If this `spec` includes a `.link` property, it means we generate an internal link.
+        if (spec.link) {
+          const data = { link: spec.link };
+  
+          determineData: {
+            // If no actual value after "[[album:...]]"", treat it as an index link or skip.
+            if (!replacerValue || replacerValue === '-') {
+              break determineData;
+            }
+  
+            // If `spec.find` is missing, it means the link is just a plain path or string
+            // rather than referencing a data object. So store the string as `.value`.
+            if (!spec.find) {
+              data.value = replacerValue;
+              break determineData;
+            }
+  
+            // Otherwise, we do a normal "find" call with "key:value":
+            const thing = find[spec.find](replacerKey + ':' + replacerValue, wikiData);
+  
+            if (!thing) {
+              return placeholder;
+            }
+  
+            data.thing = thing;
+          }
+  
+          const {transformName} = spec;
+          const enteredLabel = node.data.label?.data;
+          const enteredHash = node.data.hash?.data;
+  
+          data.label =
+            enteredLabel ??
+            (transformName && data.thing?.name
+              ? transformName(data.thing.name, node, content)
+              : null);
+  
+          data.hash = enteredHash ?? null;
+  
+          return {i: node.i, iEnd: node.iEnd, type: 'internal-link', data};
+        }
+  
+        // ------------------------------------------------------------------------------
+        // 3) Fallback: it’s a tag that we do NOT treat as a link.
+        //    Just pass the replacerKey & replacerValue so generate() can handle it.
+        // ------------------------------------------------------------------------------
+        return {
+          ...node,
+          data: {
+            ...node.data,
+            replacerKey,
+            replacerValue,
+          },
+        };
+      }),
     };
   },
+  
 
   data(sprawl, content) {
     return {

--- a/src/data/checks.js
+++ b/src/data/checks.js
@@ -4,7 +4,7 @@ import {inspect as nodeInspect} from 'node:util';
 import {colors, ENABLE_COLOR} from '#cli';
 
 import CacheableObject from '#cacheable-object';
-import {replacerSpec, parseInput} from '#replacer';
+import {replacerSpec, keylessReplacerOrder, parseInput} from '#replacer';
 import {compareArrays, cut, cutStart, empty, getNestedProp, iterateMultiline}
   from '#sugar';
 import Thing from '#thing';
@@ -142,12 +142,35 @@ function bindFindArtistOrAlias(boundFind) {
     if (alias) {
       // No need to check if the original exists here. Aliases are automatically
       // created from a field on the original, so the original certainly exists.
-      const original = alias.aliasedArtist;
-      throw new Error(`Reference ${colors.red(artistRef)} is to an alias, should be ${colors.green(original.name)}`);
+      throw new Error(`Reference ${colors.red(artistRef)} is to an alias, `
+      `should be ${colors.green(alias.aliasedArtist.name)}`);
     }
 
     return boundFind.artist(artistRef);
   };
+}
+
+function bindFindThing(boundFind) {
+  return ref => {
+    // Find findable Things in the order defined in keylessReplacerOrder
+    for (const key of keylessReplacerOrder) {
+      const thing = boundFind[key](ref, {mode: 'quiet'});
+      if (thing) {
+        return boundFind[key](ref);
+      }
+    }
+
+    // If we still didn't match anything, check if an artist alias was misused
+    const artistAlias = boundFind.artistAlias(ref, {mode: 'quiet'});
+    if (artistAlias) {
+      // No need to check if the original exists here. Aliases are automatically
+      // created from a field on the original, so the original certainly exists.
+      const original = artistAlias.aliasedArtist;
+      throw new Error(`Reference ${colors.red(ref)} is to an alias, should be ${colors.green(original.name)}`);
+    }
+
+    throw new Error(`Reference ${colors.red(ref)} didn't match anything`);
+  }
 }
 
 function getFieldPropertyMessage(yamlDocumentSpec, property) {
@@ -232,6 +255,7 @@ export function filterReferenceErrors(wikiData, {
   ];
 
   const boundFind = bindFind(wikiData, {mode: 'error'});
+  const findThing = bindFindThing(boundFind);
   const findArtistOrAlias = bindFindArtistOrAlias(boundFind);
 
   const aggregate = openAggregate({message: `Errors validating between-thing references in data`});
@@ -311,7 +335,7 @@ export function filterReferenceErrors(wikiData, {
                 break;
 
               case '_commentary':
-                findFn = findArtistOrAlias;
+                findFn = findThing;
                 break;
 
               case '_contrib':
@@ -599,6 +623,7 @@ export function reportContentTextErrors(wikiData, {
   ];
 
   const boundFind = bindFind(wikiData, {mode: 'error'});
+  const findThing = bindFindThing(boundFind);
   const findArtistOrAlias = bindFindArtistOrAlias(boundFind);
 
   function* processContent(input) {
@@ -609,52 +634,51 @@ export function reportContentTextErrors(wikiData, {
       const length = node.iEnd - node.i;
 
       if (node.type === 'tag') {
-        const replacerKeyImplied = !node.data.replacerKey;
-        const replacerKey = replacerKeyImplied ? 'track' : node.data.replacerKey.data;
-        const spec = replacerSpec[replacerKey];
-
-        if (!spec) {
-          yield {
-            index, length,
-            message:
-              `Unknown tag key ${colors.red(`"${replacerKey}"`)}`,
-          };
-
-          // No spec, no further errors to report.
-          continue;
-        }
-
-        const replacerValue = node.data.replacerValue[0].data;
-
-        if (spec.find) {
-          let findFn;
-
-          switch (spec.find) {
-            case 'artist':
-              findFn = findArtistOrAlias;
-              break;
-
-            default:
-              findFn = boundFind[spec.find];
-              break;
-          }
-
-          const findRef =
-            (replacerKeyImplied
-              ? replacerValue
-              : replacerKey + `:` + replacerValue);
-
-          try {
-            findFn(findRef);
-          } catch (error) {
+        let findFn;
+        let findRef;
+        const replacerKeyMissing = !node.data.replacerKey;
+        if (replacerKeyMissing) {
+          findFn = findThing;
+          findRef = node.data.replacerValue[0].data;
+        } else {
+          const replacerKey = node.data.replacerKey.data;
+          const replacerValue = node.data.replacerValue[0].data;
+          const spec = replacerSpec[replacerKey];
+          if (!spec) {
             yield {
               index, length,
-              message: error.message,
+              message:
+                `Unknown tag key ${colors.red(`"${replacerKey}"`)}`,
             };
-
-            // It's only possible to have one error per node at the moment.
+  
+            // No spec, no further errors to report.
             continue;
           }
+          if (spec.find) {
+            switch (spec.find) {
+              case 'artist':
+                findFn = findArtistOrAlias;
+                break;
+  
+              default:
+                findFn = boundFind[spec.find];
+                break;
+            }
+  
+            findRef = replacerKey + `:` + replacerValue;
+          } else {
+            continue;
+          }
+        }
+        try {
+          findFn(findRef);
+        } catch (error) {
+          yield {
+            index, length,
+            message: error.message,
+          };
+          // It's only possible to have one error per node at the moment.
+          continue;
         }
       } else if (node.type === 'external-link') {
         try {

--- a/src/data/things/artist.js
+++ b/src/data/things/artist.js
@@ -56,6 +56,8 @@ export class Artist extends Thing {
       find: soupyFind.input('artist'),
     }),
 
+    alwaysReferenceByDirectory: flag(false),
+
     // Update only
 
     find: soupyFind(),
@@ -137,6 +139,11 @@ export class Artist extends Thing {
       bindTo: 'artistData',
 
       include: artist => !artist.isAlias,
+
+      getMatchableNames: artist =>
+        (artist.alwaysReferenceByDirectory 
+          ? [] 
+          : [artist.name]),
     },
 
     artistAlias: {
@@ -199,6 +206,8 @@ export class Artist extends Thing {
       'Aliases': {property: 'aliasNames'},
 
       'Dead URLs': {ignore: true},
+
+      'Always Reference By Directory': {property: 'alwaysReferenceByDirectory'},
 
       'Review Points': {ignore: true},
     },

--- a/src/data/things/group.js
+++ b/src/data/things/group.js
@@ -9,6 +9,7 @@ import {
   color,
   contentString,
   directory,
+  flag,
   name,
   referenceList,
   seriesList,
@@ -48,6 +49,8 @@ export class Group extends Thing {
     serieses: seriesList({
       group: input.myself(),
     }),
+
+    alwaysReferenceByDirectory: flag(false),
 
     // Update only
 
@@ -105,6 +108,11 @@ export class Group extends Thing {
     group: {
       referenceTypes: ['group', 'group-gallery'],
       bindTo: 'groupData',
+
+      getMatchableNames: group =>
+        (group.alwaysReferenceByDirectory 
+          ? [] 
+          : [group.name]),
     },
   };
 
@@ -149,6 +157,8 @@ export class Group extends Thing {
         property: 'serieses',
         transform: parseSerieses,
       },
+
+      'Always Reference By Directory': {property: 'alwaysReferenceByDirectory'},
 
       'Review Points': {ignore: true},
     },

--- a/src/replacer.js
+++ b/src/replacer.js
@@ -146,6 +146,13 @@ export const replacerSpec = {
   },
 };
 
+export const keylessReplacerOrder = [
+  'track',
+  'artist',
+  'album',
+  'group',
+];
+
 // Syntax literals.
 const tagBeginning = '[[';
 const tagEnding = ']]';


### PR DESCRIPTION
Closes https://github.com/hsmusic/hsmusic-wiki/issues/579 and probably another one I can't find.

Before this PR, `[[TrackName]]` had hardcoded special handling for Tracks across the codebase. In Commentary bodies, you could use `[[Sburban Jungle]]` and have it resolve to `[[track:sburban-jungle]]`, but you couldn't simply use `[[Michael Guy Bowman]]` or a group/album name.

This adds support to [[Syntax]] to groups, albums and artists in Commentary, though extending it to other fields like Lyrics if we need it should be easy.

![image](https://github.com/user-attachments/assets/5c91c525-8fd4-4c23-ae55-926801e22262)
![image](https://github.com/user-attachments/assets/9f7b37c2-fd5c-4fa3-a755-e58d352723c7)

Absolutely do not merge this before thorough review, for reasons.

For one, the priority currently goes `Track > Artist > Album > Group` (we then check for Artist Alias, erroring if there's a match), based on an estimated order of number of appearances. When developing, I originally crashed against "Moonsweater", which matched Whimsy's "moonsweater" *alias*, which luckily this order fixes. Since all the current [[References]] are to tracks, I think this change is fully backwards compatible and we don't need to touch `hsmusic-data` at all. I haven't seen anything wrong while going through random Commentaries, but we should keep checking.

Also, currently we have this order defined in two places, `checks.js` and `transformContent.js`, which is Bad. I couldn't find a good place to define a constant or even a variable that will eventually make it to both places. If it exists, feel free to tell me where and I'll fix that. Alternatively maybe we can dynamically fetch all the names of Things that implement `getMatchableNames`, but if there was an easy way to do that I couldn't find it.

Finally, while all checks pass, it's completely possible I have broken something (especially in error handling, which I still barely understand) and made them *more permissive*, so this should be checked too, though I haven't seen anything wrong, and I did some manual tests. 

Good luck reviewing this!