### PR TITLE
"Commentary — for this wiki" section for artist info page

### DIFF
--- a/src/content/dependencies/generateArtistInfoPage.js
+++ b/src/content/dependencies/generateArtistInfoPage.js
@@ -115,7 +115,10 @@ export default {
       relation('generateArtistInfoPageFlashesChunkedList', artist),
 
     commentaryChunkedList:
-      relation('generateArtistInfoPageCommentaryChunkedList', artist),
+      relation('generateArtistInfoPageCommentaryChunkedList', artist, false),
+
+    wikiEditorCommentaryChunkedList:
+      relation('generateArtistInfoPageCommentaryChunkedList', artist, true),
   }),
 
   data: (query, artist) => ({
@@ -262,7 +265,8 @@ export default {
                       {href: '#flashes'},
                       language.$(pageCapsule, 'flashList.title')),
 
-                  !html.isBlank(relations.commentaryChunkedList) &&
+                  (!html.isBlank(relations.commentaryChunkedList) ||
+                   !html.isBlank(relations.wikiEditorCommentaryChunkedList)) &&
                     html.tag('a',
                       {href: '#commentary'},
                       language.$(pageCapsule, 'commentaryList.title')),
@@ -380,6 +384,17 @@ export default {
               }),
 
             relations.commentaryChunkedList,
+
+            html.tags([
+              html.tag('p',
+                {[html.onlyIfSiblings]: true},
+
+                language.$(pageCapsule, 'wikiEditorCommentary', {
+                  artist: data.name,
+                })),
+
+              relations.wikiEditorCommentaryChunkedList,
+            ]),
           ]),
         ],
 

--- a/src/content/dependencies/generateArtistInfoPage.js
+++ b/src/content/dependencies/generateArtistInfoPage.js
@@ -353,12 +353,17 @@ export default {
               }),
 
             html.tags([
-              html.tag('p',
-                {[html.onlyIfSiblings]: true},
+              language.encapsulate(pageCapsule, 'wikiEditArtworks', capsule =>
+                relations.contentHeading.clone()
+                  .slots({
+                    tag: 'p',
 
-                language.$(pageCapsule, 'wikiEditArtworks', {
-                  artist: data.name,
-                })),
+                    title:
+                      language.$(capsule, {artist: data.name}),
+
+                    stickyTitle:
+                      language.$(capsule, 'sticky'),
+                  })),
 
               relations.editsForWikiArtworksChunkedList,
             ]),
@@ -386,12 +391,17 @@ export default {
             relations.commentaryChunkedList,
 
             html.tags([
-              html.tag('p',
-                {[html.onlyIfSiblings]: true},
+              language.encapsulate(pageCapsule, 'wikiEditorCommentary', capsule =>
+                relations.contentHeading.clone()
+                  .slots({
+                    tag: 'p',
 
-                language.$(pageCapsule, 'wikiEditorCommentary', {
-                  artist: data.name,
-                })),
+                    title:
+                      language.$(capsule, {artist: data.name}),
+
+                    stickyTitle:
+                      language.$(capsule, 'sticky'),
+                  })),
 
               relations.wikiEditorCommentaryChunkedList,
             ]),

--- a/src/content/dependencies/generateArtistInfoPageCommentaryChunkedList.js
+++ b/src/content/dependencies/generateArtistInfoPageCommentaryChunkedList.js
@@ -19,7 +19,7 @@ export default {
 
   extraDependencies: ['html', 'language'],
 
-  query(artist) {
+  query(artist, filterWikiEditorCommentary) {
     const processEntry = ({
       thing,
       entry,
@@ -87,6 +87,12 @@ export default {
         .flatMap(thing =>
           thing.commentary
             .filter(entry => entry.artists.includes(artist))
+
+            .filter(({annotation}) =>
+              (filterWikiEditorCommentary
+                ? annotation?.startsWith(`wiki editor`)
+                : !annotation?.startsWith(`wiki editor`)))
+
             .map(entry => processEntry({thing, entry})));
 
     const processAlbumEntries = ({albums}) =>
@@ -146,7 +152,7 @@ export default {
     return {chunks};
   },
 
-  relations: (relation, query) => ({
+  relations: (relation, query, _artist, filterWikiEditorCommentary) => ({
     chunks:
       query.chunks
         .map(() => relation('generateArtistInfoPageChunk')),
@@ -179,10 +185,13 @@ export default {
       query.chunks
         .map(({chunk}) => chunk
           .map(({annotation}) =>
-            relation('transformContent', annotation))),
+            relation('transformContent',
+              (filterWikiEditorCommentary
+                ? annotation?.replace(/^wiki editor(, )?/, '')
+                : annotation)))),
   }),
 
-  data: (query) => ({
+  data: (query, _artist, _filterWikiEditorCommentary) => ({
     chunkTypes:
       query.chunks
         .map(({chunkType}) => chunkType),

--- a/src/content/dependencies/generateArtistInfoPageCommentaryChunkedList.js
+++ b/src/content/dependencies/generateArtistInfoPageCommentaryChunkedList.js
@@ -179,9 +179,7 @@ export default {
       query.chunks
         .map(({chunk}) => chunk
           .map(({annotation}) =>
-            (annotation
-              ? relation('transformContent', annotation)
-              : null))),
+            relation('transformContent', annotation))),
   }),
 
   data: (query) => ({
@@ -232,12 +230,10 @@ export default {
                     }).map(({item, link, annotation, type}) =>
                       item.slots({
                         annotation:
-                          (annotation
-                            ? annotation.slots({
-                                mode: 'inline',
-                                absorbPunctuationFollowingExternalLinks: false,
-                              })
-                            : null),
+                          annotation.slots({
+                            mode: 'inline',
+                            absorbPunctuationFollowingExternalLinks: false,
+                          }),
 
                         content:
                           (type === 'album'

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -1247,6 +1247,9 @@ artistPage:
   wikiEditArtworks: >-
     {ARTIST} has edited these artworks for this wiki:
 
+  wikiEditorCommentary: >-
+    {ARTIST} has written these commentary entries as an editor of this wiki:
+
 #
 # artistGalleryPage:
 #   The artist gallery page shows a neat grid of all of the album and

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -1244,11 +1244,13 @@ artistPage:
     orBrowseList: "View {LINK}! Or browse the list:"
     link: "art gallery"
 
-  wikiEditArtworks: >-
-    {ARTIST} has edited these artworks for this wiki:
+  wikiEditArtworks:
+    _: "{ARTIST} has edited these artworks for this wiki:"
+    sticky: "Artworks — edited for this wiki"
 
-  wikiEditorCommentary: >-
-    {ARTIST} has written these commentary entries as an editor of this wiki:
+  wikiEditorCommentary:
+    _: "{ARTIST} has written these commentary entries as an editor of this wiki:"
+    sticky: "Commentary — written for this wiki"
 
 #
 # artistGalleryPage:

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -291,16 +291,16 @@ releaseInfo:
 
     sticky:
       _: "Tracks that reference this one:"
-      fromGroup: "Tracks from {GROUP} that reference this one:"
-      fromOther: "Tracks from somewhere else that reference this one:"
+      fromGroup: "Tracks that reference this one — from {GROUP}:"
+      fromOther: "Tracks that reference this one — from somewhere else:"
 
   tracksThatSample:
     _: "Tracks that sample {TRACK}:"
 
     sticky:
       _: "Tracks that sample this one:"
-      fromGroup: "Tracks from {GROUP} that sample this one:"
-      fromOther: "Tracks from somewhere else that sample this one:"
+      fromGroup: "Tracks that sample this one — from {GROUP}:"
+      fromOther: "Tracks that sample this one — from somewhere else:"
 
   flashesThatFeature:
     _: "Flashes & games that feature {TRACK}:"


### PR DESCRIPTION
Development:

- Resolves #568.
- Resolves #600.

Spiritual follow-up to #550, also incorporating #512.

Besides the above, this PR tweaks the strings for custom sticky subheadings for "from (group)" and "from somewhere else" on track info pages. These are basically *further-*subheadings under "Tracks that reference/sample this one", so for text stability, the further-sub part is placed at the end, after an emdash.