### PR TITLE
Deferred path conditions

### DIFF
--- a/src/page/album.js
+++ b/src/page/album.js
@@ -38,9 +38,12 @@ export function pathsForTarget(album) {
       },
     },
 
-    !empty(album.referencedArtworks) && {
+    {
       type: 'page',
       path: ['albumReferencedArtworks', album.directory],
+
+      condition: () =>
+        !empty(album.referencedArtworks),
 
       contentFunction: {
         name: 'generateAlbumReferencedArtworksPage',
@@ -48,9 +51,12 @@ export function pathsForTarget(album) {
       },
     },
 
-    !empty(album.referencedByArtworks) && {
+    {
       type: 'page',
       path: ['albumReferencingArtworks', album.directory],
+
+      condition: () =>
+        !empty(album.referencedByArtworks),
 
       contentFunction: {
         name: 'generateAlbumReferencingArtworksPage',
@@ -80,13 +86,15 @@ export function pathsTargetless({wikiData: {wikiInfo}}) {
       contentFunction: {name: 'generateCommentaryIndexPage'},
     },
 
-    wikiInfo.canonicalBase === 'https://hsmusic.wiki/' &&
-      {
-        type: 'redirect',
-        fromPath: ['page', 'list/all-commentary'],
-        toPath: ['commentaryIndex'],
-        title: 'Album Commentary',
-      },
+    {
+      type: 'redirect',
+      fromPath: ['page', 'list/all-commentary'],
+      toPath: ['commentaryIndex'],
+      title: 'Album Commentary',
+
+      condition: () =>
+        wikiInfo.canonicalBase === 'https://hsmusic.wiki/',
+    },
   ];
 }
 

--- a/src/page/artist.js
+++ b/src/page/artist.js
@@ -8,10 +8,6 @@ export function targets({wikiData}) {
 }
 
 export function pathsForTarget(artist) {
-  const hasGalleryPage =
-    !empty(artist.albumCoverArtistContributions) ||
-    !empty(artist.trackCoverArtistContributions);
-
   return [
     {
       type: 'page',
@@ -23,9 +19,13 @@ export function pathsForTarget(artist) {
       },
     },
 
-    hasGalleryPage && {
+    {
       type: 'page',
       path: ['artistGallery', artist.directory],
+
+      condition: () =>
+        !empty(artist.albumCoverArtistContributions) ||
+        !empty(artist.trackCoverArtistContributions),
 
       contentFunction: {
         name: 'generateArtistGalleryPage',

--- a/src/page/group.js
+++ b/src/page/group.js
@@ -7,8 +7,6 @@ export function targets({wikiData}) {
 }
 
 export function pathsForTarget(group) {
-  const hasGalleryPage = !empty(group.albums);
-
   return [
     {
       type: 'page',
@@ -20,9 +18,12 @@ export function pathsForTarget(group) {
       },
     },
 
-    hasGalleryPage && {
+    {
       type: 'page',
       path: ['groupGallery', group.directory],
+
+      condition: () =>
+        !empty(group.albums),
 
       contentFunction: {
         name: 'generateGroupGalleryPage',
@@ -34,20 +35,24 @@ export function pathsForTarget(group) {
 
 export function pathsTargetless({wikiData: {wikiInfo}}) {
   return [
-    wikiInfo.canonicalBase === 'https://hsmusic.wiki/' &&
-      {
-        type: 'redirect',
-        fromPath: ['page', 'albums/fandom'],
-        toPath: ['groupGallery', 'fandom'],
-        title: 'Fandom - Gallery',
-      },
+    {
+      type: 'redirect',
+      fromPath: ['page', 'albums/fandom'],
+      toPath: ['groupGallery', 'fandom'],
+      title: 'Fandom - Gallery',
 
-    wikiInfo.canonicalBase === 'https://hsmusic.wiki/' &&
-      {
-        type: 'redirect',
-        fromPath: ['page', 'albums/official'],
-        toPath: ['groupGallery', 'official'],
-        title: 'Official - Gallery',
-      },
+      condition: () =>
+        wikiInfo.canonicalBase === 'https://hsmusic.wiki/',
+    },
+
+    {
+      type: 'redirect',
+      fromPath: ['page', 'albums/official'],
+      toPath: ['groupGallery', 'official'],
+      title: 'Official - Gallery',
+
+      condition: () =>
+        wikiInfo.canonicalBase === 'https://hsmusic.wiki/',
+    },
   ];
 }

--- a/src/page/track.js
+++ b/src/page/track.js
@@ -20,9 +20,12 @@ export function pathsForTarget(track) {
       },
     },
 
-    !empty(track.referencedArtworks) && {
+    {
       type: 'page',
       path: ['trackReferencedArtworks', track.directory],
+
+      condition: () =>
+        !empty(track.referencedArtworks),
 
       contentFunction: {
         name: 'generateTrackReferencedArtworksPage',
@@ -30,9 +33,12 @@ export function pathsForTarget(track) {
       },
     },
 
-    !empty(track.referencedByArtworks) && {
+    {
       type: 'page',
       path: ['trackReferencingArtworks', track.directory],
+
+      condition: () =>
+        !empty(track.referencedByArtworks),
 
       contentFunction: {
         name: 'generateTrackReferencingArtworksPage',

--- a/src/write/build-modes/live-dev-server.js
+++ b/src/write/build-modes/live-dev-server.js
@@ -389,7 +389,11 @@ export async function go({
     // URL to page map expects trailing slash but no leading slash.
     const pathnameKey = pathname.replace(/^\//, '') + (pathname.endsWith('/') ? '' : '/');
 
-    if (!Object.hasOwn(urlToPageMap, pathnameKey)) {
+    const is404 =
+      !Object.hasOwn(urlToPageMap, pathnameKey) ||
+      !(urlToPageMap[pathnameKey].page.condition?.() ?? true);
+
+    if (is404) {
       response.writeHead(404, contentTypePlain);
       response.end(`No page found for: ${pathnameKey}\n`);
       if (loudResponses) console.log(`${requestHead} [404] ${pathname} (no page)`);

--- a/src/write/build-modes/static-build.js
+++ b/src/write/build-modes/static-build.js
@@ -195,7 +195,7 @@ export async function go({
           return null;
         }
 
-        const paths = [];
+        let paths = [];
 
         if (pageSpec.pathsTargetless) {
           const result = pageSpec.pathsTargetless({wikiData});
@@ -224,6 +224,9 @@ export async function go({
           paths.push(...targets.flatMap(target => pageSpec.pathsForTarget(target)));
           // TODO: Validate each pathsForTargets entry
         }
+
+        paths =
+          paths.filter(path => path.condition?.() ?? true);
 
         return paths;
       })


### PR DESCRIPTION
Makes `pathsForTarget` and `pathsTargetless` define conditional "does this page actually exist?" logic within a function, so that evaluation may be deferred wherever convenient.

For live-dev-server: We compute all page paths like normal, filling even the pages that might not exist into `urlToPageMap`. When the URL of a page is actually accessed, we check against evaluating the page's `condition` function, if present.

For static-build: We just filter the list of writes before returning, per build step. This means we evaluate all conditions at once and at the start of the build, just like before.

This makes no difference for static-build performance, but live-dev-server goes from computing page paths in about 8.2 seconds... to computing them in just 0.8 seconds(!!!). Of course, once a page is accessed, its condition still needs to be run. But conditions typically access the same data that actually generating the page would anyway—you're caching the same values used during content generation—and, you know, you only compute that *for the one page you're accessing,* not for Every Single Page Ever. It's faster. 👍 