### PR TITLE
Sidebar search transience

### DIFF
--- a/src/static/js/client/sidebar-search.js
+++ b/src/static/js/client/sidebar-search.js
@@ -350,7 +350,7 @@ export function addPageListeners() {
     }
 
     const inputRect = info.searchInput.getBoundingClientRect();
-    if (domEvent.clientX < inputRect.left) {
+    if (domEvent.clientX < inputRect.left - 3) {
       info.searchInput.select();
     }
   });

--- a/src/static/js/client/sidebar-search.js
+++ b/src/static/js/client/sidebar-search.js
@@ -461,7 +461,7 @@ export function initializeState() {
       info.searchInput.value = session.activeQuery;
       activateSidebarSearch(session.activeQuery);
     } else if (session.activeQueryResults) {
-      recallRecentSidebarSearch();
+      considerRecallingRecentSidebarSearch();
     }
   }
 }
@@ -1057,11 +1057,22 @@ function restoreSidebarSearchColumn() {
   info.searchInput.placeholder = info.standbyInputPlaceholder;
 }
 
-function recallRecentSidebarSearch() {
+function considerRecallingRecentSidebarSearch() {
   const {session, state} = info;
+
+  if (document.documentElement.dataset.urlKey === 'localized.home') {
+    return forgetRecentSidebarSearch();
+  }
 
   info.searchInput.placeholder = session.activeQuery;
   state.recallingRecentSearch = true;
+}
+
+function forgetRecentSidebarSearch() {
+  const {session} = info;
+
+  session.activeQuery = null;
+  session.activeQueryResults = null;
 }
 
 async function handleDroppedIntoSearchInput(domEvent) {

--- a/src/static/js/client/sidebar-search.js
+++ b/src/static/js/client/sidebar-search.js
@@ -72,6 +72,7 @@ export const info = {
     collapsedDetailsForTidiness: null,
 
     recallingRecentSearch: null,
+    recallingRecentSearchFromMouse: null,
 
     currentValue: null,
 
@@ -317,6 +318,14 @@ export function mutatePageContent() {
 export function addPageListeners() {
   if (!info.searchInput) return;
 
+  info.searchInput.addEventListener('mousedown', _domEvent => {
+    const {state} = info;
+
+    if (state.recallingRecentSearch) {
+      state.recallingRecentSearchFromMouse = true;
+    }
+  });
+
   info.searchInput.addEventListener('focus', _domEvent => {
     const {session, state} = info;
 
@@ -325,6 +334,19 @@ export function addPageListeners() {
       info.searchInput.placeholder = info.standbyInputPlaceholder;
       showSidebarSearchResults(session.activeQueryResults);
       state.recallingRecentSearch = false;
+    }
+  });
+
+  info.searchLabel.addEventListener('click', domEvent => {
+    const {state} = info;
+
+    if (state.recallingRecentSearchFromMouse) {
+      if (info.searchInput.selectionStart === info.searchInput.selectionEnd) {
+        info.searchInput.select();
+      }
+
+      state.recallingRecentSearchFromMouse = false;
+      return;
     }
   });
 

--- a/src/static/js/client/sidebar-search.js
+++ b/src/static/js/client/sidebar-search.js
@@ -348,6 +348,11 @@ export function addPageListeners() {
       state.recallingRecentSearchFromMouse = false;
       return;
     }
+
+    const inputRect = info.searchInput.getBoundingClientRect();
+    if (domEvent.clientX < inputRect.left) {
+      info.searchInput.select();
+    }
   });
 
   info.searchInput.addEventListener('change', _domEvent => {

--- a/src/static/js/client/sidebar-search.js
+++ b/src/static/js/client/sidebar-search.js
@@ -476,6 +476,10 @@ function trackSidebarSearchDownloadEnds(event) {
 async function activateSidebarSearch(query) {
   const {session, state} = info;
 
+  if (!query) {
+    return;
+  }
+
   if (state.stoppedTypingTimeout) {
     clearTimeout(state.stoppedTypingTimeout);
     state.stoppedTypingTimeout = null;

--- a/src/static/js/client/sidebar-search.js
+++ b/src/static/js/client/sidebar-search.js
@@ -49,6 +49,8 @@ export const info = {
   endSearchLine: null,
   endSearchLink: null,
 
+  standbyInputPlaceholder: null,
+
   preparingString: null,
   loadingDataString: null,
   searchingString: null,
@@ -68,6 +70,8 @@ export const info = {
 
     tidiedSidebar: null,
     collapsedDetailsForTidiness: null,
+
+    recallingRecentSearch: null,
 
     currentValue: null,
 
@@ -132,6 +136,9 @@ export function getPageReferences() {
 
   info.searchSidebarColumn =
     info.searchBox.closest('.sidebar-column');
+
+  info.standbyInputPlaceholder =
+    info.searchInput.placeholder;
 
   const findString = classPart =>
     info.searchBox.querySelector(`.wiki-search-${classPart}-string`);
@@ -310,6 +317,17 @@ export function mutatePageContent() {
 export function addPageListeners() {
   if (!info.searchInput) return;
 
+  info.searchInput.addEventListener('focus', _domEvent => {
+    const {session, state} = info;
+
+    if (state.recallingRecentSearch) {
+      info.searchInput.value = session.activeQuery;
+      info.searchInput.placeholder = info.standbyInputPlaceholder;
+      showSidebarSearchResults(session.activeQueryResults);
+      state.recallingRecentSearch = false;
+    }
+  });
+
   info.searchInput.addEventListener('change', _domEvent => {
     const {state} = info;
 
@@ -412,11 +430,11 @@ export function initializeState() {
   if (!info.searchInput) return;
 
   if (session.activeQuery) {
-    info.searchInput.value = session.activeQuery;
     if (session.repeatQueryOnReload) {
+      info.searchInput.value = session.activeQuery;
       activateSidebarSearch(session.activeQuery);
     } else if (session.activeQueryResults) {
-      showSidebarSearchResults(session.activeQueryResults);
+      recallRecentSidebarSearch();
     }
   }
 }
@@ -1008,6 +1026,15 @@ function restoreSidebarSearchColumn() {
 
   state.collapsedDetailsForTidiness = [];
   state.tidiedSidebar = null;
+
+  info.searchInput.placeholder = info.standbyInputPlaceholder;
+}
+
+function recallRecentSidebarSearch() {
+  const {session, state} = info;
+
+  info.searchInput.placeholder = session.activeQuery;
+  state.recallingRecentSearch = true;
 }
 
 async function handleDroppedIntoSearchInput(domEvent) {


### PR DESCRIPTION
(Code is yesterday's from Whisper, summary is from Lan.)

This pull request adjusts the way that an "active" (now recent) search query is preserved and presented as you navigate the site after making a search. Summary of the relevant new beavior:

* Newly made searches are saved as the active/recent search just like before.
* Recent searches are now only recalled quietly at first: the search input's placeholder is replaced with the query you searched. Otherwise it's visually just as though you hadn't made a search at all, in particular meaning it takes no more space than usual, and the sidebar is left as-is.
* The results during the recent search (also saved like usual) are restored only once you focus the search input. This also collapses other sidebar contents like usual, and restores the query as the input's actual value, which is immediately selected for quick replacing (if you selected the input by click).
* Returning to the wiki homepage always discards a recent search, forgetting it even if you navigate to some other page after. However, navigating between any other links on the wiki will continue to preserve the recent search (just quietly, until you interact).

We also made a couple halfway-related changes:

* `activateSidebarSearch`, the common entry point for all new searches, now always discards an empty query passed directly to it. This has no bearing on DOM i.e. it doesn't care about or affect `info.searchInput`, but it does cancel out of itself when passed a blank string. Some recent code (we believe #585) made *clearing* the search input sometimes activate a search. This sidesteps that problem entirely.
* We found selecting the entire search input was convenient for reading a replace, but we didn't want clicking to *always* do that, because you should still be able to e.g. click to move the cursor or select a range of text. Instead we made that hapepn when you click the magnifying glass. (Really, anywhere more than 3px left of the search input. The offset is so that clicking at the very start of the input is a little easier.)

We've labelled this also under "performance" because generating search results takes *some* manner of time, a relatively expensive mutation to do at the start of every page load—especially if we're blocking the first render (#470). Safari doesn't support blocking renders though, so we haven't gotten to test that hands-on.

This PR also spiritually follows up recent non-PR changes in 30a817020a548351b3ef44276d130858d328685b, which made search results not fill up the entire screen height e.g. on mobile devices. The changes there and here work well together, but this one recontextualizes those to be about ensuring there's still a cue for where you are *as you continue a search,* rather than after you navigate to a page. In the latter case, now, we just show the entire page, right away, same as if you'd gotten there without searching.
