### PR TITLE
Show image overlay for images linked from content

### DIFF
--- a/src/content/dependencies/generateImageOverlay.js
+++ b/src/content/dependencies/generateImageOverlay.js
@@ -1,0 +1,50 @@
+export default {
+  extraDependencies: ['html', 'language'],
+
+  generate: ({html, language}) =>
+    html.tag('div', {id: 'image-overlay-container'},
+      html.tag('div', {id: 'image-overlay-content-container'}, [
+        html.tag('span', {id: 'image-overlay-image-area'},
+          html.tag('span', {id: 'image-overlay-image-layout'}, [
+            html.tag('img', {id: 'image-overlay-image'}),
+            html.tag('img', {id: 'image-overlay-image-thumb'}),
+          ])),
+
+        html.tag('div', {id: 'image-overlay-action-container'},
+          language.encapsulate('releaseInfo.viewOriginalFile', capsule => [
+            html.tag('div', {id: 'image-overlay-action-content-without-size'},
+              language.$(capsule, {
+                link: html.tag('a', {class: 'image-overlay-view-original'},
+                  language.$(capsule, 'link')),
+              })),
+
+            html.tag('div', {id: 'image-overlay-action-content-with-size'}, [
+              language.$(capsule, 'withSize', {
+                link:
+                  html.tag('a', {class: 'image-overlay-view-original'},
+                    language.$(capsule, 'link')),
+
+                size:
+                  html.tag('span',
+                    {[html.joinChildren]: ''},
+                    [
+                      html.tag('span', {id: 'image-overlay-file-size-kilobytes'},
+                        language.$('count.fileSize.kilobytes', {
+                          kilobytes:
+                            html.tag('span', {class: 'image-overlay-file-size-count'}),
+                        })),
+
+                      html.tag('span', {id: 'image-overlay-file-size-megabytes'},
+                        language.$('count.fileSize.megabytes', {
+                          megabytes:
+                            html.tag('span', {class: 'image-overlay-file-size-count'}),
+                        })),
+                    ]),
+              }),
+
+              html.tag('span', {id: 'image-overlay-file-size-warning'},
+                language.$(capsule, 'sizeWarning')),
+            ]),
+          ])),
+      ])),
+};

--- a/src/content/dependencies/generatePageLayout.js
+++ b/src/content/dependencies/generatePageLayout.js
@@ -540,10 +540,11 @@ export default {
 
     const imageOverlayHTML = html.tag('div', {id: 'image-overlay-container'},
       html.tag('div', {id: 'image-overlay-content-container'}, [
-        html.tag('a', {id: 'image-overlay-image-container'}, [
-          html.tag('img', {id: 'image-overlay-image'}),
-          html.tag('img', {id: 'image-overlay-image-thumb'}),
-        ]),
+        html.tag('span', {id: 'image-overlay-image-area'},
+          html.tag('span', {id: 'image-overlay-image-layout'}, [
+            html.tag('img', {id: 'image-overlay-image'}),
+            html.tag('img', {id: 'image-overlay-image-thumb'}),
+          ])),
 
         html.tag('div', {id: 'image-overlay-action-container'},
           language.encapsulate('releaseInfo.viewOriginalFile', capsule => [

--- a/src/content/dependencies/generatePageLayout.js
+++ b/src/content/dependencies/generatePageLayout.js
@@ -5,6 +5,7 @@ export default {
   contentDependencies: [
     'generateColorStyleRules',
     'generateFooterLocalizationLinks',
+    'generateImageOverlay',
     'generatePageSidebar',
     'generateSearchSidebarBox',
     'generateStickyHeadingContainer',
@@ -59,6 +60,9 @@ export default {
 
     relations.colorStyleRules =
       relation('generateColorStyleRules');
+
+    relations.imageOverlay =
+      relation('generateImageOverlay');
 
     return relations;
   },
@@ -538,52 +542,6 @@ export default {
             ])),
         ]);
 
-    const imageOverlayHTML = html.tag('div', {id: 'image-overlay-container'},
-      html.tag('div', {id: 'image-overlay-content-container'}, [
-        html.tag('span', {id: 'image-overlay-image-area'},
-          html.tag('span', {id: 'image-overlay-image-layout'}, [
-            html.tag('img', {id: 'image-overlay-image'}),
-            html.tag('img', {id: 'image-overlay-image-thumb'}),
-          ])),
-
-        html.tag('div', {id: 'image-overlay-action-container'},
-          language.encapsulate('releaseInfo.viewOriginalFile', capsule => [
-            html.tag('div', {id: 'image-overlay-action-content-without-size'},
-              language.$(capsule, {
-                link: html.tag('a', {class: 'image-overlay-view-original'},
-                  language.$(capsule, 'link')),
-              })),
-
-            html.tag('div', {id: 'image-overlay-action-content-with-size'}, [
-              language.$(capsule, 'withSize', {
-                link:
-                  html.tag('a', {class: 'image-overlay-view-original'},
-                    language.$(capsule, 'link')),
-
-                size:
-                  html.tag('span',
-                    {[html.joinChildren]: ''},
-                    [
-                      html.tag('span', {id: 'image-overlay-file-size-kilobytes'},
-                        language.$('count.fileSize.kilobytes', {
-                          kilobytes:
-                            html.tag('span', {class: 'image-overlay-file-size-count'}),
-                        })),
-
-                      html.tag('span', {id: 'image-overlay-file-size-megabytes'},
-                        language.$('count.fileSize.megabytes', {
-                          megabytes:
-                            html.tag('span', {class: 'image-overlay-file-size-count'}),
-                        })),
-                    ]),
-              }),
-
-              html.tag('span', {id: 'image-overlay-file-size-warning'},
-                language.$(capsule, 'sizeWarning')),
-            ]),
-          ])),
-      ]));
-
     const styleRulesCSS =
       html.resolve(slots.styleRules, {normalize: 'string'});
 
@@ -780,7 +738,7 @@ export default {
                 ]),
 
               // infoCardHTML,
-              imageOverlayHTML,
+              relations.imageOverlay,
             ]),
         ])
     ]).toString();

--- a/src/content/dependencies/image.js
+++ b/src/content/dependencies/image.js
@@ -224,7 +224,6 @@ export default {
 
       const originalDimensions = getDimensionsOfImagePath(mediaSrc);
       const availableThumbs = getThumbnailsAvailableForDimensions(originalDimensions);
-      const originalLength = Math.max(originalDimensions[0], originalDimensions[1]);
 
       const fileSize =
         (willLink && mediaSrc
@@ -235,8 +234,7 @@ export default {
         fileSize &&
           {'data-original-size': fileSize},
 
-        originalLength &&
-          {'data-original-length': originalLength},
+        {'data-dimensions': originalDimensions.join('x')},
 
         !empty(availableThumbs) &&
           {'data-thumbs':

--- a/src/content/dependencies/linkPathFromMedia.js
+++ b/src/content/dependencies/linkPathFromMedia.js
@@ -1,5 +1,16 @@
+import {empty} from '#sugar';
+
 export default {
   contentDependencies: ['linkTemplate'],
+
+  extraDependencies: [
+    'checkIfImagePathHasCachedThumbnails',
+    'getDimensionsOfImagePath',
+    'getSizeOfMediaFile',
+    'getThumbnailsAvailableForDimensions',
+    'html',
+    'to',
+  ],
 
   relations: (relation) =>
     ({link: relation('linkTemplate')}),
@@ -7,7 +18,45 @@ export default {
   data: (path) =>
     ({path}),
 
-  generate: (data, relations) =>
-    relations.link
-      .slot('path', ['media.path', data.path]),
+  generate(data, relations, {
+    checkIfImagePathHasCachedThumbnails,
+    getDimensionsOfImagePath,
+    getSizeOfMediaFile,
+    getThumbnailsAvailableForDimensions,
+    html,
+    to,
+  }) {
+    const attributes = html.attributes();
+
+    if (checkIfImagePathHasCachedThumbnails(data.path)) {
+      const dimensions = getDimensionsOfImagePath(data.path);
+      const availableThumbs = getThumbnailsAvailableForDimensions(dimensions);
+      const fileSize = getSizeOfMediaFile(data.path);
+
+      const embedSrc =
+        to('thumb.path', data.path.replace(/\.(png|jpg)$/, '.tack.jpg'));
+
+      attributes.add([
+        {class: 'image-media-link'},
+
+        {'data-embed-src': embedSrc},
+
+        fileSize &&
+          {'data-original-size': fileSize},
+
+        !empty(availableThumbs) &&
+          {'data-thumbs':
+              availableThumbs
+                .map(([name, size]) => `${name}:${size}`)
+                .join(' ')},
+      ]);
+    }
+
+    relations.link.setSlots({
+      attributes,
+      path: ['media.path', data.path],
+    });
+
+    return relations.link;
+  },
 };

--- a/src/content/dependencies/linkPathFromMedia.js
+++ b/src/content/dependencies/linkPathFromMedia.js
@@ -44,6 +44,8 @@ export default {
         fileSize &&
           {'data-original-size': fileSize},
 
+        {'data-dimensions': dimensions.join('x')},
+
         !empty(availableThumbs) &&
           {'data-thumbs':
               availableThumbs

--- a/src/content/dependencies/linkTemplate.js
+++ b/src/content/dependencies/linkTemplate.js
@@ -26,6 +26,11 @@ export default {
       type: 'html',
       mutable: false,
     },
+
+    suffixNormalContent: {
+      type: 'html',
+      mutable: false,
+    },
   },
 
   generate(slots, {
@@ -61,13 +66,22 @@ export default {
       attributes.set('title', slots.tooltip);
     }
 
-    const content =
+    const mainContent =
       (html.isBlank(slots.content)
         ? language.$('misc.missingLinkContent')
-        : striptags(html.resolve(slots.content, {normalize: 'string'}), {
-            disallowedTags: new Set(['a']),
-          }));
+        : striptags(
+            html.resolve(slots.content, {normalize: 'string'}),
+            {disallowedTags: new Set(['a'])}));
 
-    return html.tag('a', attributes, content);
+    const allContent =
+      (html.isBlank(slots.suffixNormalContent)
+        ? mainContent
+        : html.tags([
+            mainContent,
+            html.tag('span', {class: 'normal-content'},
+              slots.suffixNormalContent),
+          ], {[html.joinChildren]: ''}));
+
+    return html.tag('a', attributes, allContent);
   },
 }

--- a/src/content/dependencies/transformContent.js
+++ b/src/content/dependencies/transformContent.js
@@ -264,7 +264,7 @@ export default {
           }
 
           const text = nextNode.data;
-          const match = text.match(/^[.,;:?!…]+(?=.*[a-z])/i);
+          const match = text.match(/^[.,;:?!…]+(?=[^\n]*[a-z])/i);
           const suffix = match?.[0];
           if (suffix) {
             template.setSlot('suffixNormalContent', suffix);

--- a/src/content/dependencies/transformContent.js
+++ b/src/content/dependencies/transformContent.js
@@ -258,6 +258,20 @@ export default {
       data.nodes.map((node, index) => {
         const nextNode = data.nodes[index + 1];
 
+        const absorbFollowingPunctuation = template => {
+          if (nextNode?.type !== 'text') {
+            return;
+          }
+
+          const text = nextNode.data;
+          const match = text.match(/^[.,;:?!…]+/);
+          const suffix = match?.[0];
+          if (suffix) {
+            template.setSlot('suffixNormalContent', suffix);
+            offsetTextNode = suffix.length;
+          }
+        };
+
         switch (node.type) {
           case 'text': {
             const text = node.data.slice(offsetTextNode);
@@ -458,14 +472,8 @@ export default {
               fromContent: true,
             });
 
-            if (slots.absorbPunctuationFollowingExternalLinks && nextNode?.type === 'text') {
-              const text = nextNode.data;
-              const match = text.match(/^[.,;:?!…]+/);
-              const suffix = match?.[0];
-              if (suffix) {
-                externalLink.setSlot('suffixNormalContent', suffix);
-                offsetTextNode = suffix.length;
-              }
+            if (slots.absorbPunctuationFollowingExternalLinks) {
+              absorbFollowingPunctuation(externalLink);
             }
 
             if (slots.indicateExternalLinks) {

--- a/src/content/dependencies/transformContent.js
+++ b/src/content/dependencies/transformContent.js
@@ -460,6 +460,18 @@ export default {
               link.setSlot('tooltipStyle', 'none');
             }
 
+            let doTheAbsorbyThing = false;
+
+            // TODO: This is just silly.
+            try {
+              const tag = html.resolve(link, {normalize: 'tag'});
+              doTheAbsorbyThing ||= tag.attributes.has('class', 'image-media-link');
+            } catch {}
+
+            if (doTheAbsorbyThing) {
+              absorbFollowingPunctuation(link);
+            }
+
             return {type: 'processed-internal-link', data: link};
           }
 

--- a/src/content/dependencies/transformContent.js
+++ b/src/content/dependencies/transformContent.js
@@ -264,7 +264,7 @@ export default {
           }
 
           const text = nextNode.data;
-          const match = text.match(/^[.,;:?!…]+/);
+          const match = text.match(/^[.,;:?!…]+(?=.*[a-z])/i);
           const suffix = match?.[0];
           if (suffix) {
             template.setSlot('suffixNormalContent', suffix);

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -904,6 +904,24 @@ a:not([href]):hover {
   color: white;
 }
 
+.image-media-link::after {
+  content: '';
+  display: inline-block;
+  width: 22px;
+  height: 1em;
+
+  background-color: var(--primary-color);
+
+  mask-image: url(/static-4p1/misc/image.svg);
+  mask-repeat: no-repeat;
+  mask-position: calc(100% - 2px);
+  vertical-align: text-bottom;
+}
+
+.image-media-link:hover::after {
+  background-color: white;
+}
+
 .nav-link {
   display: inline-block;
 }

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -887,6 +887,10 @@ a:not([href]):hover {
   text-decoration: none;
 }
 
+a .normal-content {
+  color: white;
+}
+
 .external-link:not(.from-content) {
   white-space: nowrap;
 }
@@ -897,10 +901,6 @@ a:not([href]):hover {
 }
 
 .external-link.indicate-external:hover::after {
-  color: white;
-}
-
-.external-link .normal-content {
   color: white;
 }
 

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -3157,31 +3157,30 @@ main.long-content .content-sticky-heading-container .content-sticky-subheading-r
           backdrop-filter: blur(3px);
 }
 
-#image-overlay-image-container {
+#image-overlay-image-area {
   display: block;
-  position: relative;
   overflow: hidden;
   width: 80vmin;
-  height: 80vmin;
   margin-left: auto;
   margin-right: auto;
 }
 
+#image-overlay-image-layout {
+  display: block;
+  position: relative;
+  margin: 4px 3px;
+  background: rgba(0, 0, 0, 0.65);
+}
+
 #image-overlay-image,
 #image-overlay-image-thumb {
-  display: inline-block;
-  object-fit: contain;
+  display: block;
   width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.65);
+  height: auto;
 }
 
 #image-overlay-image {
   position: absolute;
-  top: 3px;
-  left: 3px;
-  width: calc(100% - 6px);
-  height: calc(100% - 4px);
 }
 
 #image-overlay-image-thumb {
@@ -3195,7 +3194,7 @@ main.long-content .content-sticky-heading-container .content-sticky-subheading-r
   transition: opacity 0.25s;
 }
 
-#image-overlay-image-container::after {
+#image-overlay-image-area::after {
   content: "";
   display: block;
   position: absolute;
@@ -3208,18 +3207,18 @@ main.long-content .content-sticky-heading-container .content-sticky-subheading-r
   transition: 0.25s;
 }
 
-#image-overlay-container.loaded #image-overlay-image-container::after {
+#image-overlay-container.loaded #image-overlay-image-area::after {
   width: 100%;
   background: white;
   opacity: 0;
 }
 
-#image-overlay-container.errored #image-overlay-image-container::after {
+#image-overlay-container.errored #image-overlay-image-area::after {
   width: 100%;
   background: red;
 }
 
-#image-overlay-container:not(.visible) #image-overlay-image-container::after {
+#image-overlay-container:not(.visible) #image-overlay-image-area::after {
   width: 0 !important;
 }
 

--- a/src/static/js/client/image-overlay.js
+++ b/src/static/js/client/image-overlay.js
@@ -66,8 +66,13 @@ export function getPageReferences() {
   info.fileSizeWarning =
     document.getElementById('image-overlay-file-size-warning');
 
+  const linkQuery = [
+    '.image-link',
+    '.image-media-link',
+  ].join(', ');
+
   info.links =
-    Array.from(document.querySelectorAll('.image-link'))
+    Array.from(document.querySelectorAll(linkQuery))
       .filter(link => !link.closest('.no-image-preview'));
 }
 

--- a/src/static/js/client/image-overlay.js
+++ b/src/static/js/client/image-overlay.js
@@ -234,7 +234,7 @@ async function loadOverlayImage(details) {
   // Show the thumbnail size on each <img> element's data attributes.
   // Y'know, just for debugging convenience.
   info.mainImage.dataset.displayingThumb = details.mainThumb;
-  info.thumbImage.dataset.displayingThumb = details.thumbThubm;
+  info.thumbImage.dataset.displayingThumb = details.thumbThumb;
 
   if (details.dimensions) {
     info.mainImage.width = details.dimensions[0];

--- a/src/static/js/client/image-overlay.js
+++ b/src/static/js/client/image-overlay.js
@@ -159,6 +159,11 @@ function getImageLinkDetails(imageLink) {
       a.dataset.thumbs ??
       null,
 
+    dimensions:
+      img?.dataset.dimensions?.split('x') ??
+      a.dataset.dimensions?.split('x') ??
+      null,
+
     color:
       cssProp(imageLink, '--primary-color'),
   };
@@ -230,6 +235,20 @@ async function loadOverlayImage(details) {
   // Y'know, just for debugging convenience.
   info.mainImage.dataset.displayingThumb = details.mainThumb;
   info.thumbImage.dataset.displayingThumb = details.thumbThubm;
+
+  if (details.dimensions) {
+    info.mainImage.width = details.dimensions[0];
+    info.mainImage.height = details.dimensions[1];
+    info.thumbImage.width = details.dimensions[0];
+    info.thumbImage.height = details.dimensions[1];
+    cssProp(info.thumbImage, 'aspect-ratio', details.dimensions.join('/'));
+  } else {
+    info.mainImage.removeAttribute('width');
+    info.mainImage.removeAttribute('height');
+    info.thumbImage.removeAttribute('width');
+    info.thumbImage.removeAttribute('height');
+    cssProp(info.thumbImage, 'aspect-ratio', null);
+  }
 
   info.mainImage.addEventListener('load', handleMainImageLoaded);
   info.mainImage.addEventListener('error', handleMainImageErrored);

--- a/src/static/js/client/image-overlay.js
+++ b/src/static/js/client/image-overlay.js
@@ -93,10 +93,10 @@ function handleContainerClicked(evt) {
     return;
   }
 
-  // If you clicked anything close to or beneath the action bar, don't hide
-  // the image overlay.
+  // If you clicked anything near the action bar, don't hide the
+  // image overlay.
   const rect = info.actionContainer.getBoundingClientRect();
-  if (evt.clientY >= rect.top - 40) {
+  if (evt.clientY >= rect.top - 40 && evt.clientY <= rect.bottom + 40) {
     return;
   }
 

--- a/src/static/js/client/image-overlay.js
+++ b/src/static/js/client/image-overlay.js
@@ -141,13 +141,18 @@ function getImageLinkDetails(imageLink) {
       a.href,
 
     embeddedSrc:
-      img.src,
+      img?.src ??
+      a.dataset.embedSrc,
 
     originalFileSize:
-      img.dataset.originalSize,
+      img?.dataset.originalSize ??
+      a.dataset.originalSize ??
+      null,
 
     availableThumbList:
-      img.dataset.thumbs,
+      img?.dataset.thumbs ??
+      a.dataset.thumbs ??
+      null,
 
     color:
       cssProp(imageLink, '--primary-color'),

--- a/src/static/misc/image.svg
+++ b/src/static/misc/image.svg
@@ -1,0 +1,11 @@
+<!-- Copyright © (c) 2019-2023 The Bootstrap authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+The Software is provided "as is", without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose and noninfringement. In no event shall the authors or copyright holders be liable for any claim, damages or other liability, whether in an action of contract, tort or otherwise, arising from, out of or in connection with the Software or the use or other dealings in the Software. -->
+
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-image-fill" viewBox="0 0 16 16">
+  <path d="M.002 3a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2h-12a2 2 0 0 1-2-2V3zm1 9v1a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V9.5l-3.777-1.947a.5.5 0 0 0-.577.093l-3.71 3.71-2.66-1.772a.5.5 0 0 0-.63.062L1.002 12zm5-6.5a1.5 1.5 0 1 0-3 0 1.5 1.5 0 0 0 3 0z"/>
+</svg>


### PR DESCRIPTION
Development:

* Resolves #538 

See demo and screenshots in [#hsmusic-chat](https://discord.com/channels/749042497610842152/779895315750715422/1352387325442785341).

Sort of a grab bag of related changes apart from the main feature, including:

* Image overlay now fits itself to rectangles. Minor HTML layout changes to support this; we now have a container which is exactly the size of both the main image and the thumb. (Its own size is still according to the thumb, which I believe loads before the overlay is shown to begin with.)
    * This may result in a slight presentational change wrt margins and a tiny sliver of darker "border" (transparent background) that was, and is no longer, visible at the top and bottom of the image. We can tweak these as desired but I think we'll come back to it later alongside video embeds or other more interesting overlay behavior.
* Thumb size is now Actually Correct instead of generally having its height a bit off due to a lower resolution representation of the aspect ratio of the original image. (For example, a 800x430 image scaled to fit in an 8x8 square becomes 8x4; scaled up this will always give you an 8:4 aspect ratio, never 8:4.3.)
* Punctuation absorption is factored out ("normal content" works in any link now) and is a little more intelligent, considering if there's eventually going to be any words-y text in the immediately following text node before activating. This mostly means links which are *only* separated by punctuation don't cause *that* punctuation to get absorbed. Avoids humorous bullshit. ([#hsmusic-chat](https://discord.com/channels/749042497610842152/779895315750715422/1352436725590265898))
* Image overlay layout is factored out of `generatePageLayout`. It's still static.
* Image overlay client code works gracefully with these links that don't actually contain `<img>` elements—just a second path for most attribute accesses in `getImageLinkDetails`, and additionally querying for `.image-media-link` in `info.link`.
* In general clicking on the background behind the image overlay dismisses the overlay. However, previously, clicking anywhere near *or below* the "action bar" - the line w/ the "view original file" link - would cause that click to be ignored (for this purpose). Now the threshold is only to a set distance below that bar; clicking further down inside the background *will* dismiss the overlay. Helps for short/wide images, but also for tall displays (e.g. portrait orientation phones).