### PR TITLE
Sticky collapse!

### DIFF
--- a/src/content/dependencies/generateStickyHeadingContainer.js
+++ b/src/content/dependencies/generateStickyHeadingContainer.js
@@ -13,27 +13,45 @@ export default {
     },
   },
 
-  generate: (slots, {html}) =>
-    html.tag('div', {class: 'content-sticky-heading-container'},
+  generate: (slots, {html}) => html.tags([
+    html.tag('div', {class: 'content-sticky-heading-root'},
       !html.isBlank(slots.cover) &&
         {class: 'has-cover'},
 
-      [
-        html.tag('div', {class: 'content-sticky-heading-row'}, [
-          html.tag('h1', slots.title),
+      html.tag('div', {class: 'content-sticky-heading-anchor'},
+        html.tag('div', {class: 'content-sticky-heading-container'},
+          !html.isBlank(slots.cover) &&
+            {class: 'has-cover'},
 
-          html.tag('div', {class: 'content-sticky-heading-cover-container'},
-            {[html.onlyIfContent]: true},
+          [
+            html.tag('div', {class: 'content-sticky-heading-row'}, [
+              html.tag('h1', [
+                slots.title,
 
-            html.tag('div', {class: 'content-sticky-heading-cover'},
-              {[html.onlyIfContent]: true},
+                // Placement after generally keeps the contents from being
+                // the first, when matched by .querySelector() calls.
+                html.tag('span', {class: 'reference-collapsed-heading'},
+                  slots.title.clone()),
+              ]),
 
-              (html.isBlank(slots.cover)
-                ? html.blank()
-                : slots.cover.slot('mode', 'thumbnail')))),
-        ]),
+              html.tag('div', {class: 'content-sticky-heading-cover-container'},
+                {[html.onlyIfContent]: true},
 
-        html.tag('div', {class: 'content-sticky-subheading-row'},
-          html.tag('h2', {class: 'content-sticky-subheading'})),
-      ]),
+                html.tag('div', {class: 'content-sticky-heading-cover'},
+                  {[html.onlyIfContent]: true},
+
+                  (html.isBlank(slots.cover)
+                    ? html.blank()
+                    : slots.cover.slot('mode', 'thumbnail')))),
+            ]),
+
+            html.tag('div', {class: 'content-sticky-subheading-row'},
+              html.tag('h2', {class: 'content-sticky-subheading'})),
+          ]))),
+
+    html.tag('h1', {class: 'imaginary-static-heading-root'},
+      html.tag('span', {class: 'imaginary-static-heading-row'},
+        html.tag('span', {class: 'imaginary-static-heading-title'},
+          slots.title.clone()))),
+  ]),
 };

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -2992,6 +2992,7 @@ main.long-content .content-sticky-heading-container .content-sticky-subheading-r
   position: relative;
   margin: 0;
   padding-right: 20px;
+  line-height: 1.4;
 }
 
 .content-sticky-heading-row h1 .reference-collapsed-heading {

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -3083,6 +3083,7 @@ main.long-content .content-sticky-heading-container .content-sticky-subheading-r
 }
 
 .content-sticky-subheading-row {
+  position: absolute;
   width: 100%;
   box-sizing: border-box;
   padding: 10px 20px 5px 20px;

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -3078,7 +3078,6 @@ main.long-content .content-sticky-heading-container .content-sticky-subheading-r
 }
 
 .content-sticky-subheading-row {
-  position: absolute;
   width: 100%;
   box-sizing: border-box;
   padding: 10px 20px 5px 20px;

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -2992,6 +2992,10 @@ main.long-content .content-sticky-heading-container .content-sticky-subheading-r
   position: relative;
   margin: 0;
   padding-right: 20px;
+}
+
+.content-sticky-heading-row h1,
+.imaginary-static-heading-title {
   line-height: 1.4;
 }
 

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -3015,8 +3015,12 @@ main.long-content .content-sticky-heading-container .content-sticky-subheading-r
     height: var(--uncollapsed-heading-height);
   }
 
-  to {
+  99.9% {
     height: var(--collapsed-heading-height);
+  }
+
+  to {
+    height: auto;
   }
 }
 

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -2903,14 +2903,36 @@ h3.content-heading {
   );
 }
 
-.content-sticky-heading-container {
+.content-sticky-heading-root {
   position: sticky;
   top: 0;
+  width: 100%;
+}
 
+.content-sticky-heading-anchor {
+  position: relative;
+  width: 100%;
+}
+
+.content-sticky-heading-container {
+  position: absolute;
+  width: 100%;
+}
+
+.imaginary-static-heading-root,
+.imaginary-static-heading-row,
+.imaginary-static-heading-title {
+  display: block;
+}
+
+.content-sticky-heading-root,
+.imaginary-static-heading-root {
+  width: calc(100% + 2 * var(--content-padding));
   margin: calc(-1 * var(--content-padding));
-  margin-bottom: calc(0.5 * var(--content-padding));
+}
 
-  transform: translateY(-5px);
+.imaginary-static-heading-root {
+  margin-bottom: calc(0.5 * var(--content-padding));
 }
 
 main.long-content .content-sticky-heading-container {
@@ -2924,7 +2946,12 @@ main.long-content .content-sticky-heading-container .content-sticky-subheading-r
   padding-right: calc(var(--long-content-padding-ratio) * (100% - 2 * var(--content-padding)) + var(--content-padding));
 }
 
-.content-sticky-heading-row {
+.imaginary-static-heading-root {
+  visibility: hidden;
+}
+
+.content-sticky-heading-row,
+.imaginary-static-heading-row {
   box-sizing: border-box;
   padding:
     calc(1.25 * var(--content-padding) + 5px)
@@ -2934,7 +2961,9 @@ main.long-content .content-sticky-heading-container .content-sticky-subheading-r
 
   width: 100%;
   margin: 0;
+}
 
+.content-sticky-heading-row {
   background: var(--bg-black-color);
   border-bottom: 1px dotted rgba(220, 220, 220, 0.4);
 
@@ -2950,9 +2979,56 @@ main.long-content .content-sticky-heading-container .content-sticky-subheading-r
   grid-template-columns: 1fr min(40%, 400px);
 }
 
+.content-sticky-heading-container.cover-visible .content-sticky-heading-row {
+  grid-template-columns: 1fr min(40%, 90px);
+}
+
+.content-sticky-heading-root.has-cover +
+.imaginary-static-heading-root .imaginary-static-heading-title {
+  padding-right: min(40%, 400px);
+}
+
 .content-sticky-heading-row h1 {
+  position: relative;
   margin: 0;
   padding-right: 20px;
+}
+
+.content-sticky-heading-row h1 .reference-collapsed-heading {
+  position: absolute;
+  white-space: nowrap;
+  visibility: hidden;
+}
+
+.content-sticky-heading-container.collapse h1 {
+  white-space: nowrap;
+  overflow-wrap: normal;
+
+  animation: collapse-sticky-heading 0.35s forwards;
+  text-overflow: ellipsis;
+  overflow-x: hidden;
+}
+
+@keyframes collapse-sticky-heading {
+  from {
+    height: var(--uncollapsed-heading-height);
+  }
+
+  to {
+    height: var(--collapsed-heading-height);
+  }
+}
+
+.content-sticky-heading-container h1 a {
+  transition: text-decoration-color 0.35s;
+}
+
+.content-sticky-heading-container h1 a:not([href]) {
+  color: inherit;
+  cursor: text;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-decoration-color: transparent;
 }
 
 .content-sticky-heading-cover-container {
@@ -3297,7 +3373,7 @@ main.long-content .content-sticky-heading-container .content-sticky-subheading-r
 /* Layout - Wide or Medium */
 
 @media (min-width: 600px) {
-  .content-sticky-heading-container {
+  .content-sticky-heading-root {
     /* Safari doesn't always play nicely with position: sticky,
      * this seems to fix images sometimes displaying above the
      * position: absolute subheading (h2) child
@@ -3448,7 +3524,7 @@ main.long-content .content-sticky-heading-container .content-sticky-subheading-r
 
   /* Show sticky heading above cover art */
 
-  .content-sticky-heading-container {
+  .content-sticky-heading-root {
     z-index: 2;
   }
 

--- a/src/static/js/client/additional-names-box.js
+++ b/src/static/js/client/additional-names-box.js
@@ -3,12 +3,17 @@
 import {cssProp} from '../client-util.js';
 
 import {info as hashLinkInfo} from './hash-link.js';
+import {info as stickyHeadingInfo} from './sticky-heading.js';
 
 export const info = {
   id: 'additionalNamesBoxInfo',
 
   box: null,
+
   links: null,
+  stickyHeadingLink: null,
+
+  contentContainer: null,
   mainContentContainer: null,
 
   state: {
@@ -23,6 +28,14 @@ export function getPageReferences() {
   info.links =
     document.querySelectorAll('a[href="#additional-names-box"]');
 
+  info.stickyHeadingLink =
+    document.querySelector(
+      '.content-sticky-heading-container ' +
+      'a[href="#additional-names-box"]');
+
+  info.contentContainer =
+    document.querySelector('#content');
+
   info.mainContentContainer =
     document.querySelector('#content .main-content-container');
 }
@@ -31,6 +44,34 @@ export function addInternalListeners() {
   hashLinkInfo.event.beforeHashLinkScrolls.push(({target}) => {
     if (target === info.box) {
       return false;
+    }
+  });
+
+  stickyHeadingInfo.event.whenStuckStatusChanges.push((index, stuck) => {
+    const {state} = info;
+
+    if (!info.stickyHeadingLink) return;
+
+    const container = stickyHeadingInfo.contentContainers[index];
+    if (container !== info.contentContainer) return;
+
+    if (stuck) {
+      if (!state.visible) {
+        info.stickyHeadingLink.removeAttribute('href');
+
+        if (info.stickyHeadingLink.hasAttribute('title')) {
+          info.stickyHeadingLink.dataset.restoreTitle = info.stickyHeadingLink.getAttribute('title');
+          info.stickyHeadingLink.removeAttribute('title');
+        }
+      }
+    } else {
+      info.stickyHeadingLink.setAttribute('href', '#additional-names-box');
+
+      const {restoreTitle} = info.stickyHeadingLink.dataset;
+      if (restoreTitle) {
+        info.stickyHeadingLink.setAttribute('title', restoreTitle);
+        delete info.stickyHeadingLink.dataset.restoreTitle;
+      }
     }
   });
 }
@@ -48,6 +89,7 @@ function handleAdditionalNamesBoxLinkClicked(domEvent) {
 
   domEvent.preventDefault();
 
+  if (!domEvent.target.hasAttribute('href')) return;
   if (!info.box || !info.mainContentContainer) return;
 
   const margin =

--- a/src/static/js/client/sticky-heading.js
+++ b/src/static/js/client/sticky-heading.js
@@ -9,6 +9,7 @@ export const info = {
 
   stickyContainers: null,
 
+  stickyHeadingRows: null,
   stickyHeadings: null,
   stickySubheadingRows: null,
   stickySubheadings: null,
@@ -51,9 +52,13 @@ export function getPageReferences() {
     info.stickyCovers
       .map(el => el?.querySelector('.image-text-area'));
 
-  info.stickyHeadings =
+  info.stickyHeadingRows =
     info.stickyContainers
-      .map(el => el.querySelector('.content-sticky-heading-row h1'));
+      .map(el => el.querySelector('.content-sticky-heading-row'));
+
+  info.stickyHeadings =
+    info.stickyHeadingRows
+      .map(el => el.querySelector('h1'));
 
   info.stickySubheadingRows =
     info.stickyContainers
@@ -221,15 +226,8 @@ function getContentHeadingClosestToStickySubheading(index) {
     return null;
   }
 
-  const stickySubheading = info.stickySubheadings[index];
-
-  if (stickySubheading.childNodes.length === 0) {
-    // Supply a non-breaking space to ensure correct basic line height.
-    stickySubheading.appendChild(document.createTextNode('\xA0'));
-  }
-
-  const stickyContainer = info.stickyContainers[index];
-  const stickyRect = stickyContainer.getBoundingClientRect();
+  const stickyHeadingRow = info.stickyHeadingRows[index];
+  const stickyRect = stickyHeadingRow.getBoundingClientRect();
 
   // Subheadings only appear when the sticky heading is collapsed,
   // so the used bottom edge should always be *as though* it's only
@@ -239,18 +237,15 @@ function getContentHeadingClosestToStickySubheading(index) {
     stickyHeading.getBoundingClientRect().height -
     parseFloat(getComputedStyle(stickyHeading).fontSize);
 
-  const subheadingRect = stickySubheading.getBoundingClientRect();
-
   const stickyBottom =
     (stickyRect.bottom
-   + subheadingRect.height
    - correctBottomEdge);
 
   // Iterate from bottom to top of the content area.
   const contentHeadings = info.contentHeadings[index];
   for (const heading of contentHeadings.slice().reverse()) {
     const headingRect = heading.getBoundingClientRect();
-    if (headingRect.y + headingRect.height / 1.5 < stickyBottom + 20) {
+    if (headingRect.y + headingRect.height / 1.5 < stickyBottom + 40) {
       return heading;
     }
   }

--- a/src/static/js/client/sticky-heading.js
+++ b/src/static/js/client/sticky-heading.js
@@ -1,13 +1,15 @@
 /* eslint-env browser */
 
 import {filterMultipleArrays, stitchArrays} from '../../shared-util/sugar.js';
-import {dispatchInternalEvent, templateContent} from '../client-util.js';
+import {cssProp, dispatchInternalEvent, templateContent}
+  from '../client-util.js';
 
 export const info = {
   id: 'stickyHeadingInfo',
 
   stickyContainers: null,
 
+  stickyHeadings: null,
   stickySubheadingRows: null,
   stickySubheadings: null,
 
@@ -20,12 +22,16 @@ export const info = {
   contentCovers: null,
   contentCoversReveal: null,
 
+  imaginaryStaticHeadings: null,
+  referenceCollapsedHeading: null,
+
   state: {
     displayedHeading: null,
   },
 
   event: {
     whenDisplayedHeadingChanges: [],
+    whenStuckStatusChanges: [],
   },
 };
 
@@ -45,6 +51,10 @@ export function getPageReferences() {
     info.stickyCovers
       .map(el => el?.querySelector('.image-text-area'));
 
+  info.stickyHeadings =
+    info.stickyContainers
+      .map(el => el.querySelector('.content-sticky-heading-row h1'));
+
   info.stickySubheadingRows =
     info.stickyContainers
       .map(el => el.querySelector('.content-sticky-subheading-row'));
@@ -55,7 +65,7 @@ export function getPageReferences() {
 
   info.contentContainers =
     info.stickyContainers
-      .map(el => el.parentElement);
+      .map(el => el.closest('.content-sticky-heading-root').parentElement);
 
   info.contentCovers =
     info.contentContainers
@@ -68,6 +78,14 @@ export function getPageReferences() {
   info.contentHeadings =
     info.contentContainers
       .map(el => Array.from(el.querySelectorAll('.content-heading')));
+
+  info.imaginaryStaticHeadings =
+    info.contentContainers
+      .map(el => el.querySelector('.imaginary-static-heading-root'));
+
+  info.referenceCollapsedHeading =
+    info.stickyHeadings
+      .map(el => el.querySelector('.reference-collapsed-heading'));
 }
 
 export function mutatePageContent() {
@@ -137,15 +155,61 @@ function topOfViewInside(el, scroll = window.scrollY) {
     scroll < el.offsetTop + el.offsetHeight);
 }
 
+function updateStuckStatus(index) {
+  const {event} = info;
+
+  const contentContainer = info.contentContainers[index];
+  const stickyContainer = info.stickyContainers[index];
+
+  const wasStuck = stickyContainer.classList.contains('stuck');
+  const stuck = topOfViewInside(contentContainer);
+
+  if (stuck === wasStuck) return;
+
+  if (stuck) {
+    stickyContainer.classList.add('stuck');
+  } else {
+    stickyContainer.classList.remove('stuck');
+  }
+
+  dispatchInternalEvent(event, 'whenStuckStatusChanges', index, stuck);
+}
+
+function updateCollapseStatus(index) {
+  const stickyContainer = info.stickyContainers[index];
+  const stickyHeading = info.stickyHeadings[index];
+  const imaginaryStaticHeading = info.imaginaryStaticHeadings[index];
+  const referenceCollapsedHeading = info.referenceCollapsedHeading[index];
+
+  const {height: uncollapsedHeight} = stickyHeading.getBoundingClientRect();
+  const {height: collapsedHeight} = referenceCollapsedHeading.getBoundingClientRect();
+
+  if (
+    imaginaryStaticHeading.getBoundingClientRect().bottom < 4 ||
+    imaginaryStaticHeading.getBoundingClientRect().top < -80
+  ) {
+    if (!stickyContainer.classList.contains('collapse')) {
+      stickyContainer.classList.add('collapse');
+      cssProp(stickyContainer, '--uncollapsed-heading-height', uncollapsedHeight + 'px');
+      cssProp(stickyContainer, '--collapsed-heading-height', collapsedHeight + 'px');
+    }
+  } else {
+    stickyContainer.classList.remove('collapse');
+  }
+}
+
 function updateStickyCoverVisibility(index) {
   const stickyCoverContainer = info.stickyCoverContainers[index];
+  const stickyContainer = info.stickyContainers[index];
   const contentCover = info.contentCovers[index];
 
   if (contentCover && stickyCoverContainer) {
     if (contentCover.getBoundingClientRect().bottom < 4) {
       stickyCoverContainer.classList.add('visible');
+      stickyContainer.classList.add('cover-visible');
     } else {
       stickyCoverContainer.classList.remove('visible');
+      stickyContainer.classList.remove('cover-visible');
     }
   }
 }
@@ -167,10 +231,20 @@ function getContentHeadingClosestToStickySubheading(index) {
   const stickyContainer = info.stickyContainers[index];
   const stickyRect = stickyContainer.getBoundingClientRect();
 
-  // TODO: Should this compute with the subheading row instead of h2?
+  // Subheadings only appear when the sticky heading is collapsed,
+  // so the used bottom edge should always be *as though* it's only
+  // displaying one line of text. Subtract the current discrepancy.
+  const stickyHeading = info.stickyHeadings[index];
+  const correctBottomEdge =
+    stickyHeading.getBoundingClientRect().height -
+    parseFloat(getComputedStyle(stickyHeading).fontSize);
+
   const subheadingRect = stickySubheading.getBoundingClientRect();
 
-  const stickyBottom = stickyRect.bottom + subheadingRect.height;
+  const stickyBottom =
+    (stickyRect.bottom
+   + subheadingRect.height
+   - correctBottomEdge);
 
   // Iterate from bottom to top of the content area.
   const contentHeadings = info.contentHeadings[index];
@@ -187,7 +261,12 @@ function getContentHeadingClosestToStickySubheading(index) {
 function updateStickySubheadingContent(index) {
   const {event, state} = info;
 
-  const closestHeading = getContentHeadingClosestToStickySubheading(index);
+  const stickyContainer = info.stickyContainers[index];
+
+  const closestHeading =
+    (stickyContainer.classList.contains('collapse')
+      ? getContentHeadingClosestToStickySubheading(index)
+      : null);
 
   if (state.displayedHeading === closestHeading) return;
 
@@ -233,6 +312,8 @@ function updateStickySubheadingContent(index) {
 }
 
 export function updateStickyHeadings(index) {
+  updateStuckStatus(index);
+  updateCollapseStatus(index);
   updateStickyCoverVisibility(index);
   updateStickySubheadingContent(index);
 }

--- a/src/static/js/client/sticky-heading.js
+++ b/src/static/js/client/sticky-heading.js
@@ -233,9 +233,10 @@ function getContentHeadingClosestToStickySubheading(index) {
   // so the used bottom edge should always be *as though* it's only
   // displaying one line of text. Subtract the current discrepancy.
   const stickyHeading = info.stickyHeadings[index];
+  const referenceCollapsedHeading = info.referenceCollapsedHeading[index];
   const correctBottomEdge =
     stickyHeading.getBoundingClientRect().height -
-    parseFloat(getComputedStyle(stickyHeading).fontSize);
+    referenceCollapsedHeading.getBoundingClientRect().height;
 
   const stickyBottom =
     (stickyRect.bottom


### PR DESCRIPTION
Addresses a number of matters to do with the sticky heading with plenty new behavior. Assorted demos in [#devblog-discussion](https://discord.com/channels/749042497610842152/803366441537241138/1354234410207285321).

* Collapses the "sticky heading row"—the visible title of the page itself—down into a single row, which cuts off with an ellipsis, when you scroll past the height of the title heading itself. (Or eighty pixels through the heading, whichever comes first.)
    * There is a smooth height transition for this effect. Cool! Only when collapsing, not when expanding.
    * Until the sticky heading has collapsed (which does happen on one-line headings too, just with no effect), the sticky subheading is disabled.
* Expands the title area horizontally to stop just before the *small* / sticky cover artwork, once that artwork is displayed.
    * This effect is not animated, since of course it affects the appearance of the text itself (where it cuts off with an ellipsis).
    * Because the sticky heading is by this point already collapsed to one line, there's no concern over a wider layout causing fewer lines of word wrap and, distractingly, adjusting the height of the sticky heading overall!
* Gracefully disables the additional names box in-heading toggle link when the sticky heading starts sticking.
    * ...Unless the additional names box is already visible.
    * Clicking still scrolls past the cover art (on mobile; thanks past Tangle!! [#hsmusic-chat](https://discord.com/channels/749042497610842152/779895315750715422/1214908754408116274)), or back up, to the additional names box.
    * This active/inactive state is only computed *at the moment* the sticky heading *becomes* stuck or un-stuck, so if you had the additional names box visible while scrolled down, then hid it (also while scrolled down), the link keeps being a link until you scroll all the way back to the top—and down again.
        * This basically just means the activeness of the link shouldn't change on its own in any distracting way.

Internal shenanigans support lots of the above:

* Separates the sticky heading so that its own dimensions don't affect the layout of the page.
    * This requires some HTML hierarchy changes to keep the `position: sticky` behavior actually working, resembling:
        * #content (same as normal)
        * sticky-heading-root—position: sticky
        * sticky-heading-anchor—position: relative
        * sticky-heading-container—position: absolute
    * Because the sticky heading can now have dynamic height, the sticky *subheading*, which "looked" like it expanded the height of the heading (as a whole) but, courtesy a `position: absolute`, really didn't, now does.
* Adds a mock version of the title to the page, so that the basic height of the heading—not collapsed—*is* reflected in the page layout.
    * This requires some CSS bullshit, mostly to make the mock title match the same dimensions as the sticky heading (in its un-collapsed state), including for example factoring the width of the cover art and matching outset/negative margins.
    * This only *usually* works perfectly, and there may occasionally be mismatches between word wrapping which, in turn, may affect the number of lines and thus height given to keep the sticky heading from covering content. Scary.
* The height animation (when collapsing) precomputes its start and end heights dynamically. We use a mock version of the heading with `white-space: pre` to compute the final height, and grab the current height for the starting point, then animate between with a CSS `forwards` animation rather than transition.
    * The concludes with `height: auto`—the browser retakes charge after the animation is complete.
* Content heading hit detection for the sticky subheading counts on the height of the sticky heading row, not the sticky heading container, and completely bypasses the height of the subheading itself, fudging numbers a little harder in that regard, but reducing logical complexity that we haven't been able to really figure out.
    * Hit detection is based on the current real height of the sticky heading row, still, but adjusted to the height of the collapsed heading, reusing the same mock `white-space: pre` heading. When the heading is fully collapsed—not animating—this adjustment is zero.
* There's a new internal event for integrating the additional names box with the sticky heading. Rather than transfer excessive data in a, what's the word, like, ultra domain-specific language/vocabulary, we just tell the state and which sticky heading is affected. The additional names box directly integrates with the `info` variable for the sticky-heading module. This is tighter integration than any API should ever have, but hsmusic gently works this way everywhere, so we're happy to (*gently*) have it here too.