### PR TITLE
Search filters and fuzzy + verbatim search!

### DIFF
--- a/src/common-util/search-spec.js
+++ b/src/common-util/search-spec.js
@@ -147,10 +147,7 @@ export const searchSpec = {
 
       const contribKeys = [
         'artistContribs',
-        'bannerArtistContribs',
         'contributorContribs',
-        'coverArtistContribs',
-        'wallpaperArtistContribs',
       ];
 
       const contributions =

--- a/src/common-util/search-spec.js
+++ b/src/common-util/search-spec.js
@@ -85,104 +85,132 @@ function prepareArtwork(thing, {
   return serializeSrc;
 }
 
+function baselineProcess(thing, opts) {
+  const fields = {};
+
+  fields.primaryName =
+    thing.name;
+
+  fields.artwork =
+    prepareArtwork(thing, opts);
+
+  fields.color =
+    thing.color;
+
+  return fields;
+}
+
+const baselineStore = [
+  'primaryName',
+  'artwork',
+  'color',
+];
+
+function genericQuery(wikiData) {
+  return [
+    wikiData.albumData,
+
+    wikiData.artTagData,
+
+    wikiData.artistData
+      .filter(artist => !artist.isAlias),
+
+    wikiData.flashData,
+
+    wikiData.groupData,
+
+    wikiData.trackData
+      // Exclude rereleases - there's no reasonable way to differentiate
+      // them from the main release as part of this query.
+      .filter(track => !track.mainReleaseTrack),
+  ].flat();
+}
+
+function genericProcess(thing, opts) {
+  const fields = baselineProcess(thing, opts);
+
+  const kind =
+    thing.constructor[Symbol.for('Thing.referenceType')];
+
+  fields.parentName =
+    (kind === 'track'
+      ? thing.album.name
+   : kind === 'group'
+      ? thing.category.name
+   : kind === 'flash'
+      ? thing.act.name
+      : null);
+
+  fields.artTags =
+    (thing.constructor.hasPropertyDescriptor('artTags')
+      ? thing.artTags.map(artTag => artTag.nameShort)
+      : []);
+
+  fields.additionalNames =
+    (thing.constructor.hasPropertyDescriptor('additionalNames')
+      ? thing.additionalNames.map(entry => entry.name)
+   : thing.constructor.hasPropertyDescriptor('aliasNames')
+      ? thing.aliasNames
+      : []);
+
+  const contribKeys = [
+    'artistContribs',
+    'contributorContribs',
+  ];
+
+  const contributions =
+    contribKeys
+      .filter(key => Object.hasOwn(thing, key))
+      .flatMap(key => thing[key]);
+
+  fields.contributors =
+    contributions
+      .flatMap(({artist}) => [
+        artist.name,
+        ...artist.aliasNames,
+      ]);
+
+  const groups =
+     (Object.hasOwn(thing, 'groups')
+       ? thing.groups
+    : Object.hasOwn(thing, 'album')
+       ? thing.album.groups
+       : []);
+
+  const mainContributorNames =
+    contributions
+      .map(({artist}) => artist.name);
+
+  fields.groups =
+    groups
+      .filter(group => !mainContributorNames.includes(group.name))
+      .map(group => group.name);
+
+  return fields;
+}
+
+const genericStore = baselineStore;
+
 export const searchSpec = {
   generic: {
-    query: ({
-      albumData,
-      artTagData,
-      artistData,
-      flashData,
-      groupData,
-      trackData,
-    }) => [
-      albumData,
+    query: genericQuery,
+    process: genericProcess,
 
-      artTagData,
+    index: [
+      'primaryName',
+      'parentName',
+      'artTags',
+      'additionalNames',
+      'contributors',
+      'groups',
+    ].map(field => ({field, tokenize: 'forward'})),
 
-      artistData
-        .filter(artist => !artist.isAlias),
+    store: genericStore,
+  },
 
-      flashData,
-
-      groupData,
-
-      trackData
-        // Exclude rereleases - there's no reasonable way to differentiate
-        // them from the main release as part of this query.
-        .filter(track => !track.mainReleaseTrack),
-    ].flat(),
-
-    process(thing, opts) {
-      const fields = {};
-
-      fields.primaryName =
-        thing.name;
-
-      const kind =
-        thing.constructor[Symbol.for('Thing.referenceType')];
-
-      fields.parentName =
-        (kind === 'track'
-          ? thing.album.name
-       : kind === 'group'
-          ? thing.category.name
-       : kind === 'flash'
-          ? thing.act.name
-          : null);
-
-      fields.color =
-        thing.color;
-
-      fields.artTags =
-        (thing.constructor.hasPropertyDescriptor('artTags')
-          ? thing.artTags.map(artTag => artTag.nameShort)
-          : []);
-
-      fields.additionalNames =
-        (thing.constructor.hasPropertyDescriptor('additionalNames')
-          ? thing.additionalNames.map(entry => entry.name)
-       : thing.constructor.hasPropertyDescriptor('aliasNames')
-          ? thing.aliasNames
-          : []);
-
-      const contribKeys = [
-        'artistContribs',
-        'contributorContribs',
-      ];
-
-      const contributions =
-        contribKeys
-          .filter(key => Object.hasOwn(thing, key))
-          .flatMap(key => thing[key]);
-
-      fields.contributors =
-        contributions
-          .flatMap(({artist}) => [
-            artist.name,
-            ...artist.aliasNames,
-          ]);
-
-      const groups =
-         (Object.hasOwn(thing, 'groups')
-           ? thing.groups
-        : Object.hasOwn(thing, 'album')
-           ? thing.album.groups
-           : []);
-
-      const mainContributorNames =
-        contributions
-          .map(({artist}) => artist.name);
-
-      fields.groups =
-        groups
-          .filter(group => !mainContributorNames.includes(group.name))
-          .map(group => group.name);
-
-      fields.artwork =
-        prepareArtwork(thing, opts);
-
-      return fields;
-    },
+  verbatim: {
+    query: genericQuery,
+    process: genericProcess,
 
     index: [
       'primaryName',
@@ -193,11 +221,7 @@ export const searchSpec = {
       'groups',
     ],
 
-    store: [
-      'primaryName',
-      'artwork',
-      'color',
-    ],
+    store: genericStore,
   },
 };
 

--- a/src/content/dependencies/generateSearchSidebarBox.js
+++ b/src/content/dependencies/generateSearchSidebarBox.js
@@ -57,6 +57,23 @@ export default {
             html.tag('template', {class: 'wiki-search-tag-result-kind-string'},
               language.$(capsule, 'artTag')),
           ]),
+
+          language.encapsulate(capsule, 'resultFilter', capsule => [
+            html.tag('template', {class: 'wiki-search-album-result-filter-string'},
+              language.$(capsule, 'album')),
+
+            html.tag('template', {class: 'wiki-search-artist-result-filter-string'},
+              language.$(capsule, 'artist')),
+
+            html.tag('template', {class: 'wiki-search-group-result-filter-string'},
+              language.$(capsule, 'group')),
+
+            html.tag('template', {class: 'wiki-search-track-result-filter-string'},
+              language.$(capsule, 'track')),
+
+            html.tag('template', {class: 'wiki-search-tag-result-filter-string'},
+              language.$(capsule, 'artTag')),
+          ]),
         ],
       })),
 };

--- a/src/content/dependencies/generateSearchSidebarBox.js
+++ b/src/content/dependencies/generateSearchSidebarBox.js
@@ -65,6 +65,9 @@ export default {
             html.tag('template', {class: 'wiki-search-artist-result-filter-string'},
               language.$(capsule, 'artist')),
 
+            html.tag('template', {class: 'wiki-search-flash-result-filter-string'},
+              language.$(capsule, 'flash')),
+
             html.tag('template', {class: 'wiki-search-group-result-filter-string'},
               language.$(capsule, 'group')),
 

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -748,6 +748,7 @@ summary.underline-white > span:hover a:not(:hover) {
 }
 
 .wiki-search-filter-link {
+  display: inline-block;
   margin: 2px;
   padding: 2px 4px;
   border: 2px solid transparent;

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -754,24 +754,42 @@ summary.underline-white > span:hover a:not(:hover) {
   border-radius: 4px;
 }
 
-.wiki-search-filter-link.active.shown {
+.wiki-search-filter-link:where(.active.shown) {
   animation:
     0.15s ease   0.00s forwards normal    show-filter,
     0.60s linear 0.15s infinite alternate blink-filter;
 }
 
-.wiki-search-filter-link.active:not(.shown) {
+.wiki-search-filter-link:where(.active:not(.shown)) {
   animation:
     0.00s linear 0.00s forwards normal    show-filter,
     0.60s linear 0.00s infinite alternate blink-filter;
 }
 
-.wiki-search-filter-link:not(.active).hidden {
+.wiki-search-filter-link:where(:not(.active).hidden) {
   /* We can't just reverse the show-filter animation,
    * because that won't actually start it over again.
    */
   animation:
     0.15s ease   0.00s forwards reverse   show-filter-the-sequel;
+}
+
+.wiki-search-filter-link.active-from-query {
+  background: var(--primary-color);
+  border-color: var(--primary-color);
+  color: #000a;
+  animation: none;
+}
+
+.wiki-search-filter-link.active-from-query::after {
+  content: "I";
+  color: black;
+  font-family: monospace;
+  font-weight: 800;
+  font-size: 1.2em;
+  margin-left: 0.5ch;
+  vertical-align: middle;
+  animation: 1s steps(2, jump-none) 0.6s infinite blink-caret;
 }
 
 @keyframes show-filter {
@@ -807,6 +825,11 @@ summary.underline-white > span:hover a:not(:hover) {
   to {
     background: color-mix(in srgb, var(--primary-color) 90%, transparent);
   }
+}
+
+@keyframes blink-caret {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 
 .wiki-search-result {

--- a/src/static/css/site.css
+++ b/src/static/css/site.css
@@ -743,6 +743,72 @@ summary.underline-white > span:hover a:not(:hover) {
   cursor: default;
 }
 
+.wiki-search-filter-container {
+  padding: 4px;
+}
+
+.wiki-search-filter-link {
+  margin: 2px;
+  padding: 2px 4px;
+  border: 2px solid transparent;
+  border-radius: 4px;
+}
+
+.wiki-search-filter-link.active.shown {
+  animation:
+    0.15s ease   0.00s forwards normal    show-filter,
+    0.60s linear 0.15s infinite alternate blink-filter;
+}
+
+.wiki-search-filter-link.active:not(.shown) {
+  animation:
+    0.00s linear 0.00s forwards normal    show-filter,
+    0.60s linear 0.00s infinite alternate blink-filter;
+}
+
+.wiki-search-filter-link:not(.active).hidden {
+  /* We can't just reverse the show-filter animation,
+   * because that won't actually start it over again.
+   */
+  animation:
+    0.15s ease   0.00s forwards reverse   show-filter-the-sequel;
+}
+
+@keyframes show-filter {
+  from {
+    background: transparent;
+    border-color: transparent;
+    color: var(--primary-color);
+  }
+
+  to {
+    background: var(--primary-color);
+    border-color: var(--primary-color);
+    color: black;
+  }
+}
+
+/* Exactly the same as show-filter above. */
+@keyframes show-filter-the-sequel {
+  from {
+    background: transparent;
+    border-color: transparent;
+    color: var(--primary-color);
+  }
+
+  to {
+    background: var(--primary-color);
+    border-color: var(--primary-color);
+    color: black;
+  }
+}
+
+@keyframes blink-filter {
+  to {
+    background: color-mix(in srgb, var(--primary-color) 90%, transparent);
+  }
+}
+
 .wiki-search-result {
   position: relative;
   display: flex;

--- a/src/static/js/client/sidebar-search.js
+++ b/src/static/js/client/sidebar-search.js
@@ -809,7 +809,7 @@ function showSidebarSearchResults(results) {
 
 function tidyResults(results) {
   const tidiedResults =
-    results.map(({doc, id}) => ({
+    results.results.map(({doc, id}) => ({
       reference: id ?? null,
       referenceType: (id ? id.split(':')[0] : null),
       directory: (id ? id.split(':')[1] : null),
@@ -851,6 +851,8 @@ function fillResultElements(results, {
 }
 
 function showFilterElements(results) {
+  const {queriedKind} = results;
+
   const tidiedResults = tidyResults(results);
 
   const allReferenceTypes =
@@ -864,6 +866,18 @@ function showFilterElements(results) {
     if (allReferenceTypes.includes(type)) {
       shownAny = true;
       cssProp(filterLink, 'display', null);
+
+      if (queriedKind) {
+        filterLink.setAttribute('inert', 'inert');
+      } else {
+        filterLink.removeAttribute('inert');
+      }
+
+      if (type === queriedKind) {
+        filterLink.classList.add('active-from-query');
+      } else {
+        filterLink.classList.remove('active-from-query');
+      }
     } else {
       cssProp(filterLink, 'display', 'none');
     }

--- a/src/static/js/client/sidebar-search.js
+++ b/src/static/js/client/sidebar-search.js
@@ -44,6 +44,7 @@ export const info = {
   filterContainer: null,
   albumFilterLink: null,
   artistFilterLink: null,
+  flashFilterLink: null,
   groupFilterLink: null,
   tagFilterLink: null,
   trackFilterLink: null,
@@ -74,6 +75,7 @@ export const info = {
 
   albumResultFilterString: null,
   artistResultFilterString: null,
+  flashResultFilterString: null,
   groupResultFilterString: null,
   tagResultFilterString: null,
   trackResultFilterString: null,
@@ -199,6 +201,9 @@ export function getPageReferences() {
 
   info.artistResultFilterString =
     findString('artist-result-filter');
+
+  info.flashResultFilterString =
+    findString('flash-result-filter');
 
   info.groupResultFilterString =
     findString('group-result-filter');
@@ -596,6 +601,7 @@ function forEachFilter(callback) {
     'album',
     'artist',
     'group',
+    'flash',
     'tag',
   ];
 

--- a/src/static/js/client/sidebar-search.js
+++ b/src/static/js/client/sidebar-search.js
@@ -677,6 +677,8 @@ function clearSidebarSearch() {
 }
 
 function clearSidebarFilter() {
+  const {session} = info;
+
   toggleSidebarSearchFilter(session.activeFilterType);
 
   forEachFilter((_type, filterLink) => {
@@ -857,12 +859,13 @@ function showFilterElements(results) {
   let shownAny = false;
 
   forEachFilter((type, filterLink) => {
+    filterLink.classList.remove('shown', 'hidden');
+
     if (allReferenceTypes.includes(type)) {
       shownAny = true;
       cssProp(filterLink, 'display', null);
     } else {
       cssProp(filterLink, 'display', 'none');
-      filterLink.classList.remove('shown', 'hidden');
     }
   });
 
@@ -1211,8 +1214,10 @@ function toggleSidebarSearchFilter(toggleType) {
         filterLink.classList.add(filterActive ? 'shown' : 'hidden');
       }
 
-      shownAnyResults =
-        fillResultElements(session.activeQueryResults, {filterType});
+      if (session.activeQueryResults) {
+        shownAnyResults =
+          fillResultElements(session.activeQueryResults, {filterType});
+      }
 
       session.activeFilterType = filterType;
     } else {
@@ -1256,6 +1261,8 @@ function forgetRecentSidebarSearch() {
 
   session.activeQuery = null;
   session.activeQueryResults = null;
+
+  clearSidebarFilter();
 }
 
 async function handleDroppedIntoSearchInput(domEvent) {

--- a/src/static/js/client/sidebar-search.js
+++ b/src/static/js/client/sidebar-search.js
@@ -1,7 +1,7 @@
 /* eslint-env browser */
 
 import {getColors} from '../../shared-util/colors.js';
-import {accumulateSum, empty} from '../../shared-util/sugar.js';
+import {accumulateSum, empty, unique} from '../../shared-util/sugar.js';
 
 import {
   cssProp,
@@ -41,6 +41,13 @@ export const info = {
   failedRule: null,
   failedContainer: null,
 
+  filterContainer: null,
+  albumFilterLink: null,
+  artistFilterLink: null,
+  groupFilterLink: null,
+  tagFilterLink: null,
+  trackFilterLink: null,
+
   resultsRule: null,
   resultsContainer: null,
   results: null,
@@ -64,6 +71,12 @@ export const info = {
   artistResultKindString: null,
   groupResultKindString: null,
   tagResultKindString: null,
+
+  albumResultFilterString: null,
+  artistResultFilterString: null,
+  groupResultFilterString: null,
+  tagResultFilterString: null,
+  trackResultFilterString: null,
 
   state: {
     sidebarColumnShownForSearch: null,
@@ -95,6 +108,10 @@ export const info = {
     activeQueryResults: {
       type: 'json',
       maxLength: settings => settings.maxActiveResultsStorage,
+    },
+
+    activeFilterType: {
+      type: 'string',
     },
 
     repeatQueryOnReload: {
@@ -176,6 +193,21 @@ export function getPageReferences() {
 
   info.tagResultKindString =
     findString('tag-result-kind');
+
+  info.albumResultFilterString =
+    findString('album-result-filter');
+
+  info.artistResultFilterString =
+    findString('artist-result-filter');
+
+  info.groupResultFilterString =
+    findString('group-result-filter');
+
+  info.tagResultFilterString =
+    findString('tag-result-filter');
+
+  info.trackResultFilterString =
+    findString('track-result-filter');
 }
 
 export function addInternalListeners() {
@@ -264,6 +296,38 @@ export function mutatePageContent() {
 
   info.searchBox.appendChild(info.failedRule);
   info.searchBox.appendChild(info.failedContainer);
+
+  // Filter section
+
+  info.filterContainer =
+    document.createElement('div');
+
+  info.filterContainer.classList.add('wiki-search-filter-container');
+
+  cssProp(info.filterContainer, 'display', 'none');
+
+  forEachFilter((type, _filterLink) => {
+    // TODO: It's probably a sin to access `session` during this step LOL
+    const {session} = info;
+
+    const filterLink = document.createElement('a');
+
+    filterLink.href = '#';
+    filterLink.classList.add('wiki-search-filter-link');
+
+    if (session.activeFilterType === type) {
+      filterLink.classList.add('active');
+    }
+
+    const string = info[type + 'ResultFilterString'];
+    filterLink.appendChild(templateContent(string));
+
+    info[type + 'FilterLink'] = filterLink;
+
+    info.filterContainer.appendChild(filterLink);
+  });
+
+  info.searchBox.appendChild(info.filterContainer);
 
   // Results section
 
@@ -371,7 +435,7 @@ export function addPageListeners() {
     const {settings, state} = info;
 
     if (!info.searchInput.value) {
-      clearSidebarSearch();
+      clearSidebarSearch(); // ...but don't clear filter
       return;
     }
 
@@ -433,8 +497,16 @@ export function addPageListeners() {
   info.endSearchLink.addEventListener('click', domEvent => {
     domEvent.preventDefault();
     clearSidebarSearch();
+    clearSidebarFilter();
     possiblyHideSearchSidebarColumn();
     restoreSidebarSearchColumn();
+  });
+
+  forEachFilter((type, filterLink) => {
+    filterLink.addEventListener('click', domEvent => {
+      domEvent.preventDefault();
+      toggleSidebarSearchFilter(type);
+    });
   });
 
   info.resultsContainer.addEventListener('scroll', () => {
@@ -518,6 +590,20 @@ function trackSidebarSearchDownloadEnds(event) {
   }
 }
 
+function forEachFilter(callback) {
+  const filterOrder = [
+    'track',
+    'album',
+    'artist',
+    'group',
+    'tag',
+  ];
+
+  for (const type of filterOrder) {
+    callback(type, info[type + 'FilterLink']);
+  }
+}
+
 async function activateSidebarSearch(query) {
   const {session, state} = info;
 
@@ -582,6 +668,14 @@ function clearSidebarSearch() {
   session.resultsScrollOffset = null;
 
   hideSidebarSearchResults();
+}
+
+function clearSidebarFilter() {
+  toggleSidebarSearchFilter(session.activeFilterType);
+
+  forEachFilter((_type, filterLink) => {
+    filterLink.classList.remove('shown', 'hidden');
+  });
 }
 
 function updateSidebarSearchStatus() {
@@ -670,10 +764,42 @@ function showSidebarSearchFailed() {
 }
 
 function showSidebarSearchResults(results) {
-  console.debug(`Showing search results:`, results);
+  const {session} = info;
+
+  console.debug(`Showing search results:`, flattenResults(results));
 
   showSearchSidebarColumn();
 
+  info.searchBox.classList.add('showing-results');
+  info.searchSidebarColumn.classList.add('search-showing-results');
+
+  let filterType = session.activeFilterType;
+  let shownAnyResults =
+    fillResultElements(results, {filterType: session.activeFilterType});
+
+  showFilterElements(results);
+
+  if (!shownAnyResults) {
+    shownAnyResults = toggleSidebarSearchFilter(filterType);
+    filterType = null;
+  }
+
+  if (shownAnyResults) {
+    cssProp(info.endSearchRule, 'display', 'block');
+    cssProp(info.endSearchLine, 'display', 'block');
+
+    tidySidebarSearchColumn();
+  } else {
+    const p = document.createElement('p');
+    p.classList.add('wiki-search-no-results');
+    p.appendChild(templateContent(info.noResultsString));
+    info.results.appendChild(p);
+  }
+
+  restoreSidebarSearchResultsScrollOffset();
+}
+
+function flattenResults(results) {
   const flatResults =
     Object.entries(results)
       .filter(([index]) => index === 'generic')
@@ -686,8 +812,18 @@ function showSidebarSearchResults(results) {
           data: doc,
         })));
 
-  info.searchBox.classList.add('showing-results');
-  info.searchSidebarColumn.classList.add('search-showing-results');
+  return flatResults;
+}
+
+function fillResultElements(results, {
+  filterType = null,
+} = {}) {
+  const flatResults = flattenResults(results);
+
+  const filteredResults =
+    (filterType
+      ? flatResults.filter(result => result.referenceType === filterType)
+      : flatResults);
 
   while (info.results.firstChild) {
     info.results.firstChild.remove();
@@ -696,28 +832,43 @@ function showSidebarSearchResults(results) {
   cssProp(info.resultsRule, 'display', 'block');
   cssProp(info.resultsContainer, 'display', 'block');
 
-  if (empty(flatResults)) {
-    const p = document.createElement('p');
-    p.classList.add('wiki-search-no-results');
-    p.appendChild(templateContent(info.noResultsString));
-    info.results.appendChild(p);
+  if (empty(filteredResults)) {
+    return false;
   }
 
-  for (const result of flatResults) {
+  for (const result of filteredResults) {
     const el = generateSidebarSearchResult(result);
     if (!el) continue;
 
     info.results.appendChild(el);
   }
 
-  if (!empty(flatResults)) {
-    cssProp(info.endSearchRule, 'display', 'block');
-    cssProp(info.endSearchLine, 'display', 'block');
+  return true;
+}
 
-    tidySidebarSearchColumn();
+function showFilterElements(results) {
+  const flatResults = flattenResults(results);
+
+  const allReferenceTypes =
+    unique(flatResults.map(result => result.referenceType));
+
+  let shownAny = false;
+
+  forEachFilter((type, filterLink) => {
+    if (allReferenceTypes.includes(type)) {
+      shownAny = true;
+      cssProp(filterLink, 'display', null);
+    } else {
+      cssProp(filterLink, 'display', 'none');
+      filterLink.classList.remove('shown', 'hidden');
+    }
+  });
+
+  if (shownAny) {
+    cssProp(info.filterContainer, 'display', null);
+  } else {
+    cssProp(info.filterContainer, 'display', 'none');
   }
-
-  restoreSidebarSearchResultsScrollOffset();
 }
 
 function generateSidebarSearchResult(result) {
@@ -908,6 +1059,8 @@ function generateSidebarSearchResultTemplate(slots) {
 }
 
 function hideSidebarSearchResults() {
+  cssProp(info.filterContainer, 'display', 'none');
+
   cssProp(info.resultsRule, 'display', 'none');
   cssProp(info.resultsContainer, 'display', 'none');
 
@@ -1038,6 +1191,34 @@ function tidySidebarSearchColumn() {
       }
     }
   }
+}
+
+function toggleSidebarSearchFilter(toggleType) {
+  const {session} = info;
+
+  if (!toggleType) return null;
+
+  let shownAnyResults = null;
+
+  forEachFilter((type, filterLink) => {
+    if (type === toggleType) {
+      const filterActive = filterLink.classList.toggle('active');
+      const filterType = (filterActive ? type : null);
+
+      if (cssProp(filterLink, 'display') !== 'none') {
+        filterLink.classList.add(filterActive ? 'shown' : 'hidden');
+      }
+
+      shownAnyResults =
+        fillResultElements(session.activeQueryResults, {filterType});
+
+      session.activeFilterType = filterType;
+    } else {
+      filterLink.classList.remove('active');
+    }
+  });
+
+  return shownAnyResults;
 }
 
 function restoreSidebarSearchColumn() {

--- a/src/static/js/client/sidebar-search.js
+++ b/src/static/js/client/sidebar-search.js
@@ -772,7 +772,7 @@ function showSidebarSearchFailed() {
 function showSidebarSearchResults(results) {
   const {session} = info;
 
-  console.debug(`Showing search results:`, flattenResults(results));
+  console.debug(`Showing search results:`, tidyResults(results));
 
   showSearchSidebarColumn();
 
@@ -805,31 +805,27 @@ function showSidebarSearchResults(results) {
   restoreSidebarSearchResultsScrollOffset();
 }
 
-function flattenResults(results) {
-  const flatResults =
-    Object.entries(results)
-      .filter(([index]) => index === 'generic')
-      .flatMap(([index, results]) => results
-        .flatMap(({doc, id}) => ({
-          index,
-          reference: id ?? null,
-          referenceType: (id ? id.split(':')[0] : null),
-          directory: (id ? id.split(':')[1] : null),
-          data: doc,
-        })));
+function tidyResults(results) {
+  const tidiedResults =
+    results.map(({doc, id}) => ({
+      reference: id ?? null,
+      referenceType: (id ? id.split(':')[0] : null),
+      directory: (id ? id.split(':')[1] : null),
+      data: doc,
+    }));
 
-  return flatResults;
+  return tidiedResults;
 }
 
 function fillResultElements(results, {
   filterType = null,
 } = {}) {
-  const flatResults = flattenResults(results);
+  const tidiedResults = tidyResults(results);
 
   const filteredResults =
     (filterType
-      ? flatResults.filter(result => result.referenceType === filterType)
-      : flatResults);
+      ? tidiedResults.filter(result => result.referenceType === filterType)
+      : tidiedResults);
 
   while (info.results.firstChild) {
     info.results.firstChild.remove();
@@ -853,10 +849,10 @@ function fillResultElements(results, {
 }
 
 function showFilterElements(results) {
-  const flatResults = flattenResults(results);
+  const tidiedResults = tidyResults(results);
 
   const allReferenceTypes =
-    unique(flatResults.map(result => result.referenceType));
+    unique(tidiedResults.map(result => result.referenceType));
 
   let shownAny = false;
 

--- a/src/static/js/search-worker.js
+++ b/src/static/js/search-worker.js
@@ -480,18 +480,24 @@ function queryIndex({termsKey, indexKey}, query, options) {
 
   for (const interestingFieldCombination of interestingFieldCombinations) {
     for (const query of queriesBy(interestingFieldCombination)) {
-      const commonAcrossFields = new Set();
+      const [firstQueryFieldLine, ...restQueryFieldLines] = query;
 
-      for (const [index, {field, query: fieldQuery}] of query.entries()) {
-        const firstFieldInQuery = (index === 0);
+      const commonAcrossFields =
+        new Set(
+          particleResults
+            [firstQueryFieldLine.field]
+            [firstQueryFieldLine.query]);
+
+      for (const currQueryFieldLine of restQueryFieldLines) {
         const tossResults = new Set(commonAcrossFields);
 
-        for (const result of particleResults[field][fieldQuery]) {
-          if (firstFieldInQuery) {
-            commonAcrossFields.add(result);
-          } else {
-            tossResults.delete(result);
-          }
+        const keepResults =
+          particleResults
+            [currQueryFieldLine.field]
+            [currQueryFieldLine.query];
+
+        for (const result of keepResults) {
+          tossResults.delete(result);
         }
 
         for (const result of tossResults) {

--- a/src/static/js/search-worker.js
+++ b/src/static/js/search-worker.js
@@ -373,6 +373,8 @@ function postActionResult(id, status, value) {
 function performSearchAction({query, options}) {
   const {generic, verbatim} = indexes;
 
+  const {queriedKind} = processTerms(query);
+
   const genericResults =
     queryGenericIndex(generic, query, options);
 
@@ -388,7 +390,10 @@ function performSearchAction({query, options}) {
           .filter(({id}) => verbatimIDs.has(id))
       : verbatimResults ?? genericResults);
 
-  return commonResults;
+  return {
+    results: commonResults,
+    queriedKind,
+  };
 }
 
 const interestingFieldCombinations = [

--- a/src/static/js/search-worker.js
+++ b/src/static/js/search-worker.js
@@ -601,12 +601,12 @@ function queryVerbatimIndex(index, query, options) {
 
 function processTerms(query) {
   const kindTermSpec = [
-    {kind: 'album', terms: ['album']},
-    {kind: 'artist', terms: ['artist']},
-    {kind: 'flash', terms: ['flash']},
-    {kind: 'group', terms: ['group']},
-    {kind: 'tag', terms: ['art tag', 'tag']},
-    {kind: 'track', terms: ['track']},
+    {kind: 'album', terms: ['album', 'albums']},
+    {kind: 'artist', terms: ['artist', 'artists']},
+    {kind: 'flash', terms: ['flash', 'flashes']},
+    {kind: 'group', terms: ['group', 'groups']},
+    {kind: 'tag', terms: ['art tag', 'art tags', 'tag', 'tags']},
+    {kind: 'track', terms: ['track', 'tracks']},
   ];
 
   const genericTerms = [];

--- a/src/static/js/search-worker.js
+++ b/src/static/js/search-worker.js
@@ -468,44 +468,46 @@ function queryGenericIndex(index, query, options) {
             ])),
       ]));
 
-  const results = new Set();
+  let matchedResults = new Set();
 
   for (const interestingFieldCombination of interestingFieldCombinations) {
     for (const query of queriesBy(interestingFieldCombination)) {
-      const idToMatchingFieldsMap = new Map();
-      for (const {field, query: fieldQuery} of query) {
-        for (const id of particleResults[field][fieldQuery]) {
-          if (idToMatchingFieldsMap.has(id)) {
-            idToMatchingFieldsMap.get(id).push(field);
+      const commonAcrossFields = new Set();
+
+      for (const [index, {field, query: fieldQuery}] of query.entries()) {
+        const firstFieldInQuery = (index === 0);
+        const tossResults = new Set(commonAcrossFields);
+
+        for (const result of particleResults[field][fieldQuery]) {
+          if (firstFieldInQuery) {
+            commonAcrossFields.add(result);
           } else {
-            idToMatchingFieldsMap.set(id, [field]);
+            tossResults.delete(result);
           }
+        }
+
+        for (const result of tossResults) {
+          commonAcrossFields.delete(result);
         }
       }
 
-      const commonAcrossFields =
-        Array.from(idToMatchingFieldsMap.entries())
-          .filter(([id, matchingFields]) =>
-            matchingFields.length === interestingFieldCombination.length)
-          .map(([id]) => id);
-
       for (const result of commonAcrossFields) {
-        results.add(result);
+        matchedResults.add(result);
       }
     }
   }
 
-  const constituted =
-    boilerplate.constitute(results);
+  matchedResults = Array.from(matchedResults);
 
-  const constitutedAndFiltered =
-    constituted
-      .filter(({id}) =>
-        (queriedKind
-          ? id.split(':')[0] === queriedKind
-          : true));
+  const filteredResults =
+    (queriedKind
+      ? matchedResults.filter(id => id.split(':')[0] === queriedKind)
+      : matchedResults);
 
-  return constitutedAndFiltered;
+  const constitutedResults =
+    boilerplate.constitute(filteredResults);
+
+  return constitutedResults;
 }
 
 function queryVerbatimIndex(index, query, options) {
@@ -555,44 +557,46 @@ function queryVerbatimIndex(index, query, options) {
             ])),
       ]));
 
-  const results = new Set();
+  let matchedResults = new Set();
 
   for (const interestingFieldCombination of interestingFieldCombinations) {
     for (const query of queriesBy(interestingFieldCombination)) {
-      const idToMatchingFieldsMap = new Map();
-      for (const {field, query: fieldQuery} of query) {
-        for (const id of particleResults[field][fieldQuery]) {
-          if (idToMatchingFieldsMap.has(id)) {
-            idToMatchingFieldsMap.get(id).push(field);
+      const commonAcrossFields = new Set();
+
+      for (const [index, {field, query: fieldQuery}] of query.entries()) {
+        const firstFieldInQuery = (index === 0);
+        const tossResults = new Set(commonAcrossFields);
+
+        for (const result of particleResults[field][fieldQuery]) {
+          if (firstFieldInQuery) {
+            commonAcrossFields.add(result);
           } else {
-            idToMatchingFieldsMap.set(id, [field]);
+            tossResults.delete(result);
           }
+        }
+
+        for (const result of tossResults) {
+          commonAcrossFields.delete(result);
         }
       }
 
-      const commonAcrossFields =
-        Array.from(idToMatchingFieldsMap.entries())
-          .filter(([id, matchingFields]) =>
-            matchingFields.length === interestingFieldCombination.length)
-          .map(([id]) => id);
-
       for (const result of commonAcrossFields) {
-        results.add(result);
+        matchedResults.add(result);
       }
     }
   }
 
-  const constituted =
-    boilerplate.constitute(results);
+  matchedResults = Array.from(matchedResults);
 
-  const constitutedAndFiltered =
-    constituted
-      .filter(({id}) =>
-        (queriedKind
-          ? id.split(':')[0] === queriedKind
-          : true));
+  const filteredResults =
+    (queriedKind
+      ? matchedResults.filter(id => id.split(':')[0] === queriedKind)
+      : matchedResults);
 
-  return constitutedAndFiltered;
+  const constitutedResults =
+    boilerplate.constitute(filteredResults);
+
+  return constitutedResults;
 }
 
 function processTerms(query) {

--- a/src/static/js/search-worker.js
+++ b/src/static/js/search-worker.js
@@ -615,7 +615,7 @@ function processTerms(query) {
 
   const termRegexp =
     new RegExp(
-      String.raw`(?<kind>${kindTermSpec.flatMap(spec => spec.terms).join('|')})` +
+      String.raw`(?<kind>(?<=^|\s)(?:${kindTermSpec.flatMap(spec => spec.terms).join('|')})(?=$|\s))` +
       String.raw`|(?<=^|\s)(?<quote>["'])(?<regularVerbatim>.+?)\k<quote>(?=$|\s)` +
       String.raw`|(?<=^|\s)[“”‘’](?<curlyVerbatim>.+?)[“”‘’](?=$|\s)` +
       String.raw`|[^\s\-]+`,

--- a/src/static/js/search-worker.js
+++ b/src/static/js/search-worker.js
@@ -371,58 +371,149 @@ function postActionResult(id, status, value) {
 }
 
 function performSearchAction({query, options}) {
-  const {generic, ...otherIndexes} = indexes;
+  const {generic, verbatim} = indexes;
 
   const genericResults =
     queryGenericIndex(generic, query, options);
 
-  const otherResults =
-    withEntries(otherIndexes, entries => entries
-      .map(([indexName, index]) => [
-        indexName,
-        index.search(query, options),
-      ]));
+  const verbatimResults =
+    queryVerbatimIndex(verbatim, query, options);
 
-  return {
-    generic: genericResults,
-    ...otherResults,
-  };
+  const verbatimIDs =
+    new Set(verbatimResults?.map(result => result.id));
+
+  const commonResults =
+    (verbatimResults && genericResults
+      ? genericResults
+          .filter(({id}) => verbatimIDs.has(id))
+      : verbatimResults ?? genericResults);
+
+  return commonResults;
 }
 
+const interestingFieldCombinations = [
+  ['primaryName', 'parentName', 'groups'],
+  ['primaryName', 'parentName'],
+  ['primaryName', 'groups', 'contributors'],
+  ['primaryName', 'groups', 'artTags'],
+  ['primaryName', 'groups'],
+  ['primaryName', 'contributors'],
+  ['primaryName', 'artTags'],
+  ['parentName', 'groups', 'artTags'],
+  ['parentName', 'artTags'],
+  ['groups', 'contributors'],
+  ['groups', 'artTags'],
+
+  // This prevents just matching *everything* tagged "john" if you
+  // only search "john", but it actually supports matching more than
+  // *two* tags at once: "john rose lowas" works! This is thanks to
+  // flexsearch matching multiple field values in a single query.
+  ['artTags', 'artTags'],
+
+  ['contributors', 'parentName'],
+  ['contributors', 'groups'],
+  ['primaryName', 'contributors'],
+  ['primaryName'],
+];
+
 function queryGenericIndex(index, query, options) {
-  const interestingFieldCombinations = [
-    ['primaryName', 'parentName', 'groups'],
-    ['primaryName', 'parentName'],
-    ['primaryName', 'groups', 'contributors'],
-    ['primaryName', 'groups', 'artTags'],
-    ['primaryName', 'groups'],
-    ['primaryName', 'contributors'],
-    ['primaryName', 'artTags'],
-    ['parentName', 'groups', 'artTags'],
-    ['parentName', 'artTags'],
-    ['groups', 'contributors'],
-    ['groups', 'artTags'],
-
-    // This prevents just matching *everything* tagged "john" if you
-    // only search "john", but it actually supports matching more than
-    // *two* tags at once: "john rose lowas" works! This is thanks to
-    // flexsearch matching multiple field values in a single query.
-    ['artTags', 'artTags'],
-
-    ['contributors', 'parentName'],
-    ['contributors', 'groups'],
-    ['primaryName', 'contributors'],
-    ['primaryName'],
-  ];
-
   const interestingFields =
     unique(interestingFieldCombinations.flat());
 
   const {genericTerms, queriedKind} =
     processTerms(query);
 
+  if (empty(genericTerms)) return null;
+
   const particles =
     particulate(genericTerms);
+
+  const groupedParticles =
+    groupArray(particles, ({length}) => length);
+
+  const queriesBy = keys =>
+    (groupedParticles.get(keys.length) ?? [])
+      .flatMap(permutations)
+      .map(values => values.map(({terms}) => terms.join(' ')))
+      .map(values =>
+        stitchArrays({
+          field: keys,
+          query: values,
+        }));
+
+  const boilerplate = queryBoilerplate(index);
+
+  const particleResults =
+    Object.fromEntries(
+      interestingFields.map(field => [
+        field,
+        Object.fromEntries(
+          particles.flat()
+            .map(({terms}) => terms.join(' '))
+            .map(query => [
+              query,
+              new Set(
+                boilerplate
+                  .query(query, {
+                    ...options,
+                    field,
+                    limit: Infinity,
+                  })
+                  .fieldResults[field]),
+            ])),
+      ]));
+
+  const results = new Set();
+
+  for (const interestingFieldCombination of interestingFieldCombinations) {
+    for (const query of queriesBy(interestingFieldCombination)) {
+      const idToMatchingFieldsMap = new Map();
+      for (const {field, query: fieldQuery} of query) {
+        for (const id of particleResults[field][fieldQuery]) {
+          if (idToMatchingFieldsMap.has(id)) {
+            idToMatchingFieldsMap.get(id).push(field);
+          } else {
+            idToMatchingFieldsMap.set(id, [field]);
+          }
+        }
+      }
+
+      const commonAcrossFields =
+        Array.from(idToMatchingFieldsMap.entries())
+          .filter(([id, matchingFields]) =>
+            matchingFields.length === interestingFieldCombination.length)
+          .map(([id]) => id);
+
+      for (const result of commonAcrossFields) {
+        results.add(result);
+      }
+    }
+  }
+
+  const constituted =
+    boilerplate.constitute(results);
+
+  const constitutedAndFiltered =
+    constituted
+      .filter(({id}) =>
+        (queriedKind
+          ? id.split(':')[0] === queriedKind
+          : true));
+
+  return constitutedAndFiltered;
+}
+
+function queryVerbatimIndex(index, query, options) {
+  const interestingFields =
+    unique(interestingFieldCombinations.flat());
+
+  const {verbatimTerms, queriedKind} =
+    processTerms(query);
+
+  if (empty(verbatimTerms)) return null;
+
+  const particles =
+    particulate(verbatimTerms);
 
   const groupedParticles =
     groupArray(particles, ({length}) => length);
@@ -510,11 +601,14 @@ function processTerms(query) {
   ];
 
   const genericTerms = [];
+  const verbatimTerms = [];
   let queriedKind = null;
 
   const termRegexp =
     new RegExp(
       String.raw`(?<kind>${kindTermSpec.flatMap(spec => spec.terms).join('|')})` +
+      String.raw`|(?<=^|\s)(?<quote>["'])(?<regularVerbatim>.+?)\k<quote>(?=$|\s)` +
+      String.raw`|(?<=^|\s)[“”‘’](?<curlyVerbatim>.+?)[“”‘’](?=$|\s)` +
       String.raw`|[^\s\-]+`,
       'gi');
 
@@ -530,10 +624,16 @@ function processTerms(query) {
       continue;
     }
 
+    const verbatim = groups.regularVerbatim || groups.curlyVerbatim;
+    if (verbatim) {
+      verbatimTerms.push(verbatim);
+      continue;
+    }
+
     genericTerms.push(match[0]);
   }
 
-  return {genericTerms, queriedKind};
+  return {genericTerms, verbatimTerms, queriedKind};
 }
 
 function particulate(terms) {

--- a/src/static/js/search-worker.js
+++ b/src/static/js/search-worker.js
@@ -371,15 +371,9 @@ function postActionResult(id, status, value) {
 }
 
 function performSearchAction({query, options}) {
-  const {generic, verbatim} = indexes;
-
   const {queriedKind} = processTerms(query);
-
-  const genericResults =
-    queryGenericIndex(generic, query, options);
-
-  const verbatimResults =
-    queryVerbatimIndex(verbatim, query, options);
+  const genericResults = queryGenericIndex(query, options);
+  const verbatimResults = queryVerbatimIndex(query, options);
 
   const verbatimIDs =
     new Set(verbatimResults?.map(result => result.id));
@@ -421,106 +415,31 @@ const interestingFieldCombinations = [
   ['primaryName'],
 ];
 
-function queryGenericIndex(index, query, options) {
-  const interestingFields =
-    unique(interestingFieldCombinations.flat());
-
-  const {genericTerms, queriedKind} =
-    processTerms(query);
-
-  if (empty(genericTerms)) return null;
-
-  const particles =
-    particulate(genericTerms);
-
-  const groupedParticles =
-    groupArray(particles, ({length}) => length);
-
-  const queriesBy = keys =>
-    (groupedParticles.get(keys.length) ?? [])
-      .flatMap(permutations)
-      .map(values => values.map(({terms}) => terms.join(' ')))
-      .map(values =>
-        stitchArrays({
-          field: keys,
-          query: values,
-        }));
-
-  const boilerplate = queryBoilerplate(index);
-
-  const particleResults =
-    Object.fromEntries(
-      interestingFields.map(field => [
-        field,
-        Object.fromEntries(
-          particles.flat()
-            .map(({terms}) => terms.join(' '))
-            .map(query => [
-              query,
-              new Set(
-                boilerplate
-                  .query(query, {
-                    ...options,
-                    field,
-                    limit: Infinity,
-                  })
-                  .fieldResults[field]),
-            ])),
-      ]));
-
-  let matchedResults = new Set();
-
-  for (const interestingFieldCombination of interestingFieldCombinations) {
-    for (const query of queriesBy(interestingFieldCombination)) {
-      const commonAcrossFields = new Set();
-
-      for (const [index, {field, query: fieldQuery}] of query.entries()) {
-        const firstFieldInQuery = (index === 0);
-        const tossResults = new Set(commonAcrossFields);
-
-        for (const result of particleResults[field][fieldQuery]) {
-          if (firstFieldInQuery) {
-            commonAcrossFields.add(result);
-          } else {
-            tossResults.delete(result);
-          }
-        }
-
-        for (const result of tossResults) {
-          commonAcrossFields.delete(result);
-        }
-      }
-
-      for (const result of commonAcrossFields) {
-        matchedResults.add(result);
-      }
-    }
-  }
-
-  matchedResults = Array.from(matchedResults);
-
-  const filteredResults =
-    (queriedKind
-      ? matchedResults.filter(id => id.split(':')[0] === queriedKind)
-      : matchedResults);
-
-  const constitutedResults =
-    boilerplate.constitute(filteredResults);
-
-  return constitutedResults;
+function queryGenericIndex(query, options) {
+  return queryIndex({
+    indexKey: 'generic',
+    termsKey: 'genericTerms',
+  }, query, options);
 }
 
-function queryVerbatimIndex(index, query, options) {
+function queryVerbatimIndex(query, options) {
+  return queryIndex({
+    indexKey: 'verbatim',
+    termsKey: 'verbatimTerms',
+  }, query, options);
+}
+
+function queryIndex({termsKey, indexKey}, query, options) {
   const interestingFields =
     unique(interestingFieldCombinations.flat());
 
-  const {verbatimTerms, queriedKind} =
+  const {[termsKey]: terms, queriedKind} =
     processTerms(query);
 
-  if (empty(verbatimTerms)) return null;
+  if (empty(terms)) return null;
 
   const particles =
-    particulate(verbatimTerms);
+    particulate(terms);
 
   const groupedParticles =
     groupArray(particles, ({length}) => length);
@@ -535,7 +454,7 @@ function queryVerbatimIndex(index, query, options) {
           query: values,
         }));
 
-  const boilerplate = queryBoilerplate(index);
+  const boilerplate = queryBoilerplate(indexes[indexKey]);
 
   const particleResults =
     Object.fromEntries(

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -822,6 +822,7 @@ misc:
       album: "Albums"
       artTag: "Art Tags"
       artist: "Artists"
+      flash: "Flashes"
       group: "Groups"
       track: "Tracks"
 

--- a/src/strings-default.yaml
+++ b/src/strings-default.yaml
@@ -818,6 +818,13 @@ misc:
       artist: "(artist)"
       group: "(group)"
 
+    resultFilter:
+      album: "Albums"
+      artTag: "Art Tags"
+      artist: "Artists"
+      group: "Groups"
+      track: "Tracks"
+
   # skippers:
   #
   #   These are navigational links that only show up when you're


### PR DESCRIPTION
Resolves #589.

<details><summary>Video demos!!</summary>

Adds search filters!

https://github.com/user-attachments/assets/271de66c-5813-479b-8294-6ae9d9128192

And fuzzy search!

https://github.com/user-attachments/assets/44a01dd9-2674-4cb1-9dab-c07449ac5176

And integrates a filter type from the query!

https://github.com/user-attachments/assets/17d20f5c-1aa1-49ed-b9f8-ad182a498d49

WOAH!</details>

---

We've made the `generic` search spec filter "fuzzy" by specifying (on every indexed field) `{tokenize: 'forward'}`, per FlexSearch docs. We also added a new `verbatim` spec, which is exactly the same, but does not tokenize forwards. The details of what verbatim DOES are a little funky, so:

* `processTerms` gets stuff between quotes each as its own term, and these go into a separate `verbatimTerms` result list.
* `processTerms` doesn't *further* break these down, which has an impact on `particulate`—in the query `"dog" "cat banana"` the only particulations are `[["dog"], ["cat banana"]]` and `[["dog", "cat banana"]]`.
* Since `"dog" "cat banana"` has only two terms, it will only try to search for interesting field combinations of length one or two. In practice this means searching `"land of fans"` is, for example, only going to search from interesting field combinations of length *one*, of which we've only got `['primaryName']` at the moment. So single-term searches (only possible with multiple words via verbatim terms) cut out all the other stuff you'd probably treat as junk.
* We don't process generic and verbatim terms alongside each other AT ALL. You *can* specify them together, but they're treated completely separately; only after both searches are performed are the common results filtered. So it's a bit fuggin' useless, since the query `"land of" 3` is only gonna search primary names (from verbatim) for `land of` and (from verbatim) for `3`.
    * ergo it is a lot of copy-pasted pipeline 👍 
    * We wanna change this so they're processed together and `"land of" 3` would be treated as two terms and make up interesting field combinations of length 1 or 2. MAYBE WE WILL DO THIS, BEFORE WE MERGE THIS. Maybe not. Look at the commits to find out lmfao
* Verbatim search still doesn't care about word order sorry sorry sorry. We couldn't figure that out. `"land fans of"` is the same as `"land of fans"`. The only difference is in particulation (see above) and - more importantly - in tokenization, which means `"crystal"` is gonna match the literal word `crystal` and not stuff like `Crystalanachronysms`.

Search filters are 100% frontend code so there's not a whole lot to talk about for them, except that state management is freaking annoying purely because CSS animations are freaking annoying. They're cool and work though!

Oh yeah and a filter kind you typed into the query does integrate. See third video. That involves returning the query kind term as part of the search results, so term processing is still exclusive to `processTerms` within `search-worker.js` (with the rest of the actual Searching Code).