### PR TITLE
Improve gen-thumbs performance

### DIFF
--- a/src/gen-thumbs.js
+++ b/src/gen-thumbs.js
@@ -464,27 +464,32 @@ async function getImageMagickVersion(binary) {
 
 // Write all requested thumbtacks for a source image in one pass
 // This saves a lot of disk reads which are probably the main bottleneck
-function buildMultiThumbArgs({src, dstDir, baseName, thumbtacks}) {
-  const args = [src, '-strip'];
+function prepareConvertArgs(filePathInMedia, dirnameInCache, thumbtacks) {
+  const args = [filePathInMedia, '-strip'];
+
+  const basename =
+    path.basename(filePathInMedia, path.extname(filePathInMedia));
 
   // do larger sizes first
-  thumbtacks
-    .sort((a, b) => thumbnailSpec[b].size - thumbnailSpec[a].size)
-    .forEach(tack => {
-      const {size, quality} = thumbnailSpec[tack];
-      const outFile = path.join(dstDir, `${baseName}.${tack}.jpg`);
-      args.push(
-        '(', '+clone',
-        '-resize', `${size}x${size}>`,
-        '-interlace', 'Plane',
-        '-quality', `${quality}%`,
-        '-write', outFile,
-        '+delete', ')',
-      );
-    });
+  thumbtacks.sort((a, b) => thumbnailSpec[b].size - thumbnailSpec[a].size);
+
+  for (const tack of thumbtacks) {
+    const {size, quality} = thumbnailSpec[tack];
+    const filename = `${basename}.${tack}.jpg`;
+    const filePathInCache = path.join(dirnameInCache, filename);
+    args.push(
+      '(', '+clone',
+      '-resize', `${size}x${size}>`,
+      '-interlace', 'Plane',
+      '-quality', `${quality}%`,
+      '-write', filePathInCache,
+      '+delete', ')',
+    );
+  }
 
   // throw away the (already written) image stream
   args.push('null:');
+
   return args;
 }
 
@@ -586,19 +591,18 @@ async function generateImageThumbnails(imagePath, thumbtacks, {
   mediaCachePath,
   spawnConvert,
 }) {
-  if (!thumbtacks.length) return;
+  if (empty(thumbtacks)) return;
 
-  const filePathInMedia = path.join(mediaPath, imagePath);
-  const dstDir          = path.join(mediaCachePath, path.dirname(imagePath));
-  await mkdir(dstDir, {recursive: true});
+  const filePathInMedia =
+    path.join(mediaPath, imagePath);
 
-  const baseName  = path.basename(imagePath, path.extname(imagePath));
-  const convertArgs = buildMultiThumbArgs({
-    src: filePathInMedia,
-    dstDir,
-    baseName,
-    thumbtacks,
-  });
+  const dirnameInCache =
+    path.join(mediaCachePath, path.dirname(imagePath));
+
+  await mkdir(dirnameInCache, {recursive: true});
+
+  const convertArgs =
+    prepareConvertArgs(filePathInMedia, dirnameInCache, thumbtacks);
 
   await promisifyProcess(spawnConvert(convertArgs), false);
 }

--- a/src/gen-thumbs.js
+++ b/src/gen-thumbs.js
@@ -462,6 +462,32 @@ async function getImageMagickVersion(binary) {
   return match[1];
 }
 
+// Write all requested thumbtacks for a source image in one pass
+// This saves a lot of disk reads which are probably the main bottleneck
+function buildMultiThumbArgs({src, dstDir, baseName, thumbtacks}) {
+  const args = [src, '-strip'];
+
+  // do larger sizes first
+  thumbtacks
+    .sort((a, b) => thumbnailSpec[b].size - thumbnailSpec[a].size)
+    .forEach(tack => {
+      const {size, quality} = thumbnailSpec[tack];
+      const outFile = path.join(dstDir, `${baseName}.${tack}.jpg`);
+      args.push(
+        '(', '+clone',
+        '-resize', `${size}x${size}>`,
+        '-interlace', 'Plane',
+        '-quality', `${quality}%`,
+        '-write', outFile,
+        '+delete', ')',
+      );
+    });
+
+  // throw away the (already written) image stream
+  args.push('null:');
+  return args;
+}
+
 async function getSpawnMagick(tool) {
   if (tool !== 'identify' && tool !== 'convert') {
     throw new Error(`Expected identify or convert`);
@@ -555,43 +581,28 @@ async function determineThumbtacksNeededForFile({
   return mismatchedWithinRightSize;
 }
 
-async function generateImageThumbnail(imagePath, thumbtack, {
+async function generateImageThumbnails(imagePath, thumbtacks, {
   mediaPath,
   mediaCachePath,
   spawnConvert,
 }) {
-  const filePathInMedia =
-    path.join(mediaPath, imagePath);
+  if (!thumbtacks.length) return;
 
-  const dirnameInCache =
-    path.join(mediaCachePath, path.dirname(imagePath));
+  const filePathInMedia = path.join(mediaPath, imagePath);
+  const dstDir          = path.join(mediaCachePath, path.dirname(imagePath));
+  await mkdir(dstDir, {recursive: true});
 
-  const filename =
-    path.basename(imagePath, path.extname(imagePath)) +
-    `.${thumbtack}.jpg`;
+  const baseName  = path.basename(imagePath, path.extname(imagePath));
+  const convertArgs = buildMultiThumbArgs({
+    src: filePathInMedia,
+    dstDir,
+    baseName,
+    thumbtacks,
+  });
 
-  const filePathInCache =
-    path.join(dirnameInCache, filename);
-
-  await mkdir(dirnameInCache, {recursive: true});
-
-  const specEntry = thumbnailSpec[thumbtack];
-  const {size, quality} = specEntry;
-
-  const convertProcess = spawnConvert([
-    filePathInMedia,
-    '-strip',
-    '-resize',
-    `${size}x${size}>`,
-    '-interlace',
-    'Plane',
-    '-quality',
-    `${quality}%`,
-    filePathInCache,
-  ]);
-
-  await promisifyProcess(convertProcess, false);
+  await promisifyProcess(spawnConvert(convertArgs), false);
 }
+
 
 export async function determineMediaCachePath({
   mediaPath,
@@ -1111,21 +1122,19 @@ export default async function genThumbs({
   const generateCallThumbtacks =
     imageThumbtacksNeeded.flat();
 
-  const generateCallFns =
-    stitchArrays({
-      imagePath: generateCallImagePaths,
-      thumbtack: generateCallThumbtacks,
-    }).map(({imagePath, thumbtack}) => () =>
-        generateImageThumbnail(imagePath, thumbtack, {
-          mediaPath,
-          mediaCachePath,
-          spawnConvert,
-        }).catch(error => {
-            numFailed++;
-            return ({error});
-          }));
+  const generateCallFns = imagePaths.map((imagePath, idx) => () => {
+    return generateImageThumbnails(imagePath, imageThumbtacksNeeded[idx], {
+      mediaPath,
+      mediaCachePath,
+      spawnConvert,
+    }).catch(error => {
+        numFailed++;
+        return {error};
+      })});
 
-  logInfo`Generating ${generateCallFns.length} thumbnails for ${imagePaths.length} media files.`;
+  const totalThumbs = imageThumbtacksNeeded.reduce((sum, tacks) => sum + tacks.length, 0);
+
+  logInfo`Generating ${totalThumbs} thumbnails for ${imagePaths.length} media files.`;
   if (generateCallFns.length > 500) {
     logInfo`Go get a latte - this could take a while!`;
   }

--- a/src/gen-thumbs.js
+++ b/src/gen-thumbs.js
@@ -1114,27 +1114,19 @@ export default async function genThumbs({
   const writeMessageFn = () =>
     `Writing image thumbnails. [failed: ${numFailed}]`;
 
-  const generateCallImageIndices =
-    imageThumbtacksNeeded
-      .flatMap(({length}, index) =>
-        Array.from({length}, () => index));
-
-  const generateCallImagePaths =
-    generateCallImageIndices
-      .map(index => imagePaths[index]);
-
-  const generateCallThumbtacks =
-    imageThumbtacksNeeded.flat();
-
-  const generateCallFns = imagePaths.map((imagePath, idx) => () => {
-    return generateImageThumbnails(imagePath, imageThumbtacksNeeded[idx], {
-      mediaPath,
-      mediaCachePath,
-      spawnConvert,
-    }).catch(error => {
-        numFailed++;
-        return {error};
-      })});
+  const generateCallFns =
+    stitchArrays({
+      imagePath: imagePaths,
+      thumbtacks: imageThumbtacksNeeded,
+    }).map(({imagePath, thumbtacks}) => () =>
+        generateImageThumbnails(imagePath, thumbtacks, {
+          mediaPath,
+          mediaCachePath,
+          spawnConvert,
+        }).catch(error => {
+            numFailed++;
+            return {error};
+          }));
 
   const totalThumbs = imageThumbtacksNeeded.reduce((sum, tacks) => sum + tacks.length, 0);
 
@@ -1147,37 +1139,30 @@ export default async function genThumbs({
     await progressPromiseAll(writeMessageFn,
       queue(generateCallFns, magickThreads));
 
-  let successfulIndices;
+  let successfulPaths;
 
   {
-    const erroredIndices = generateCallImageIndices.slice();
-    const erroredPaths = generateCallImagePaths.slice();
-    const erroredThumbtacks = generateCallThumbtacks.slice();
+    const erroredPaths = imagePaths.slice();
     const errors = generateCallResults.map(result => result?.error);
 
     const {removed} =
       filterMultipleArrays(
-        erroredIndices,
         erroredPaths,
-        erroredThumbtacks,
         errors,
-        (_index, _imagePath, _thumbtack, error) => error);
+        (_imagePath, error) => error);
 
-    successfulIndices = new Set(removed[0]);
-
-    const chunks =
-      chunkMultipleArrays(erroredPaths, erroredThumbtacks, errors,
-        (imagePath, lastImagePath) => imagePath !== lastImagePath);
+    ([successfulPaths] = removed);
 
     // TODO: This should obviously be an aggregate error.
     // ...Just like every other error report here, and those dang aggregates
     // should be constructable from within the queue, rather than after.
-    for (const [[imagePath], thumbtacks, errors] of chunks) {
-      logError`Failed to generate thumbnails for ${imagePath}:`;
-      for (const {thumbtack, error} of stitchArrays({thumbtack: thumbtacks, error: errors})) {
-        logError`- ${thumbtack}: ${error}`;
-      }
-    }
+    stitchArrays({
+      imagePath: erroredPaths,
+      error: errors,
+    }).forEach(({imagePath, error}) => {
+        logError`Failed to generate thumbnails for ${imagePath}:`;
+        logError`- ${error}`;
+      });
 
     if (empty(errors)) {
       logInfo`All needed thumbnails generated successfully - nice!`;
@@ -1191,8 +1176,8 @@ export default async function genThumbs({
     imagePaths,
     imageThumbtacksNeeded,
     imageDimensions,
-    (_imagePath, _thumbtacksNeeded, _dimensions, index) =>
-      successfulIndices.has(index));
+    (imagePath, _thumbtacksNeeded, _dimensions) =>
+      successfulPaths.includes(imagePath));
 
   for (const {
     imagePath,

--- a/src/gen-thumbs.js
+++ b/src/gen-thumbs.js
@@ -462,37 +462,6 @@ async function getImageMagickVersion(binary) {
   return match[1];
 }
 
-// Write all requested thumbtacks for a source image in one pass
-// This saves a lot of disk reads which are probably the main bottleneck
-function prepareConvertArgs(filePathInMedia, dirnameInCache, thumbtacks) {
-  const args = [filePathInMedia, '-strip'];
-
-  const basename =
-    path.basename(filePathInMedia, path.extname(filePathInMedia));
-
-  // do larger sizes first
-  thumbtacks.sort((a, b) => thumbnailSpec[b].size - thumbnailSpec[a].size);
-
-  for (const tack of thumbtacks) {
-    const {size, quality} = thumbnailSpec[tack];
-    const filename = `${basename}.${tack}.jpg`;
-    const filePathInCache = path.join(dirnameInCache, filename);
-    args.push(
-      '(', '+clone',
-      '-resize', `${size}x${size}>`,
-      '-interlace', 'Plane',
-      '-quality', `${quality}%`,
-      '-write', filePathInCache,
-      '+delete', ')',
-    );
-  }
-
-  // throw away the (already written) image stream
-  args.push('null:');
-
-  return args;
-}
-
 async function getSpawnMagick(tool) {
   if (tool !== 'identify' && tool !== 'convert') {
     throw new Error(`Expected identify or convert`);
@@ -586,6 +555,37 @@ async function determineThumbtacksNeededForFile({
   return mismatchedWithinRightSize;
 }
 
+// Write all requested thumbtacks for a source image in one pass
+// This saves a lot of disk reads which are probably the main bottleneck
+function prepareConvertArgs(filePathInMedia, dirnameInCache, thumbtacks) {
+  const args = [filePathInMedia, '-strip'];
+
+  const basename =
+    path.basename(filePathInMedia, path.extname(filePathInMedia));
+
+  // do larger sizes first
+  thumbtacks.sort((a, b) => thumbnailSpec[b].size - thumbnailSpec[a].size);
+
+  for (const tack of thumbtacks) {
+    const {size, quality} = thumbnailSpec[tack];
+    const filename = `${basename}.${tack}.jpg`;
+    const filePathInCache = path.join(dirnameInCache, filename);
+    args.push(
+      '(', '+clone',
+      '-resize', `${size}x${size}>`,
+      '-interlace', 'Plane',
+      '-quality', `${quality}%`,
+      '-write', filePathInCache,
+      '+delete', ')',
+    );
+  }
+
+  // throw away the (already written) image stream
+  args.push('null:');
+
+  return args;
+}
+
 async function generateImageThumbnails(imagePath, thumbtacks, {
   mediaPath,
   mediaCachePath,
@@ -606,7 +606,6 @@ async function generateImageThumbnails(imagePath, thumbtacks, {
 
   await promisifyProcess(spawnConvert(convertArgs), false);
 }
-
 
 export async function determineMediaCachePath({
   mediaPath,


### PR DESCRIPTION
By doing the converts for a single image as a batch imagemagick operation, we spawn 6k instead of 44k ImageMagick processes and save a bunch of I/O operations.

This resulted in a 2.29x faster process on my machine, but it was such low hanging fruit that for all I know this is a Windows-exclusive optimization, so please test this on a different OS too.