### PR TITLE
upd8 msgpackr (fixes Node.js 22+)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "image-size": "^1.0.2",
                 "js-yaml": "^4.1.0",
                 "marked": "^10.0.0",
-                "msgpackr": "^1.10.2",
+                "msgpackr": "^1.11.4",
                 "rimraf": "^5.0.7",
                 "striptags": "^4.0.0-alpha.4",
                 "word-wrap": "^1.2.3"
@@ -3508,9 +3508,10 @@
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node_modules/msgpackr": {
-            "version": "1.10.2",
-            "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.10.2.tgz",
-            "integrity": "sha512-L60rsPynBvNE+8BWipKKZ9jHcSGbtyJYIwjRq0VrIvQ08cRjntGXJYW/tmciZ2IHWIY8WEW32Qa2xbh5+SKBZA==",
+            "version": "1.11.4",
+            "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.4.tgz",
+            "integrity": "sha512-uaff7RG9VIC4jacFW9xzL3jc0iM32DNHe4jYVycBcjUePT/Klnfj7pqtWJt9khvDFizmjN2TlYniYmSS2LIaZg==",
+            "license": "MIT",
             "optionalDependencies": {
                 "msgpackr-extract": "^3.0.2"
             }
@@ -7988,9 +7989,9 @@
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "msgpackr": {
-            "version": "1.10.2",
-            "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.10.2.tgz",
-            "integrity": "sha512-L60rsPynBvNE+8BWipKKZ9jHcSGbtyJYIwjRq0VrIvQ08cRjntGXJYW/tmciZ2IHWIY8WEW32Qa2xbh5+SKBZA==",
+            "version": "1.11.4",
+            "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.4.tgz",
+            "integrity": "sha512-uaff7RG9VIC4jacFW9xzL3jc0iM32DNHe4jYVycBcjUePT/Klnfj7pqtWJt9khvDFizmjN2TlYniYmSS2LIaZg==",
             "requires": {
                 "msgpackr-extract": "^3.0.2"
             }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
         "image-size": "^1.0.2",
         "js-yaml": "^4.1.0",
         "marked": "^10.0.0",
-        "msgpackr": "^1.10.2",
+        "msgpackr": "^1.11.4",
         "rimraf": "^5.0.7",
         "striptags": "^4.0.0-alpha.4",
         "word-wrap": "^1.2.3"


### PR DESCRIPTION
This fixes the `"length" is outside of buffer bounds` error when preparing search data on Node.js 22+.