### PR TITLE
Custom track artist text

### DIFF
--- a/src/content/dependencies/generateArtistCredit.js
+++ b/src/content/dependencies/generateArtistCredit.js
@@ -146,6 +146,16 @@ export default {
 
       relations.formatText.setSlots({
         mode: 'inline',
+
+        substitute: [
+          {
+            match: {
+              replacerKey: 'artist',
+              replacerValue: 'screamcatcher',
+            },
+            substitute: 'YAYAS!',
+          },
+        ],
       });
     }
 

--- a/src/content/dependencies/generateArtistCredit.js
+++ b/src/content/dependencies/generateArtistCredit.js
@@ -1,4 +1,4 @@
-import {compareArrays, empty} from '#sugar';
+import {compareArrays, empty, stitchArrays} from '#sugar';
 
 export default {
   contentDependencies: [
@@ -80,6 +80,14 @@ export default {
     normalContributionAnnotationsDifferFromContext:
       query.normalContributionAnnotationsDifferFromContext,
 
+    normalContributionArtistDirectories:
+      query.normalContributions
+        .map(contrib => contrib.artist.directory),
+
+    featuringContributionArtistDirectories:
+      query.featuringContributions
+        .map(contrib => contrib.artist.directory),
+
     hasWikiEdits:
       !empty(query.wikiEditContributions),
   }),
@@ -144,18 +152,31 @@ export default {
     if (!html.isBlank(relations.formatText)) {
       formattedArtistList = relations.formatText;
 
+      const substituteContrib = ({link, directory}) => ({
+        match: {replacerKey: 'artist', replacerValue: directory},
+        substitute: link,
+
+        apply(link, node) {
+          if (node.data.label) {
+            link.setSlot('content', language.sanitize(node.data.label));
+          }
+        },
+      });
+
       relations.formatText.setSlots({
         mode: 'inline',
 
         substitute: [
-          {
-            match: {
-              replacerKey: 'artist',
-              replacerValue: 'screamcatcher',
-            },
-            substitute: 'YAYAS!',
-          },
-        ],
+          stitchArrays({
+            link: relations.normalContributionLinks,
+            directory: data.normalContributionArtistDirectories,
+          }).map(substituteContrib),
+
+          stitchArrays({
+            link: relations.featuringContributionLinks,
+            directory: data.featuringContributionArtistDirectories,
+          }).map(substituteContrib),
+        ].flat(),
       });
     }
 

--- a/src/content/dependencies/generateArtistCredit.js
+++ b/src/content/dependencies/generateArtistCredit.js
@@ -120,6 +120,10 @@ export default {
   generate(data, relations, slots, {html, language}) {
     if (!slots.normalStringKey) return html.blank();
 
+    const effectivelyDiffers =
+      (slots.showAnnotation && data.normalContributionAnnotationsDifferFromContext) ||
+      (data.normalContributionArtistsDifferFromContext);
+
     for (const link of [
       ...relations.normalContributionLinks,
       ...relations.featuringContributionLinks,
@@ -183,11 +187,13 @@ export default {
     let content;
 
     if (formattedArtistList) {
-      content =
-        language.$(slots.normalStringKey, {
-          ...slots.additionalStringOptions,
-          artists: formattedArtistList,
-        });
+      if (effectivelyDiffers) {
+        content =
+          language.$(slots.normalStringKey, {
+            ...slots.additionalStringOptions,
+            artists: formattedArtistList,
+          });
+      }
     } else {
       if (empty(relations.normalContributionLinks)) {
         return html.blank();
@@ -215,12 +221,6 @@ export default {
           ...relations.normalContributionLinks,
           ...relations.featuringContributionLinks,
         ]);
-
-      const effectivelyDiffers =
-        (formattedArtistList
-          ? null
-          : (slots.showAnnotation && data.normalContributionAnnotationsDifferFromContext) ||
-            (data.normalContributionArtistsDifferFromContext));
 
       if (empty(relations.featuringContributionLinks)) {
         if (effectivelyDiffers) {

--- a/src/content/dependencies/generateArtistCredit.js
+++ b/src/content/dependencies/generateArtistCredit.js
@@ -4,11 +4,12 @@ export default {
   contentDependencies: [
     'generateArtistCreditWikiEditsPart',
     'linkContribution',
+    'transformContent',
   ],
 
   extraDependencies: ['html', 'language'],
 
-  query: (creditContributions, contextContributions) => {
+  query: (creditContributions, contextContributions, _formatText) => {
     const query = {};
 
     const featuringFilter = contribution =>
@@ -52,7 +53,10 @@ export default {
     return query;
   },
 
-  relations: (relation, query, _creditContributions, _contextContributions) => ({
+  relations: (relation, query,
+      _creditContributions,
+      _contextContributions,
+      formatText) => ({
     normalContributionLinks:
       query.normalContributions
         .map(contrib => relation('linkContribution', contrib)),
@@ -64,9 +68,12 @@ export default {
     wikiEditsPart:
       relation('generateArtistCreditWikiEditsPart',
         query.wikiEditContributions),
+
+    formatText:
+      relation('transformContent', formatText),
   }),
 
-  data: (query, _creditContributions, _contextContributions) => ({
+  data: (query, _creditContributions, _contextContributions, _formatText) => ({
     normalContributionArtistsDifferFromContext:
       query.normalContributionArtistsDifferFromContext,
 
@@ -132,67 +139,88 @@ export default {
       });
     }
 
-    if (empty(relations.normalContributionLinks)) {
-      return html.blank();
+    let formattedArtistList = null;
+
+    if (!html.isBlank(relations.formatText)) {
+      formattedArtistList = relations.formatText;
+
+      relations.formatText.setSlots({
+        mode: 'inline',
+      });
     }
-
-    const artistsList =
-      (data.hasWikiEdits && slots.showWikiEdits
-        ? language.$('misc.artistLink.withEditsForWiki', {
-            artists:
-              language.formatConjunctionList(relations.normalContributionLinks),
-
-            edits:
-              relations.wikiEditsPart.slots({
-                showAnnotation: slots.showAnnotation,
-              }),
-          })
-        : language.formatConjunctionList(relations.normalContributionLinks));
-
-    const featuringList =
-      language.formatConjunctionList(relations.featuringContributionLinks);
-
-    const everyoneList =
-      language.formatConjunctionList([
-        ...relations.normalContributionLinks,
-        ...relations.featuringContributionLinks,
-      ]);
-
-    const effectivelyDiffers =
-      (slots.showAnnotation && data.normalContributionAnnotationsDifferFromContext) ||
-      (data.normalContributionArtistsDifferFromContext);
 
     let content;
 
-    if (empty(relations.featuringContributionLinks)) {
-      if (effectivelyDiffers) {
-        content =
-          language.$(slots.normalStringKey, {
-            ...slots.additionalStringOptions,
-            artists: artistsList,
-          });
-      } else {
-        return html.blank();
-      }
-    } else if (effectivelyDiffers && slots.normalFeaturingStringKey) {
-      content =
-        language.$(slots.normalFeaturingStringKey, {
-          ...slots.additionalStringOptions,
-          artists: artistsList,
-          featuring: featuringList,
-      });
-    } else if (slots.featuringStringKey) {
-      content =
-        language.$(slots.featuringStringKey, {
-          ...slots.additionalStringOptions,
-          artists: featuringList,
-        });
-    } else {
+    if (formattedArtistList) {
       content =
         language.$(slots.normalStringKey, {
           ...slots.additionalStringOptions,
-          artists: everyoneList,
+          artists: formattedArtistList,
         });
+    } else {
+      if (empty(relations.normalContributionLinks)) {
+        return html.blank();
+      }
+
+      const artistsList =
+        (data.hasWikiEdits && slots.showWikiEdits
+          ? language.$('misc.artistLink.withEditsForWiki', {
+              artists:
+                language.formatConjunctionList(relations.normalContributionLinks),
+
+              edits:
+                relations.wikiEditsPart.slots({
+                  showAnnotation: slots.showAnnotation,
+                }),
+            })
+
+          : language.formatConjunctionList(relations.normalContributionLinks));
+
+      const featuringList =
+        language.formatConjunctionList(relations.featuringContributionLinks);
+
+      const everyoneList =
+        language.formatConjunctionList([
+          ...relations.normalContributionLinks,
+          ...relations.featuringContributionLinks,
+        ]);
+
+      const effectivelyDiffers =
+        (formattedArtistList
+          ? null
+          : (slots.showAnnotation && data.normalContributionAnnotationsDifferFromContext) ||
+            (data.normalContributionArtistsDifferFromContext));
+
+      if (empty(relations.featuringContributionLinks)) {
+        if (effectivelyDiffers) {
+          content =
+            language.$(slots.normalStringKey, {
+              ...slots.additionalStringOptions,
+              artists: artistsList,
+            });
+        } else {
+          return html.blank();
+        }
+      } else if (effectivelyDiffers && slots.normalFeaturingStringKey) {
+        content =
+          language.$(slots.normalFeaturingStringKey, {
+            ...slots.additionalStringOptions,
+            artists: artistsList,
+            featuring: featuringList,
+        });
+      } else if (slots.featuringStringKey) {
+        content =
+          language.$(slots.featuringStringKey, {
+            ...slots.additionalStringOptions,
+            artists: featuringList,
+          });
+      } else {
+        content =
+          language.$(slots.normalStringKey, {
+            ...slots.additionalStringOptions,
+            artists: everyoneList,
+          });
+      }
     }
 
     // TODO: This is obviously evil.

--- a/src/content/dependencies/generateReleaseInfoContributionsLine.js
+++ b/src/content/dependencies/generateReleaseInfoContributionsLine.js
@@ -2,9 +2,9 @@ export default {
   contentDependencies: ['generateArtistCredit'],
   extraDependencies: ['html'],
 
-  relations: (relation, contributions) => ({
+  relations: (relation, contributions, formatText) => ({
     credit:
-      relation('generateArtistCredit', contributions, []),
+      relation('generateArtistCredit', contributions, [], formatText),
   }),
 
   slots: {

--- a/src/content/dependencies/generateTrackListItem.js
+++ b/src/content/dependencies/generateTrackListItem.js
@@ -15,7 +15,8 @@ export default {
     credit:
       relation('generateArtistCredit',
         track.artistContribs,
-        contextContributions),
+        contextContributions,
+        track.artistText),
 
     colorStyle:
       relation('generateColorStyleAttribute', track.color),

--- a/src/content/dependencies/generateTrackReleaseInfo.js
+++ b/src/content/dependencies/generateTrackReleaseInfo.js
@@ -10,7 +10,9 @@ export default {
     const relations = {};
 
     relations.artistContributionsLine =
-      relation('generateReleaseInfoContributionsLine', track.artistContribs);
+      relation('generateReleaseInfoContributionsLine',
+        track.artistContribs,
+        track.artistText);
 
     relations.listenLine =
       relation('generateReleaseInfoListenLine', track);

--- a/src/content/dependencies/linkContribution.js
+++ b/src/content/dependencies/linkContribution.js
@@ -24,6 +24,8 @@ export default {
   }),
 
   slots: {
+    content: {type: 'html', mutable: false},
+
     showAnnotation: {type: 'boolean', default: false},
     showExternalLinks: {type: 'boolean', default: false},
     showChronology: {type: 'boolean', default: false},
@@ -45,6 +47,10 @@ export default {
 
       language.encapsulate('misc.artistLink', workingCapsule => {
         const workingOptions = {};
+
+        if (!html.isBlank(slots.content)) {
+          relations.artistLink.setSlot('content', slots.content);
+        }
 
         // Filling slots early is necessary to actually give the tooltip
         // content. Otherwise, the coming-up html.isBlank() always reports

--- a/src/content/dependencies/transformContent.js
+++ b/src/content/dependencies/transformContent.js
@@ -307,6 +307,8 @@ export default {
             }),
 
             substitute: v.isHTML,
+
+            apply: v.optional(v.isFunction),
           })),
     },
   },
@@ -363,7 +365,20 @@ export default {
         const substitution = pickSubstitution(node);
 
         if (substitution) {
-          return {type: 'substitution', data: substitution.substitute};
+          const source =
+            substitution.substitute;
+
+          let substitute = source;
+
+          if (substitution.apply) {
+            const result = substitution.apply(source, node);
+
+            if (result !== undefined) {
+              substitute = result;
+            }
+          }
+
+          return {type: 'substitution', data: substitute};
         }
 
         switch (node.type) {

--- a/src/content/dependencies/transformContent.js
+++ b/src/content/dependencies/transformContent.js
@@ -109,7 +109,7 @@ export default {
           }
 
           if (spec.link) {
-            let data = {link: spec.link};
+            let data = {link: spec.link, replacerKey, replacerValue};
 
             determineData: {
               // No value at all: this is an index link.
@@ -188,8 +188,8 @@ export default {
             ...node,
             data: {
               ...node.data,
-              replacerKey: node.data.replacerKey.data,
-              replacerValue: node.data.replacerValue[0].data,
+              replacerKey,
+              replacerValue,
             },
           };
         }),
@@ -204,24 +204,7 @@ export default {
         sprawl.error,
 
       nodes:
-        sprawl.nodes
-          .map(node => {
-            switch (node.type) {
-              // Replace internal link nodes with a stub. It'll be replaced
-              // (by position) with an item from relations.
-              //
-              // TODO: This should be where label and hash get passed through,
-              // rather than in relations... (in which case there's no need to
-              // handle it specially here, and we can really just return
-              // data.nodes = sprawl.nodes)
-              case 'internal-link':
-                return {type: 'internal-link'};
-
-              // Other nodes will get processed in generate.
-              default:
-                return node;
-            }
-          }),
+        sprawl.nodes,
     };
   },
 
@@ -313,6 +296,19 @@ export default {
       validate: v => v.is('small', 'medium', 'large'),
       default: 'large',
     },
+
+    substitute: {
+      validate: v =>
+        v.strictArrayOf(
+          v.validateProperties({
+            match: v.validateProperties({
+              replacerKey: v.isString,
+              replacerValue: v.isString,
+            }),
+
+            substitute: v.isHTML,
+          })),
+    },
   },
 
   generate(data, relations, slots, {html, language, niceShowAggregate, to}) {
@@ -327,6 +323,24 @@ export default {
     let externalLinkForTooltipNodeIndex = 0;
 
     let offsetTextNode = 0;
+
+    const substitutions =
+      (slots.substitute
+        ? slots.substitute.slice()
+        : []);
+
+    const pickSubstitution = node => {
+      const index =
+        substitutions.findIndex(({match}) =>
+          match.replacerKey === node.data.replacerKey &&
+          match.replacerValue === node.data.replacerValue);
+
+      if (index === -1) {
+        return null;
+      }
+
+      return substitutions.splice(index, 1).at(0);
+    };
 
     const contentFromNodes =
       data.nodes.map((node, index) => {
@@ -345,6 +359,12 @@ export default {
             offsetTextNode = suffix.length;
           }
         };
+
+        const substitution = pickSubstitution(node);
+
+        if (substitution) {
+          return {type: 'substitution', data: substitution.substitute};
+        }
 
         switch (node.type) {
           case 'text': {

--- a/src/data/things/album.js
+++ b/src/data/things/album.js
@@ -144,6 +144,8 @@ export class Album extends Thing {
       artistProperty: input.value('albumArtistContributions'),
     }),
 
+    trackArtistText: contentString(),
+
     trackArtistContribs: [
       withResolvedContribs({
         from: input.updateValue({validate: isContributionList}),
@@ -636,6 +638,10 @@ export class Album extends Thing {
       'Artists': {
         property: 'artistContribs',
         transform: parseContributors,
+      },
+
+      'Track Artist Text': {
+        property: 'trackArtistText',
       },
 
       'Track Artists': {

--- a/src/data/things/track.js
+++ b/src/data/things/track.js
@@ -4,8 +4,15 @@ import CacheableObject from '#cacheable-object';
 import {colors} from '#cli';
 import {input} from '#composite';
 import Thing from '#thing';
-import {isBoolean, isColor, isContributionList, isDate, isFileExtension}
-  from '#validators';
+
+import {
+  isBoolean,
+  isColor,
+  isContentString,
+  isContributionList,
+  isDate,
+  isFileExtension,
+} from '#validators';
 
 import {
   parseAdditionalFiles,
@@ -156,6 +163,20 @@ export class Track extends Thing {
     dateFirstReleased: simpleDate(),
 
     // > Update & expose - Credits and contributors
+
+    artistText: [
+      exposeUpdateValueOrContinue({
+        validate: input.value(isContentString),
+      }),
+
+      withPropertyFromAlbum({
+        property: input.value('trackArtistText'),
+      }),
+
+      exposeDependency({
+        dependency: '#album.trackArtistText',
+      }),
+    ],
 
     artistContribs: [
       inheritContributionListFromMainRelease(),
@@ -568,6 +589,10 @@ export class Track extends Thing {
       },
 
       // Credits and contributors
+
+      'Artist Text': {
+        property: 'artistText',
+      },
 
       'Artists': {
         property: 'artistContribs',


### PR DESCRIPTION
Mainly a standalone feature at present, shown on track pages and in track lists (including album track lists, but also referencing/referenced track lists, etc).

This is a fairly bone-simple approach, both in data and content.

In data, artist text is (maybe unsurprisingly) a totally separate data point from artist contributions. In content they work together; in data, at the moment, they don't interact at all. Artist text is a generic content string, so of course it can include links, typically to artists. Artist text is typically *expected* to include links to the artists in the track's artist contributions, but it can link to anything (or nothing).

In the future we'd like to derive artist contributions, implicitly and if unspecified, from artist text. Artist contributions are the basis for artist chronology (and artist credit lists). Since the "artist contributions chronology" is intended as a list of all tracks where the artist is credited in the by-line, it may as well come from the artist text, which (if present) *is* the by-line, as far as wiki presentation is concerned. But that's saved for a followup.

We'd also like to be able to specify artists in either format using the `Artists` field either way, instead of strictly requiring a separate `Artist Text` field. This is also saved for a followup. We figure we'll have a "transform the whole document" step for YAML processing, but that probably touches YAML infrastructure, so it's way out of scope for this PR.

The big-deal content code is angled generic and flexible: `transformContent` now takes a `substitute` slot, an array of substitutions, each of which is consumed once (if at all) then discarded, and replaces a tag matching based on replacer key and value (e.g. `'artist'` and `'toby-fox'`). Like any slot, these substitutions are completely provided and controlled by the consumer of `transformContent`; `transformContent` itself is responsible only for *how* they're consumed. There is an optional `apply` function to customize the substitution with data from the matching node, e.g. label text.

Track artist text is consumed in `generateArtistCredit` as the typical entry point for artist credits in any context. Custom artist text (after substituting contribution links) is treated as the entire formatted artist list on its own, so always uses the "normal" contribution credit, never "featuring". However, contribution link substitutions are made from all contributions on the artist, both normal and featuring.
