### PR TITLE
Content function recursion & implicit dependencies

### DIFF
--- a/src/content-function.js
+++ b/src/content-function.js
@@ -13,6 +13,14 @@ const DECORATE_TIME = process.env.HSMUSIC_DEBUG_CONTENT_PERF === '1';
 
 export class ContentFunctionSpecError extends Error {}
 
+function optionalDecorateTime(prefix, fn) {
+  if (DECORATE_TIME) {
+    return decorateTime(`${prefix}/${generate.name}`, fn);
+  } else {
+    return fn;
+  }
+}
+
 export default function contentFunction(spec) {
   if (!spec.generate) {
     throw new ContentFunctionSpecError(`Expected generate function`);
@@ -22,19 +30,34 @@ export default function contentFunction(spec) {
     Template.validateSlotsDescription(spec.slots);
   }
 
-  return expectDependencies(spec);
+  return expectExtraDependencies(spec, null);
 }
 
 contentFunction.identifyingSymbol = Symbol(`Is a content function?`);
 
-export function expectDependencies(spec, {
-  boundExtraDependencies = null,
-} = {}) {
-  const optionalDecorateTime = (prefix, fn) =>
-    (DECORATE_TIME
-      ? decorateTime(`${prefix}/${generate.name}`, fn)
-      : fn);
+export function expectExtraDependencies(spec, boundExtraDependencies) {
+  const generate =
+    (boundExtraDependencies
+      ? prepareWorkingGenerateFunction(spec, boundExtraDependencies)
+      : () => {
+          throw new Error(`Not bound with extraDependencies yet`);
+        });
 
+  generate[contentFunction.identifyingSymbol] = true;
+
+  for (const key of ['sprawl', 'query', 'relations', 'data']) {
+    if (spec[key]) {
+      generate[key] = optionalDecorateTime(`sprawl`, spec[key]);
+    }
+  }
+
+  generate.bindExtraDependencies = (extraDependencies) =>
+    expectExtraDependencies(spec, extraDependencies);
+
+  return generate;
+}
+
+function prepareWorkingGenerateFunction(spec, boundExtraDependencies) {
   let generate = ([arg1, arg2], ...extraArgs) => {
     if (spec.data && !arg1) {
       throw new Error(`Expected data`);
@@ -80,10 +103,8 @@ export function expectDependencies(spec, {
   generate = optionalDecorateTime(`generate`, generate);
 
   if (spec.slots) {
-    const normalGenerate = generate;
-
     let stationery = null;
-    generate = function(...args) {
+    return (...args) => {
       stationery ??= boundExtraDependencies.html.stationery({
         annotation: generate.name,
 
@@ -99,7 +120,7 @@ export function expectDependencies(spec, {
 
         content(slots) {
           const args = [slots._cfArg1, slots._cfArg2];
-          return normalGenerate(args, slots);
+          return generate(args, slots);
         },
       });
 
@@ -108,35 +129,9 @@ export function expectDependencies(spec, {
         _cfArg2: args[1] ?? null,
       });
     };
-  } else {
-    const normalGenerate = generate;
-    generate = (...args) => normalGenerate(args);
   }
 
-  generate.fulfill = function() {
-    throw new Error(`not part of the flow`);
-  };
-
-  Object.defineProperty(generate, 'fulfilled', {
-    get() {
-      throw new Error(`unknowable`);
-    }
-  });
-
-  generate[contentFunction.identifyingSymbol] = true;
-
-  for (const key of ['sprawl', 'query', 'relations', 'data']) {
-    if (spec[key]) {
-      generate[key] = optionalDecorateTime(`sprawl`, spec[key]);
-    }
-  }
-
-  generate.bindExtraDependencies = (extraDependencies) =>
-    expectDependencies(spec, {
-      boundExtraDependencies: extraDependencies,
-    });
-
-  return generate;
+  return (...args) => generate(args);
 }
 
 export function getArgsForRelationsAndData(contentFunction, wikiData, ...args) {

--- a/src/content-function.js
+++ b/src/content-function.js
@@ -3,7 +3,7 @@ import {inspect as nodeInspect} from 'node:util';
 import {decorateError} from '#aggregate';
 import {colors, decorateTime, ENABLE_COLOR} from '#cli';
 import {Template} from '#html';
-import {annotateFunction, empty, setIntersection} from '#sugar';
+import {empty} from '#sugar';
 
 function inspect(value, opts = {}) {
   return nodeInspect(value, {colors: ENABLE_COLOR, ...opts});
@@ -13,166 +13,78 @@ const DECORATE_TIME = process.env.HSMUSIC_DEBUG_CONTENT_PERF === '1';
 
 export class ContentFunctionSpecError extends Error {}
 
-export default function contentFunction({
-  contentDependencies = [],
-  extraDependencies = [],
-
-  slots,
-  sprawl,
-  query,
-  relations,
-  data,
-  generate,
-}) {
-  const expectedContentDependencyKeys = new Set(contentDependencies);
-  const expectedExtraDependencyKeys = new Set(extraDependencies);
-
-  // Initial checks. These only need to be run once per description of a
-  // content function, and don't depend on any mutable context (e.g. which
-  // dependencies have been fulfilled so far).
-
-  const overlappingContentExtraDependencyKeys =
-    setIntersection(expectedContentDependencyKeys, expectedExtraDependencyKeys);
-
-  if (!empty(overlappingContentExtraDependencyKeys)) {
-    throw new ContentFunctionSpecError(`Overlap in content and extra dependency keys: ${[...overlappingContentExtraDependencyKeys].join(', ')}`);
-  }
-
-  if (!generate) {
+export default function contentFunction(spec) {
+  if (!spec.generate) {
     throw new ContentFunctionSpecError(`Expected generate function`);
   }
 
-  if (sprawl && !expectedExtraDependencyKeys.has('wikiData')) {
-    throw new ContentFunctionSpecError(`Content functions which sprawl must specify wikiData in extraDependencies`);
+  if (spec.slots) {
+    Template.validateSlotsDescription(spec.slots);
   }
 
-  if (slots && !expectedExtraDependencyKeys.has('html')) {
-    throw new ContentFunctionSpecError(`Content functions with slots must specify html in extraDependencies`);
-  }
-
-  if (slots) {
-    Template.validateSlotsDescription(slots);
-  }
-
-  // Pass all the details to expectDependencies, which will recursively build
-  // up a set of fulfilled dependencies and make functions like `relations`
-  // and `generate` callable only with sufficient fulfilled dependencies.
-
-  return expectDependencies({
-    slots,
-    sprawl,
-    query,
-    relations,
-    data,
-    generate,
-
-    expectedContentDependencyKeys,
-    expectedExtraDependencyKeys,
-    missingContentDependencyKeys: new Set(expectedContentDependencyKeys),
-    missingExtraDependencyKeys: new Set(expectedExtraDependencyKeys),
-    invalidatingDependencyKeys: new Set(),
-    fulfilledDependencyKeys: new Set(),
-    fulfilledDependencies: {},
-  });
+  return expectDependencies(spec);
 }
 
 contentFunction.identifyingSymbol = Symbol(`Is a content function?`);
 
-export function expectDependencies({
-  slots,
-  sprawl,
-  query,
-  relations,
-  data,
-  generate,
-
-  expectedContentDependencyKeys,
-  expectedExtraDependencyKeys,
-  missingContentDependencyKeys,
-  missingExtraDependencyKeys,
-  invalidatingDependencyKeys,
-  fulfilledDependencyKeys,
-  fulfilledDependencies,
-}) {
-  const hasSprawlFunction = !!sprawl;
-  const hasQueryFunction = !!query;
-  const hasRelationsFunction = !!relations;
-  const hasDataFunction = !!data;
-  const hasSlotsDescription = !!slots;
-
-  const isInvalidated = !empty(invalidatingDependencyKeys);
-  const isMissingContentDependencies = !empty(missingContentDependencyKeys);
-  const isMissingExtraDependencies = !empty(missingExtraDependencyKeys);
-
-  let wrappedGenerate;
-
+export function expectDependencies(spec, {
+  boundExtraDependencies = null,
+} = {}) {
   const optionalDecorateTime = (prefix, fn) =>
     (DECORATE_TIME
       ? decorateTime(`${prefix}/${generate.name}`, fn)
       : fn);
 
-  if (isInvalidated) {
-    wrappedGenerate = function() {
-      throw new Error(`Generate invalidated because unfulfilled dependencies provided: ${[...invalidatingDependencyKeys].join(', ')}`);
-    };
+  let generate = ([arg1, arg2], ...extraArgs) => {
+    if (spec.data && !arg1) {
+      throw new Error(`Expected data`);
+    }
 
-    annotateFunction(wrappedGenerate, {name: generate, trait: 'invalidated'});
-    wrappedGenerate.fulfilled = false;
-  } else if (isMissingContentDependencies || isMissingExtraDependencies) {
-    wrappedGenerate = function() {
-      throw new Error(`Dependencies still needed: ${[...missingContentDependencyKeys, ...missingExtraDependencyKeys].join(', ')}`);
-    };
+    if (spec.data && spec.relations && !arg2) {
+      throw new Error(`Expected relations`);
+    }
 
-    annotateFunction(wrappedGenerate, {name: generate, trait: 'unfulfilled'});
-    wrappedGenerate.fulfilled = false;
-  } else {
-    let callUnderlyingGenerate = ([arg1, arg2], ...extraArgs) => {
-      if (hasDataFunction && !arg1) {
-        throw new Error(`Expected data`);
+    if (spec.relations && !arg1) {
+      throw new Error(`Expected relations`);
+    }
+
+    try {
+      if (spec.data && spec.relations) {
+        return spec.generate(arg1, arg2, ...extraArgs, boundExtraDependencies);
+      } else if (spec.data || spec.relations) {
+        return spec.generate(arg1, ...extraArgs, boundExtraDependencies);
+      } else {
+        return spec.generate(...extraArgs, boundExtraDependencies);
       }
+    } catch (caughtError) {
+      const error = new Error(
+        `Error generating content for ${spec.generate.name}`,
+        {cause: caughtError});
 
-      if (hasDataFunction && hasRelationsFunction && !arg2) {
-        throw new Error(`Expected relations`);
-      }
+      error[Symbol.for(`hsmusic.aggregate.alwaysTrace`)] = true;
+      error[Symbol.for(`hsmusic.aggregate.traceFrom`)] = caughtError;
 
-      if (hasRelationsFunction && !arg1) {
-        throw new Error(`Expected relations`);
-      }
+      error[Symbol.for(`hsmusic.aggregate.unhelpfulTraceLines`)] = [
+        /content-function\.js/,
+        /util\/html\.js/,
+      ];
 
-      try {
-        if (hasDataFunction && hasRelationsFunction) {
-          return generate(arg1, arg2, ...extraArgs, fulfilledDependencies);
-        } else if (hasDataFunction || hasRelationsFunction) {
-          return generate(arg1, ...extraArgs, fulfilledDependencies);
-        } else {
-          return generate(...extraArgs, fulfilledDependencies);
-        }
-      } catch (caughtError) {
-        const error = new Error(
-          `Error generating content for ${generate.name}`,
-          {cause: caughtError});
+      error[Symbol.for(`hsmusic.aggregate.helpfulTraceLines`)] = [
+        /content\/dependencies\/(.*\.js:.*(?=\)))/,
+      ];
 
-        error[Symbol.for(`hsmusic.aggregate.alwaysTrace`)] = true;
-        error[Symbol.for(`hsmusic.aggregate.traceFrom`)] = caughtError;
+      throw error;
+    }
+  };
 
-        error[Symbol.for(`hsmusic.aggregate.unhelpfulTraceLines`)] = [
-          /content-function\.js/,
-          /util\/html\.js/,
-        ];
+  generate = optionalDecorateTime(`generate`, generate);
 
-        error[Symbol.for(`hsmusic.aggregate.helpfulTraceLines`)] = [
-          /content\/dependencies\/(.*\.js:.*(?=\)))/,
-        ];
+  if (spec.slots) {
+    const normalGenerate = generate;
 
-        throw error;
-      }
-    };
-
-    callUnderlyingGenerate =
-      optionalDecorateTime(`generate`, callUnderlyingGenerate);
-
-    if (hasSlotsDescription) {
-      const stationery = fulfilledDependencies.html.stationery({
+    let stationery = null;
+    generate = function(...args) {
+      stationery ??= boundExtraDependencies.html.stationery({
         annotation: generate.name,
 
         // These extra slots are for the data and relations (positional) args.
@@ -182,170 +94,49 @@ export function expectDependencies({
         slots: {
           _cfArg1: {validate: v => v.isObject},
           _cfArg2: {validate: v => v.isObject},
-          ...slots,
+          ...spec.slots,
         },
 
         content(slots) {
           const args = [slots._cfArg1, slots._cfArg2];
-          return callUnderlyingGenerate(args, slots);
+          return normalGenerate(args, slots);
         },
       });
 
-      wrappedGenerate = function(...args) {
-        return stationery.template().slots({
-          _cfArg1: args[0] ?? null,
-          _cfArg2: args[1] ?? null,
-        });
-      };
-    } else {
-      wrappedGenerate = function(...args) {
-        return callUnderlyingGenerate(args);
-      };
-    }
-
-    wrappedGenerate.fulfill = function() {
-      throw new Error(`All dependencies already fulfilled (${generate.name})`);
-    };
-
-    annotateFunction(wrappedGenerate, {name: generate, trait: 'fulfilled'});
-    wrappedGenerate.fulfilled = true;
-  }
-
-  wrappedGenerate[contentFunction.identifyingSymbol] = true;
-
-  if (hasSprawlFunction) {
-    wrappedGenerate.sprawl = optionalDecorateTime(`sprawl`, sprawl);
-  }
-
-  if (hasQueryFunction) {
-    wrappedGenerate.query = optionalDecorateTime(`query`, query);
-  }
-
-  if (hasRelationsFunction) {
-    wrappedGenerate.relations = optionalDecorateTime(`relations`, relations);
-  }
-
-  if (hasDataFunction) {
-    wrappedGenerate.data = optionalDecorateTime(`data`, data);
-  }
-
-  wrappedGenerate.fulfill ??= function fulfill(dependencies) {
-    // To avoid unneeded destructuring, `fullfillDependencies` is a mutating
-    // function. But `fulfill` itself isn't meant to mutate! We create a copy
-    // of these variables, so their original values are kept for additional
-    // calls to this same `fulfill`.
-    const newlyMissingContentDependencyKeys = new Set(missingContentDependencyKeys);
-    const newlyMissingExtraDependencyKeys = new Set(missingExtraDependencyKeys);
-    const newlyInvalidatingDependencyKeys = new Set(invalidatingDependencyKeys);
-    const newlyFulfilledDependencyKeys = new Set(fulfilledDependencyKeys);
-    const newlyFulfilledDependencies = {...fulfilledDependencies};
-
-    try {
-      fulfillDependencies(dependencies, {
-        missingContentDependencyKeys: newlyMissingContentDependencyKeys,
-        missingExtraDependencyKeys: newlyMissingExtraDependencyKeys,
-        invalidatingDependencyKeys: newlyInvalidatingDependencyKeys,
-        fulfilledDependencyKeys: newlyFulfilledDependencyKeys,
-        fulfilledDependencies: newlyFulfilledDependencies,
+      return stationery.template().slots({
+        _cfArg1: args[0] ?? null,
+        _cfArg2: args[1] ?? null,
       });
-    } catch (error) {
-      error.message += ` (${generate.name})`;
-      throw error;
-    }
+    };
+  } else {
+    const normalGenerate = generate;
+    generate = (...args) => normalGenerate(args);
+  }
 
-    return expectDependencies({
-      slots,
-      sprawl,
-      query,
-      relations,
-      data,
-      generate,
-
-      expectedContentDependencyKeys,
-      expectedExtraDependencyKeys,
-      missingContentDependencyKeys: newlyMissingContentDependencyKeys,
-      missingExtraDependencyKeys: newlyMissingExtraDependencyKeys,
-      invalidatingDependencyKeys: newlyInvalidatingDependencyKeys,
-      fulfilledDependencyKeys: newlyFulfilledDependencyKeys,
-      fulfilledDependencies: newlyFulfilledDependencies,
-    });
-
+  generate.fulfill = function() {
+    throw new Error(`not part of the flow`);
   };
 
-  Object.assign(wrappedGenerate, {
-    contentDependencies: expectedContentDependencyKeys,
-    extraDependencies: expectedExtraDependencyKeys,
+  Object.defineProperty(generate, 'fulfilled', {
+    get() {
+      throw new Error(`unknowable`);
+    }
   });
 
-  return wrappedGenerate;
-}
+  generate[contentFunction.identifyingSymbol] = true;
 
-export function fulfillDependencies(dependencies, {
-  missingContentDependencyKeys,
-  missingExtraDependencyKeys,
-  invalidatingDependencyKeys,
-  fulfilledDependencyKeys,
-  fulfilledDependencies,
-}) {
-  // This is a mutating function. Be aware: it WILL mutate the provided sets
-  // and objects EVEN IF there are errors. This function doesn't exit early,
-  // so all provided dependencies which don't have an associated error should
-  // be treated as fulfilled (this is reflected via fulfilledDependencyKeys).
-
-  const errors = [];
-
-  for (let [key, value] of Object.entries(dependencies)) {
-    if (fulfilledDependencyKeys.has(key)) {
-      errors.push(new Error(`Dependency ${key} is already fulfilled`));
-      continue;
+  for (const key of ['sprawl', 'query', 'relations', 'data']) {
+    if (spec[key]) {
+      generate[key] = optionalDecorateTime(`sprawl`, spec[key]);
     }
-
-    const isContentKey = missingContentDependencyKeys.has(key);
-    const isExtraKey = missingExtraDependencyKeys.has(key);
-
-    if (!isContentKey && !isExtraKey) {
-      errors.push(new Error(`Dependency ${key} is not expected`));
-      continue;
-    }
-
-    if (value === undefined) {
-      errors.push(new Error(`Dependency ${key} was provided undefined`));
-      continue;
-    }
-
-    const isContentFunction =
-      !!value?.[contentFunction.identifyingSymbol];
-
-    const isFulfilledContentFunction =
-      isContentFunction && value.fulfilled;
-
-    if (isContentKey) {
-      if (!isContentFunction) {
-        errors.push(new Error(`Content dependency ${key} is not a content function (got ${value})`));
-        continue;
-      }
-
-      if (!isFulfilledContentFunction) {
-        invalidatingDependencyKeys.add(key);
-      }
-
-      missingContentDependencyKeys.delete(key);
-    } else if (isExtraKey) {
-      if (isContentFunction) {
-        errors.push(new Error(`Extra dependency ${key} is a content function`));
-        continue;
-      }
-
-      missingExtraDependencyKeys.delete(key);
-    }
-
-    fulfilledDependencyKeys.add(key);
-    fulfilledDependencies[key] = value;
   }
 
-  if (!empty(errors)) {
-    throw new AggregateError(errors, `Errors fulfilling dependencies`);
-  }
+  generate.bindExtraDependencies = (extraDependencies) =>
+    expectDependencies(spec, {
+      boundExtraDependencies: extraDependencies,
+    });
+
+  return generate;
 }
 
 export function getArgsForRelationsAndData(contentFunction, wikiData, ...args) {
@@ -393,8 +184,6 @@ export function getRelationsTree(dependencies, contentFunctionName, wikiData, ..
     };
 
     if (contentFunction.relations) {
-      const listedDependencies = new Set(contentFunction.contentDependencies);
-
       // Note: "slots" here is a completely separate concept from HTML template
       // slots, which are handled completely within the content function. Here,
       // relation slots are just references to a position within the relations
@@ -408,10 +197,6 @@ export function getRelationsTree(dependencies, contentFunctionName, wikiData, ..
       })();
 
       const relationFunction = (name, ...args) => {
-        if (!listedDependencies.has(name)) {
-          throw new Error(`Called relation('${name}') but ${contentFunctionName} doesn't list that dependency`);
-        }
-
         const relationSymbol = Symbol(relationSymbolMessage(name));
         const traceError = new Error();
 
@@ -502,22 +287,6 @@ export function fillRelationsLayoutFromSlotResults(relationIdentifier, results, 
   return recursive(layout);
 }
 
-export function getNeededContentDependencyNames(contentDependencies, name) {
-  const set = new Set();
-
-  function recursive(name) {
-    const contentFunction = contentDependencies[name];
-    for (const dependencyName of contentFunction?.contentDependencies ?? []) {
-      recursive(dependencyName);
-    }
-    set.add(name);
-  }
-
-  recursive(name);
-
-  return set;
-}
-
 export const decorateErrorWithRelationStack = (fn, traceStack) =>
   decorateError(fn, caughtError => {
     let cause = caughtError;
@@ -579,65 +348,10 @@ export function quickEvaluate({
   const flatTreeInfo = flattenRelationsTree(treeInfo);
   const {root, relationIdentifier, flatRelationSlots} = flatTreeInfo;
 
-  const neededContentDependencyNames =
-    getNeededContentDependencyNames(allContentDependencies, name);
-
-  // Content functions aren't recursive, so by following the set above
-  // sequentually, we will always provide fulfilled content functions as the
-  // dependencies for later content functions.
-  const fulfilledContentDependencies = {};
-  for (const name of neededContentDependencyNames) {
-    const unfulfilledContentFunction = allContentDependencies[name];
-    if (!unfulfilledContentFunction) continue;
-
-    const {contentDependencies, extraDependencies} = unfulfilledContentFunction;
-
-    if (empty(contentDependencies) && empty(extraDependencies)) {
-      fulfilledContentDependencies[name] = unfulfilledContentFunction;
-      continue;
-    }
-
-    const fulfillments = {};
-
-    for (const dependencyName of contentDependencies ?? []) {
-      if (dependencyName in fulfilledContentDependencies) {
-        fulfillments[dependencyName] =
-          fulfilledContentDependencies[dependencyName];
-      }
-    }
-
-    for (const dependencyName of extraDependencies ?? []) {
-      if (dependencyName in allExtraDependencies) {
-        fulfillments[dependencyName] =
-          allExtraDependencies[dependencyName];
-      }
-    }
-
-    fulfilledContentDependencies[name] =
-      unfulfilledContentFunction.fulfill(fulfillments);
-  }
-
-  // There might still be unfulfilled content functions if dependencies weren't
-  // provided as part of allContentDependencies or allExtraDependencies.
-  // Catch and report these early, together in an aggregate error.
-  const unfulfilledErrors = [];
-  const unfulfilledNames = [];
-  for (const name of neededContentDependencyNames) {
-    const contentFunction = fulfilledContentDependencies[name];
-    if (!contentFunction) continue;
-    if (!contentFunction.fulfilled) {
-      try {
-        contentFunction();
-      } catch (error) {
-        error.message = `(${name}) ${error.message}`;
-        unfulfilledErrors.push(error);
-        unfulfilledNames.push(name);
-      }
-    }
-  }
-
-  if (!empty(unfulfilledErrors)) {
-    throw new AggregateError(unfulfilledErrors, `Content functions unfulfilled (${unfulfilledNames.join(', ')})`);
+  allContentDependencies = {...allContentDependencies};
+  for (const [name, contentFunction] of Object.entries(allContentDependencies)) {
+    allContentDependencies[name] =
+      contentFunction.bindExtraDependencies(allExtraDependencies);
   }
 
   const slotResults = {};
@@ -646,10 +360,9 @@ export function quickEvaluate({
     const callDecorated = (fn, ...args) =>
       decorateErrorWithRelationStack(fn, traceStack)(...args);
 
-    const contentFunction = fulfilledContentDependencies[name];
-
+    const contentFunction = allContentDependencies[name];
     if (!contentFunction) {
-      throw new Error(`Content function ${name} unfulfilled or not listed`);
+      throw new Error(`Content function ${name} not listed`);
     }
 
     const generateArgs = [];

--- a/src/content/dependencies/generateAbsoluteDatetimestamp.js
+++ b/src/content/dependencies/generateAbsoluteDatetimestamp.js
@@ -1,11 +1,4 @@
 export default {
-  contentDependencies: [
-    'generateDatetimestampTemplate',
-    'generateTooltip',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   data: (date) =>
     ({date}),
 

--- a/src/content/dependencies/generateAdditionalFilesList.js
+++ b/src/content/dependencies/generateAdditionalFilesList.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['generateAdditionalFilesListChunk'],
-  extraDependencies: ['html'],
-
   relations: (relation, additionalFiles) => ({
     chunks:
       additionalFiles

--- a/src/content/dependencies/generateAdditionalFilesListChunk.js
+++ b/src/content/dependencies/generateAdditionalFilesListChunk.js
@@ -1,9 +1,6 @@
 import {stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: ['linkAdditionalFile', 'transformContent'],
-  extraDependencies: ['getSizeOfMediaFile', 'html', 'language', 'urls'],
-
   relations: (relation, file) => ({
     description:
       relation('transformContent', file.description),

--- a/src/content/dependencies/generateAdditionalNamesBox.js
+++ b/src/content/dependencies/generateAdditionalNamesBox.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['generateAdditionalNamesBoxItem'],
-  extraDependencies: ['html', 'language'],
-
   relations: (relation, additionalNames) => ({
     items:
       additionalNames

--- a/src/content/dependencies/generateAdditionalNamesBoxItem.js
+++ b/src/content/dependencies/generateAdditionalNamesBoxItem.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['transformContent'],
-  extraDependencies: ['html', 'language'],
-
   relations: (relation, entry) => ({
     nameContent:
       relation('transformContent', entry.name),

--- a/src/content/dependencies/generateAlbumArtInfoBox.js
+++ b/src/content/dependencies/generateAlbumArtInfoBox.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['generateReleaseInfoContributionsLine'],
-  extraDependencies: ['html', 'language'],
-
   relations: (relation, album) => ({
     wallpaperArtistContributionsLine:
       (album.wallpaperArtwork

--- a/src/content/dependencies/generateAlbumArtworkColumn.js
+++ b/src/content/dependencies/generateAlbumArtworkColumn.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['generateAlbumArtInfoBox', 'generateCoverArtwork'],
-  extraDependencies: ['html'],
-
   query: (album) => ({
     nonAttachingArtworkIndex:
       (album.hasCoverArt

--- a/src/content/dependencies/generateAlbumBanner.js
+++ b/src/content/dependencies/generateAlbumBanner.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['generateBanner'],
-  extraDependencies: ['html', 'language'],
-
   relations(relation, album) {
     if (!album.hasBannerArt) {
       return {};

--- a/src/content/dependencies/generateAlbumCommentaryPage.js
+++ b/src/content/dependencies/generateAlbumCommentaryPage.js
@@ -1,22 +1,6 @@
 import {empty, stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateAlbumCommentarySidebar',
-    'generateAlbumNavAccent',
-    'generateAlbumSecondaryNav',
-    'generateAlbumStyleTags',
-    'generateCommentaryEntry',
-    'generateContentHeading',
-    'generateCoverArtwork',
-    'generatePageLayout',
-    'linkAlbum',
-    'linkExternal',
-    'linkTrack',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   query(album) {
     const query = {};
 

--- a/src/content/dependencies/generateAlbumCommentarySidebar.js
+++ b/src/content/dependencies/generateAlbumCommentarySidebar.js
@@ -1,15 +1,6 @@
 import {empty} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateAlbumSidebarTrackSection',
-    'generatePageSidebar',
-    'generatePageSidebarBox',
-    'linkAlbum',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   relations: (relation, album) => ({
     sidebar:
       relation('generatePageSidebar'),

--- a/src/content/dependencies/generateAlbumGalleryAlbumGrid.js
+++ b/src/content/dependencies/generateAlbumGalleryAlbumGrid.js
@@ -1,14 +1,6 @@
 import {stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateCoverGrid',
-    'image',
-    'linkAlbum',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   query: (album) => ({
     artworks:
       (album.hasCoverArt

--- a/src/content/dependencies/generateAlbumGalleryCoverArtistsLine.js
+++ b/src/content/dependencies/generateAlbumGalleryCoverArtistsLine.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['linkArtistGallery'],
-  extraDependencies: ['html', 'language'],
-
   relations(relation, coverArtists) {
     return {
       coverArtistLinks:

--- a/src/content/dependencies/generateAlbumGalleryNoTrackArtworksLine.js
+++ b/src/content/dependencies/generateAlbumGalleryNoTrackArtworksLine.js
@@ -1,6 +1,4 @@
 export default {
-  extraDependencies: ['html', 'language'],
-
   generate: ({html, language}) =>
     html.tag('p', {class: 'quick-info'},
       language.$('albumGalleryPage.noTrackArtworksLine')),

--- a/src/content/dependencies/generateAlbumGalleryPage.js
+++ b/src/content/dependencies/generateAlbumGalleryPage.js
@@ -2,21 +2,6 @@ import {stitchArrays, unique} from '#sugar';
 import {getKebabCase} from '#wiki-data';
 
 export default {
-  contentDependencies: [
-    'generateAlbumGalleryAlbumGrid',
-    'generateAlbumGalleryNoTrackArtworksLine',
-    'generateAlbumGalleryStatsLine',
-    'generateAlbumGalleryTrackGrid',
-    'generateAlbumNavAccent',
-    'generateAlbumSecondaryNav',
-    'generateAlbumStyleTags',
-    'generateIntrapageDotSwitcher',
-    'generatePageLayout',
-    'linkAlbum',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   query(album) {
     const query = {};
 

--- a/src/content/dependencies/generateAlbumGalleryStatsLine.js
+++ b/src/content/dependencies/generateAlbumGalleryStatsLine.js
@@ -1,8 +1,6 @@
 import {getTotalDuration} from '#wiki-data';
 
 export default {
-  extraDependencies: ['html', 'language'],
-
   data: (album) => ({
     date:
       album.date,

--- a/src/content/dependencies/generateAlbumGalleryTrackGrid.js
+++ b/src/content/dependencies/generateAlbumGalleryTrackGrid.js
@@ -1,16 +1,6 @@
 import {compareArrays, stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateAlbumGalleryCoverArtistsLine',
-    'generateCoverGrid',
-    'image',
-    'linkAlbum',
-    'linkTrack',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   query(album, label) {
     const query = {};
 

--- a/src/content/dependencies/generateAlbumInfoPage.js
+++ b/src/content/dependencies/generateAlbumInfoPage.js
@@ -1,30 +1,6 @@
 import {empty} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateAdditionalFilesList',
-    'generateAdditionalNamesBox',
-    'generateAlbumArtworkColumn',
-    'generateAlbumBanner',
-    'generateAlbumNavAccent',
-    'generateAlbumReleaseInfo',
-    'generateAlbumSecondaryNav',
-    'generateAlbumSidebar',
-    'generateAlbumSocialEmbed',
-    'generateAlbumStyleTags',
-    'generateAlbumTrackList',
-    'generateCollapsedContentEntrySection',
-    'generateCommentaryContentHeading',
-    'generateCommentaryEntry',
-    'generateContentHeading',
-    'generatePageLayout',
-    'generateReadCommentaryLine',
-    'linkAlbumCommentary',
-    'linkAlbumGallery',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   relations: (relation, album) => ({
     layout:
       relation('generatePageLayout'),

--- a/src/content/dependencies/generateAlbumNavAccent.js
+++ b/src/content/dependencies/generateAlbumNavAccent.js
@@ -1,17 +1,6 @@
 import {atOffset, empty} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateInterpageDotSwitcher',
-    'generateNextLink',
-    'generatePreviousLink',
-    'linkTrack',
-    'linkAlbumCommentary',
-    'linkAlbumGallery',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   query(album, track) {
     const query = {};
 

--- a/src/content/dependencies/generateAlbumReferencedArtworksPage.js
+++ b/src/content/dependencies/generateAlbumReferencedArtworksPage.js
@@ -1,13 +1,4 @@
 export default {
-  contentDependencies: [
-    'generateAlbumStyleTags',
-    'generateBackToAlbumLink',
-    'generateReferencedArtworksPage',
-    'linkAlbum',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   relations: (relation, album) => ({
     page:
       relation('generateReferencedArtworksPage', album.coverArtworks[0]),

--- a/src/content/dependencies/generateAlbumReferencingArtworksPage.js
+++ b/src/content/dependencies/generateAlbumReferencingArtworksPage.js
@@ -1,13 +1,4 @@
 export default {
-  contentDependencies: [
-    'generateAlbumStyleTags',
-    'generateBackToAlbumLink',
-    'generateReferencingArtworksPage',
-    'linkAlbum',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   relations: (relation, album) => ({
     page:
       relation('generateReferencingArtworksPage', album.coverArtworks[0]),

--- a/src/content/dependencies/generateAlbumReleaseInfo.js
+++ b/src/content/dependencies/generateAlbumReleaseInfo.js
@@ -1,13 +1,6 @@
 import {accumulateSum, empty} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateReleaseInfoContributionsLine',
-    'generateReleaseInfoListenLine',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   relations(relation, album) {
     const relations = {};
 

--- a/src/content/dependencies/generateAlbumSecondaryNav.js
+++ b/src/content/dependencies/generateAlbumSecondaryNav.js
@@ -1,15 +1,6 @@
 import {stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateAlbumSecondaryNavGroupPart',
-    'generateAlbumSecondaryNavSeriesPart',
-    'generateDotSwitcherTemplate',
-    'generateSecondaryNav',
-  ],
-
-  extraDependencies: ['html', 'wikiData'],
-
   sprawl: ({groupData}) => ({
     // TODO: Series aren't their own things, so we access them weirdly.
     seriesData:

--- a/src/content/dependencies/generateAlbumSecondaryNavGroupPart.js
+++ b/src/content/dependencies/generateAlbumSecondaryNavGroupPart.js
@@ -2,15 +2,6 @@ import {sortChronologically} from '#sort';
 import {atOffset} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateColorStyleAttribute',
-    'generateSecondaryNavParentSiblingsPart',
-    'linkAlbumDynamically',
-    'linkGroup',
-  ],
-
-  extraDependencies: ['html'],
-
   query(group, album) {
     const query = {};
 

--- a/src/content/dependencies/generateAlbumSecondaryNavSeriesPart.js
+++ b/src/content/dependencies/generateAlbumSecondaryNavSeriesPart.js
@@ -1,15 +1,6 @@
 import {atOffset} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateColorStyleAttribute',
-    'generateSecondaryNavParentSiblingsPart',
-    'linkAlbumDynamically',
-    'linkGroup',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   query(series, album) {
     const query = {};
 

--- a/src/content/dependencies/generateAlbumSidebar.js
+++ b/src/content/dependencies/generateAlbumSidebar.js
@@ -2,17 +2,6 @@ import {sortAlbumsTracksChronologically} from '#sort';
 import {stitchArrays, transposeArrays} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateAlbumSidebarGroupBox',
-    'generateAlbumSidebarSeriesBox',
-    'generateAlbumSidebarTrackListBox',
-    'generatePageSidebar',
-    'generatePageSidebarConjoinedBox',
-    'generateTrackReleaseBox',
-  ],
-
-  extraDependencies: ['html', 'wikiData'],
-
   sprawl: ({groupData}) => ({
     // TODO: Series aren't their own things, so we access them weirdly.
     seriesData:

--- a/src/content/dependencies/generateAlbumSidebarGroupBox.js
+++ b/src/content/dependencies/generateAlbumSidebarGroupBox.js
@@ -2,16 +2,6 @@ import {sortChronologically} from '#sort';
 import {atOffset} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generatePageSidebarBox',
-    'linkAlbum',
-    'linkExternal',
-    'linkGroup',
-    'transformContent',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   query(album, group) {
     const query = {};
 

--- a/src/content/dependencies/generateAlbumSidebarSeriesBox.js
+++ b/src/content/dependencies/generateAlbumSidebarSeriesBox.js
@@ -1,15 +1,6 @@
 import {atOffset} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generatePageSidebarBox',
-    'linkAlbum',
-    'linkGroup',
-    'transformContent',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   query(album, series) {
     const query = {};
 

--- a/src/content/dependencies/generateAlbumSidebarTrackListBox.js
+++ b/src/content/dependencies/generateAlbumSidebarTrackListBox.js
@@ -1,12 +1,4 @@
 export default {
-  contentDependencies: [
-    'generateAlbumSidebarTrackSection',
-    'generatePageSidebarBox',
-    'linkAlbum',
-  ],
-
-  extraDependencies: ['html'],
-
   relations: (relation, album, track) => ({
     box:
       relation('generatePageSidebarBox'),

--- a/src/content/dependencies/generateAlbumSidebarTrackSection.js
+++ b/src/content/dependencies/generateAlbumSidebarTrackSection.js
@@ -1,9 +1,6 @@
 import {empty, stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: ['linkTrack'],
-  extraDependencies: ['getColors', 'html', 'language'],
-
   relations(relation, album, track, trackSection) {
     const relations = {};
 

--- a/src/content/dependencies/generateAlbumSocialEmbed.js
+++ b/src/content/dependencies/generateAlbumSocialEmbed.js
@@ -1,13 +1,6 @@
 import {empty} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateSocialEmbed',
-    'generateAlbumSocialEmbedDescription',
-  ],
-
-  extraDependencies: ['absoluteTo', 'language'],
-
   relations(relation, album) {
     return {
       socialEmbed:

--- a/src/content/dependencies/generateAlbumSocialEmbedDescription.js
+++ b/src/content/dependencies/generateAlbumSocialEmbedDescription.js
@@ -1,8 +1,6 @@
 import {accumulateSum} from '#sugar';
 
 export default {
-  extraDependencies: ['language'],
-
   data: (album) => ({
     duration:
       accumulateSum(album.tracks, track => track.duration),

--- a/src/content/dependencies/generateAlbumStyleTags.js
+++ b/src/content/dependencies/generateAlbumStyleTags.js
@@ -1,9 +1,6 @@
 import {empty} from '#sugar';
 
 export default {
-  contentDependencies: ['generateAlbumWallpaperStyleTag', 'generateStyleTag'],
-  extraDependencies: ['html'],
-
   relations: (relation, album, _track) => ({
     styleTag:
       relation('generateStyleTag'),

--- a/src/content/dependencies/generateAlbumTrackList.js
+++ b/src/content/dependencies/generateAlbumTrackList.js
@@ -35,14 +35,6 @@ function getDisplayMode(album) {
 }
 
 export default {
-  contentDependencies: [
-    'generateAlbumTrackListItem',
-    'generateContentHeading',
-    'transformContent',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   query(album) {
     return {
       displayMode: getDisplayMode(album),

--- a/src/content/dependencies/generateAlbumTrackListItem.js
+++ b/src/content/dependencies/generateAlbumTrackListItem.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['generateTrackListItem'],
-  extraDependencies: ['html'],
-
   query: (track, album) => ({
     trackHasDuration:
       !!track.duration,

--- a/src/content/dependencies/generateAlbumWallpaperStyleTag.js
+++ b/src/content/dependencies/generateAlbumWallpaperStyleTag.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['generateWallpaperStyleTag'],
-  extraDependencies: ['html'],
-
   relations: (relation, album) => ({
     wallpaperStyleTag:
       (album.hasWallpaperArt

--- a/src/content/dependencies/generateArtTagAncestorDescendantMapList.js
+++ b/src/content/dependencies/generateArtTagAncestorDescendantMapList.js
@@ -6,9 +6,6 @@ import {
 } from '#sugar';
 
 export default {
-  contentDependencies: ['linkArtTagDynamically'],
-  extraDependencies: ['html', 'language'],
-
   // Recursion ain't too pretty!
 
   query(ancestorArtTag, targetArtTag) {

--- a/src/content/dependencies/generateArtTagGalleryPage.js
+++ b/src/content/dependencies/generateArtTagGalleryPage.js
@@ -2,22 +2,6 @@ import {sortArtworksChronologically} from '#sort';
 import {empty, stitchArrays, unique} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateAdditionalNamesBox',
-    'generateArtTagGalleryPageFeaturedLine',
-    'generateArtTagGalleryPageShowingLine',
-    'generateArtTagNavLinks',
-    'generateCoverGrid',
-    'generatePageLayout',
-    'generateQuickDescription',
-    'image',
-    'linkAnythingMan',
-    'linkArtTagGallery',
-    'linkExternal',
-  ],
-
-  extraDependencies: ['html', 'language', 'wikiData'],
-
   sprawl({wikiInfo}) {
     return {
       enableListings: wikiInfo.enableListings,

--- a/src/content/dependencies/generateArtTagGalleryPageFeaturedLine.js
+++ b/src/content/dependencies/generateArtTagGalleryPageFeaturedLine.js
@@ -1,6 +1,4 @@
 export default {
-  extraDependencies: ['html', 'language'],
-
   slots: {
     showing: {
       validate: v => v.is('all', 'direct', 'indirect'),

--- a/src/content/dependencies/generateArtTagGalleryPageShowingLine.js
+++ b/src/content/dependencies/generateArtTagGalleryPageShowingLine.js
@@ -1,6 +1,4 @@
 export default {
-  extraDependencies: ['html', 'language'],
-
   slots: {
     showing: {
       validate: v => v.is('all', 'direct', 'indirect'),

--- a/src/content/dependencies/generateArtTagInfoPage.js
+++ b/src/content/dependencies/generateArtTagInfoPage.js
@@ -1,20 +1,6 @@
 import {empty, stitchArrays, unique} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateAdditionalNamesBox',
-    'generateArtTagNavLinks',
-    'generateArtTagSidebar',
-    'generateContentHeading',
-    'generatePageLayout',
-    'linkArtTagGallery',
-    'linkArtTagInfo',
-    'linkExternal',
-    'transformContent',
-  ],
-
-  extraDependencies: ['html', 'language', 'wikiData'],
-
   sprawl: ({wikiInfo}) => ({
     enableListings: wikiInfo.enableListings,
   }),

--- a/src/content/dependencies/generateArtTagNavLinks.js
+++ b/src/content/dependencies/generateArtTagNavLinks.js
@@ -1,12 +1,4 @@
 export default {
-  contentDependencies: [
-    'generateInterpageDotSwitcher',
-    'linkArtTagInfo',
-    'linkArtTagGallery',
-  ],
-
-  extraDependencies: ['html', 'language', 'wikiData'],
-
   sprawl: ({wikiInfo}) =>
     ({enableListings: wikiInfo.enableListings}),
 

--- a/src/content/dependencies/generateArtTagSidebar.js
+++ b/src/content/dependencies/generateArtTagSidebar.js
@@ -1,15 +1,6 @@
 import {collectTreeLeaves, empty, stitchArrays, unique} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generatePageSidebar',
-    'generatePageSidebarBox',
-    'generateArtTagAncestorDescendantMapList',
-    'linkArtTagDynamically',
-  ],
-
-  extraDependencies: ['html', 'language', 'wikiData'],
-
   sprawl: ({artTagData}) =>
     ({artTagData}),
 

--- a/src/content/dependencies/generateArtistArtworkColumn.js
+++ b/src/content/dependencies/generateArtistArtworkColumn.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['generateCoverArtwork'],
-
   relations: (relation, artist) => ({
     coverArtwork:
       (artist.hasAvatar

--- a/src/content/dependencies/generateArtistCredit.js
+++ b/src/content/dependencies/generateArtistCredit.js
@@ -1,14 +1,6 @@
 import {compareArrays, empty, stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateArtistCreditWikiEditsPart',
-    'linkContribution',
-    'transformContent',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   query: (creditContributions, contextContributions, _formatText) => {
     const query = {};
 

--- a/src/content/dependencies/generateArtistCreditWikiEditsPart.js
+++ b/src/content/dependencies/generateArtistCreditWikiEditsPart.js
@@ -1,12 +1,4 @@
 export default {
-  contentDependencies: [
-    'generateTextWithTooltip',
-    'generateTooltip',
-    'linkContribution',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   relations: (relation, contributions) => ({
     textWithTooltip:
       relation('generateTextWithTooltip'),

--- a/src/content/dependencies/generateArtistGalleryPage.js
+++ b/src/content/dependencies/generateArtistGalleryPage.js
@@ -1,16 +1,6 @@
 import {sortArtworksChronologically} from '#sort';
 
 export default {
-  contentDependencies: [
-    'generateArtistNavLinks',
-    'generateCoverGrid',
-    'generatePageLayout',
-    'image',
-    'linkAnythingMan',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   query: (artist) => ({
     artworks:
       sortArtworksChronologically(

--- a/src/content/dependencies/generateArtistGroupContributionsInfo.js
+++ b/src/content/dependencies/generateArtistGroupContributionsInfo.js
@@ -1,9 +1,6 @@
 import {accumulateSum, empty, stitchArrays, withEntries} from '#sugar';
 
 export default {
-  contentDependencies: ['linkGroup'],
-  extraDependencies: ['html', 'language', 'wikiData'],
-
   sprawl: ({groupCategoryData}) => ({
     groupOrder:
       groupCategoryData.flatMap(category => category.groups),

--- a/src/content/dependencies/generateArtistInfoPage.js
+++ b/src/content/dependencies/generateArtistInfoPage.js
@@ -1,24 +1,6 @@
 import {empty, stitchArrays, unique} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateArtistArtworkColumn',
-    'generateArtistGroupContributionsInfo',
-    'generateArtistInfoPageArtworksChunkedList',
-    'generateArtistInfoPageCommentaryChunkedList',
-    'generateArtistInfoPageFlashesChunkedList',
-    'generateArtistInfoPageTracksChunkedList',
-    'generateArtistNavLinks',
-    'generateContentHeading',
-    'generatePageLayout',
-    'linkArtistGallery',
-    'linkExternal',
-    'linkGroup',
-    'transformContent',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   query: (artist) => ({
     trackContributions: [
       ...artist.trackArtistContributions,

--- a/src/content/dependencies/generateArtistInfoPageArtworksChunk.js
+++ b/src/content/dependencies/generateArtistInfoPageArtworksChunk.js
@@ -1,12 +1,4 @@
 export default {
-  contentDependencies: [
-    'generateArtistInfoPageChunk',
-    'generateArtistInfoPageArtworksChunkItem',
-    'linkAlbum',
-  ],
-
-  extraDependencies: ['html'],
-
   relations: (relation, album, contribs) => ({
     template:
       relation('generateArtistInfoPageChunk'),

--- a/src/content/dependencies/generateArtistInfoPageArtworksChunkItem.js
+++ b/src/content/dependencies/generateArtistInfoPageArtworksChunkItem.js
@@ -1,15 +1,6 @@
 import {empty} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateArtistInfoPageChunkItem',
-    'generateArtistInfoPageOtherArtistLinks',
-    'linkTrack',
-    'transformContent',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   query: (contrib) => ({
     kind:
       (contrib.thingProperty === 'bannerArtistContribs' ||

--- a/src/content/dependencies/generateArtistInfoPageArtworksChunkedList.js
+++ b/src/content/dependencies/generateArtistInfoPageArtworksChunkedList.js
@@ -3,11 +3,6 @@ import {sortAlbumsTracksChronologically, sortContributionsChronologically}
 import {chunkByConditions, stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateArtistInfoPageChunkedList',
-    'generateArtistInfoPageArtworksChunk',
-  ],
-
   query(artist, filterEditsForWiki) {
     const query = {};
 

--- a/src/content/dependencies/generateArtistInfoPageChunk.js
+++ b/src/content/dependencies/generateArtistInfoPageChunk.js
@@ -1,8 +1,6 @@
 import {empty} from '#sugar';
 
 export default {
-  extraDependencies: ['html', 'language'],
-
   slots: {
     mode: {
       validate: v => v.is('flash', 'album'),

--- a/src/content/dependencies/generateArtistInfoPageChunkItem.js
+++ b/src/content/dependencies/generateArtistInfoPageChunkItem.js
@@ -1,9 +1,6 @@
 import {empty} from '#sugar';
 
 export default {
-  contentDependencies: ['generateTextWithTooltip'],
-  extraDependencies: ['html', 'language'],
-
   relations: (relation) => ({
     textWithTooltip:
       relation('generateTextWithTooltip'),

--- a/src/content/dependencies/generateArtistInfoPageChunkedList.js
+++ b/src/content/dependencies/generateArtistInfoPageChunkedList.js
@@ -1,6 +1,4 @@
 export default {
-  extraDependencies: ['html'],
-
   slots: {
     groupInfo: {
       type: 'html',

--- a/src/content/dependencies/generateArtistInfoPageCommentaryChunkedList.js
+++ b/src/content/dependencies/generateArtistInfoPageCommentaryChunkedList.js
@@ -7,18 +7,6 @@ import {
 } from '#sort';
 
 export default {
-  contentDependencies: [
-    'generateArtistInfoPageChunk',
-    'generateArtistInfoPageChunkItem',
-    'linkAlbum',
-    'linkFlash',
-    'linkFlashAct',
-    'linkTrack',
-    'transformContent',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   query(artist, filterWikiEditorCommentary) {
     const processEntry = ({
       thing,

--- a/src/content/dependencies/generateArtistInfoPageFirstReleaseTooltip.js
+++ b/src/content/dependencies/generateArtistInfoPageFirstReleaseTooltip.js
@@ -2,14 +2,6 @@ import {sortAlbumsTracksChronologically} from '#sort';
 import {stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateColorStyleAttribute',
-    'generateTooltip',
-    'linkOtherReleaseOnArtistInfoPage',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   query: (track) => ({
     rereleases:
       sortAlbumsTracksChronologically(track.allReleases).slice(1),

--- a/src/content/dependencies/generateArtistInfoPageFlashesChunk.js
+++ b/src/content/dependencies/generateArtistInfoPageFlashesChunk.js
@@ -1,10 +1,4 @@
 export default {
-  contentDependencies: [
-    'generateArtistInfoPageChunk',
-    'generateArtistInfoPageFlashesChunkItem',
-    'linkFlashAct',
-  ],
-
   relations: (relation, flashAct, contribs) => ({
     template:
       relation('generateArtistInfoPageChunk'),

--- a/src/content/dependencies/generateArtistInfoPageFlashesChunkItem.js
+++ b/src/content/dependencies/generateArtistInfoPageFlashesChunkItem.js
@@ -1,8 +1,4 @@
 export default {
-  contentDependencies: ['generateArtistInfoPageChunkItem', 'linkFlash'],
-
-  extraDependencies: ['language'],
-
   relations: (relation, contrib) => ({
     // Flashes and games can list multiple contributors as collaborative
     // credits, but we don't display these on the artist page, since they

--- a/src/content/dependencies/generateArtistInfoPageFlashesChunkedList.js
+++ b/src/content/dependencies/generateArtistInfoPageFlashesChunkedList.js
@@ -3,13 +3,6 @@ import {sortContributionsChronologically, sortFlashesChronologically}
 import {chunkByConditions, stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateArtistInfoPageChunkedList',
-    'generateArtistInfoPageFlashesChunk',
-  ],
-
-  extraDependencies: ['wikiData'],
-
   sprawl: ({wikiInfo}) => ({
     enableFlashesAndGames:
       wikiInfo.enableFlashesAndGames,

--- a/src/content/dependencies/generateArtistInfoPageOtherArtistLinks.js
+++ b/src/content/dependencies/generateArtistInfoPageOtherArtistLinks.js
@@ -1,8 +1,6 @@
 import {unique} from '#sugar';
 
 export default {
-  contentDependencies: ['linkArtist'],
-
   query(contribs) {
     const associatedContributionsByOtherArtists =
       contribs

--- a/src/content/dependencies/generateArtistInfoPageRereleaseTooltip.js
+++ b/src/content/dependencies/generateArtistInfoPageRereleaseTooltip.js
@@ -1,14 +1,6 @@
 import {sortAlbumsTracksChronologically} from '#sort';
 
 export default {
-  contentDependencies: [
-    'generateColorStyleAttribute',
-    'generateTooltip',
-    'linkOtherReleaseOnArtistInfoPage'
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   query: (track) => ({
     firstRelease:
       sortAlbumsTracksChronologically(track.allReleases)[0],

--- a/src/content/dependencies/generateArtistInfoPageTracksChunk.js
+++ b/src/content/dependencies/generateArtistInfoPageTracksChunk.js
@@ -2,12 +2,6 @@ import {unique} from '#sugar';
 import {getTotalDuration} from '#wiki-data';
 
 export default {
-  contentDependencies: [
-    'generateArtistInfoPageChunk',
-    'generateArtistInfoPageTracksChunkItem',
-    'linkAlbum',
-  ],
-
   relations: (relation, artist, album, trackContribLists) => ({
     template:
       relation('generateArtistInfoPageChunk'),

--- a/src/content/dependencies/generateArtistInfoPageTracksChunkItem.js
+++ b/src/content/dependencies/generateArtistInfoPageTracksChunkItem.js
@@ -2,17 +2,7 @@ import {sortAlbumsTracksChronologically} from '#sort';
 import {empty} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateArtistInfoPageChunkItem',
-    'generateArtistInfoPageFirstReleaseTooltip',
-    'generateArtistInfoPageOtherArtistLinks',
-    'generateArtistInfoPageRereleaseTooltip',
-    'linkTrack',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
-  query (_artist, contribs) {
+  query(_artist, contribs) {
     const query = {};
 
     // TODO: Very mysterious what to do if the set of contributions is,

--- a/src/content/dependencies/generateArtistInfoPageTracksChunkedList.js
+++ b/src/content/dependencies/generateArtistInfoPageTracksChunkedList.js
@@ -4,11 +4,6 @@ import {stitchArrays} from '#sugar';
 import {chunkArtistTrackContributions} from '#wiki-data';
 
 export default {
-  contentDependencies: [
-    'generateArtistInfoPageChunkedList',
-    'generateArtistInfoPageTracksChunk',
-  ],
-
   query(artist) {
     const query = {};
 

--- a/src/content/dependencies/generateArtistNavLinks.js
+++ b/src/content/dependencies/generateArtistNavLinks.js
@@ -1,15 +1,6 @@
 import {empty} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateInterpageDotSwitcher',
-    'linkArtist',
-    'linkArtistGallery',
-    'linkArtistRollingWindow',
-  ],
-
-  extraDependencies: ['html', 'language', 'wikiData'],
-
   sprawl: ({wikiInfo}) => ({
     enableListings:
       wikiInfo.enableListings,

--- a/src/content/dependencies/generateArtistRollingWindowPage.js
+++ b/src/content/dependencies/generateArtistRollingWindowPage.js
@@ -11,16 +11,6 @@ import {
 } from '#sugar';
 
 export default {
-  contentDependencies: [
-    'image',
-    'generateArtistNavLinks',
-    'generateCoverGrid',
-    'generatePageLayout',
-    'linkAnythingMan',
-  ],
-
-  extraDependencies: ['html', 'language', 'wikiData'],
-
   sprawl: ({groupCategoryData}) => ({
     groupCategoryData,
   }),

--- a/src/content/dependencies/generateBackToAlbumLink.js
+++ b/src/content/dependencies/generateBackToAlbumLink.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['linkAlbum'],
-  extraDependencies: ['language'],
-
   relations: (relation, track) => ({
     trackLink:
       relation('linkAlbum', track),

--- a/src/content/dependencies/generateBackToTrackLink.js
+++ b/src/content/dependencies/generateBackToTrackLink.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['linkTrack'],
-  extraDependencies: ['language'],
-
   relations: (relation, track) => ({
     trackLink:
       relation('linkTrack', track),

--- a/src/content/dependencies/generateBanner.js
+++ b/src/content/dependencies/generateBanner.js
@@ -1,6 +1,4 @@
 export default {
-  extraDependencies: ['html', 'to'],
-
   slots: {
     path: {
       validate: v => v.validateArrayItems(v.isString),

--- a/src/content/dependencies/generateCollapsedContentEntrySection.js
+++ b/src/content/dependencies/generateCollapsedContentEntrySection.js
@@ -1,11 +1,4 @@
 export default {
-  contentDependencies: [
-    'generateCommentaryEntry',
-    'generateContentContentHeading',
-  ],
-
-  extraDependencies: ['html'],
-
   relations: (relation, entries, thing) => ({
     contentContentHeading:
       relation('generateContentContentHeading', thing),

--- a/src/content/dependencies/generateColorStyleAttribute.js
+++ b/src/content/dependencies/generateColorStyleAttribute.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['generateColorStyleVariables'],
-  extraDependencies: ['html'],
-
   relations: (relation) => ({
     colorVariables:
       relation('generateColorStyleVariables'),

--- a/src/content/dependencies/generateColorStyleTag.js
+++ b/src/content/dependencies/generateColorStyleTag.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['generateColorStyleVariables', 'generateStyleTag'],
-  extraDependencies: ['html'],
-
   relations: (relation) => ({
     styleTag:
       relation('generateStyleTag'),

--- a/src/content/dependencies/generateColorStyleVariables.js
+++ b/src/content/dependencies/generateColorStyleVariables.js
@@ -1,6 +1,4 @@
 export default {
-  extraDependencies: ['html', 'getColors'],
-
   slots: {
     color: {
       validate: v => v.isColor,

--- a/src/content/dependencies/generateCommentaryContentHeading.js
+++ b/src/content/dependencies/generateCommentaryContentHeading.js
@@ -1,9 +1,6 @@
 import {empty} from '#sugar';
 
 export default {
-  contentDependencies: ['generateContentContentHeading'],
-  extraDependencies: ['language'],
-
   query: (thing) => ({
     entries:
       (thing.isTrack

--- a/src/content/dependencies/generateCommentaryEntry.js
+++ b/src/content/dependencies/generateCommentaryEntry.js
@@ -1,15 +1,6 @@
 import {empty} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateCommentaryEntryDate',
-    'generateColorStyleAttribute',
-    'linkArtist',
-    'transformContent',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   relations: (relation, entry) => ({
     artistLinks:
       (!empty(entry.artists) && !entry.artistText

--- a/src/content/dependencies/generateCommentaryEntryDate.js
+++ b/src/content/dependencies/generateCommentaryEntryDate.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['generateTextWithTooltip', 'generateTooltip'],
-  extraDependencies: ['html', 'language'],
-
   relations: (relation, _entry) => ({
     textWithTooltip:
       relation('generateTextWithTooltip'),

--- a/src/content/dependencies/generateCommentaryIndexPage.js
+++ b/src/content/dependencies/generateCommentaryIndexPage.js
@@ -2,9 +2,6 @@ import {sortChronologically} from '#sort';
 import {accumulateSum, filterMultipleArrays, stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: ['generatePageLayout', 'linkAlbumCommentary'],
-  extraDependencies: ['html', 'language', 'wikiData'],
-
   sprawl({albumData}) {
     return {albumData};
   },

--- a/src/content/dependencies/generateContentContentHeading.js
+++ b/src/content/dependencies/generateContentContentHeading.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['generateContentHeading'],
-  extraDependencies: ['html', 'language'],
-
   relations: (relation, _thing) => ({
     contentHeading:
       relation('generateContentHeading'),

--- a/src/content/dependencies/generateContentHeading.js
+++ b/src/content/dependencies/generateContentHeading.js
@@ -1,7 +1,5 @@
 export default {
   extraDependencies: ['html'],
-  contentDependencies: ['generateColorStyleAttribute'],
-
   relations: (relation) => ({
     colorStyle: relation('generateColorStyleAttribute'),
   }),

--- a/src/content/dependencies/generateContributionList.js
+++ b/src/content/dependencies/generateContributionList.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['linkContribution'],
-  extraDependencies: ['html'],
-
   relations: (relation, contributions) => ({
     contributionLinks:
       contributions

--- a/src/content/dependencies/generateContributionTooltip.js
+++ b/src/content/dependencies/generateContributionTooltip.js
@@ -32,14 +32,6 @@ function getSiblings(contribution) {
 }
 
 export default {
-  contentDependencies: [
-    'generateContributionTooltipChronologySection',
-    'generateContributionTooltipExternalLinkSection',
-    'generateTooltip',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   query: (contribution) => ({
     albumArtistContribution:
       (contribution.thing.isTrack

--- a/src/content/dependencies/generateContributionTooltipChronologySection.js
+++ b/src/content/dependencies/generateContributionTooltipChronologySection.js
@@ -25,9 +25,6 @@ function getSiblings(contribution) {
 }
 
 export default {
-  contentDependencies: ['linkAnythingMan'],
-  extraDependencies: ['html', 'language'],
-
   query: (contribution) => ({
     ...getSiblings(contribution),
   }),

--- a/src/content/dependencies/generateContributionTooltipExternalLinkSection.js
+++ b/src/content/dependencies/generateContributionTooltipExternalLinkSection.js
@@ -1,14 +1,6 @@
 import {stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateExternalHandle',
-    'generateExternalIcon',
-    'generateExternalPlatform',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   relations: (relation, contribution) => ({
     icons:
       contribution.artist.urls

--- a/src/content/dependencies/generateCoverArtwork.js
+++ b/src/content/dependencies/generateCoverArtwork.js
@@ -1,15 +1,4 @@
 export default {
-  contentDependencies: [
-    'generateColorStyleAttribute',
-    'generateCoverArtworkArtTagDetails',
-    'generateCoverArtworkArtistDetails',
-    'generateCoverArtworkOriginDetails',
-    'generateCoverArtworkReferenceDetails',
-    'image',
-  ],
-
-  extraDependencies: ['html'],
-
   relations: (relation, artwork) => ({
     colorStyleAttribute:
       relation('generateColorStyleAttribute'),

--- a/src/content/dependencies/generateCoverArtworkArtTagDetails.js
+++ b/src/content/dependencies/generateCoverArtworkArtTagDetails.js
@@ -5,9 +5,6 @@ function linkable(tag) {
 }
 
 export default {
-  contentDependencies: ['linkArtTagGallery'],
-  extraDependencies: ['html', 'language'],
-
   query: (artwork) => ({
     linkableArtTags:
       artwork.artTags.filter(linkable),

--- a/src/content/dependencies/generateCoverArtworkArtistDetails.js
+++ b/src/content/dependencies/generateCoverArtworkArtistDetails.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['linkArtistGallery'],
-  extraDependencies: ['html', 'language'],
-
   relations: (relation, artwork) => ({
     artistLinks:
       artwork.artistContribs

--- a/src/content/dependencies/generateCoverArtworkOriginDetails.js
+++ b/src/content/dependencies/generateCoverArtworkOriginDetails.js
@@ -1,13 +1,4 @@
 export default {
-  contentDependencies: [
-    'generateArtistCredit',
-    'generateAbsoluteDatetimestamp',
-    'linkAlbum',
-    'transformContent',
-  ],
-
-  extraDependencies: ['html', 'language', 'pagePath'],
-
   query: (artwork) => ({
     attachedArtistContribs:
       (artwork.attachedArtwork

--- a/src/content/dependencies/generateCoverArtworkReferenceDetails.js
+++ b/src/content/dependencies/generateCoverArtworkReferenceDetails.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['linkReferencedArtworks', 'linkReferencingArtworks'],
-  extraDependencies: ['html', 'language'],
-
   relations: (relation, artwork) => ({
     referencedArtworksLink:
       relation('linkReferencedArtworks', artwork),

--- a/src/content/dependencies/generateCoverCarousel.js
+++ b/src/content/dependencies/generateCoverCarousel.js
@@ -2,8 +2,6 @@ import {empty, repeat, stitchArrays} from '#sugar';
 import {getCarouselLayoutForNumberOfItems} from '#wiki-data';
 
 export default {
-  extraDependencies: ['html'],
-
   slots: {
     images: {validate: v => v.strictArrayOf(v.isHTML)},
     links: {validate: v => v.strictArrayOf(v.isHTML)},

--- a/src/content/dependencies/generateCoverGrid.js
+++ b/src/content/dependencies/generateCoverGrid.js
@@ -1,9 +1,6 @@
 import {empty, stitchArrays, unique} from '#sugar';
 
 export default {
-  contentDependencies: ['generateGridActionLinks', 'generateGridExpando'],
-  extraDependencies: ['html', 'language'],
-
   relations: (relation) => ({
     actionLinks:
       relation('generateGridActionLinks'),

--- a/src/content/dependencies/generateDatetimestampTemplate.js
+++ b/src/content/dependencies/generateDatetimestampTemplate.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['generateTextWithTooltip'],
-  extraDependencies: ['html'],
-
   relations: (relation) => ({
     textWithTooltip:
       relation('generateTextWithTooltip'),

--- a/src/content/dependencies/generateDotSwitcherTemplate.js
+++ b/src/content/dependencies/generateDotSwitcherTemplate.js
@@ -1,6 +1,4 @@
 export default {
-  extraDependencies: ['html'],
-
   slots: {
     attributes: {
       type: 'attributes',

--- a/src/content/dependencies/generateExternalHandle.js
+++ b/src/content/dependencies/generateExternalHandle.js
@@ -1,8 +1,6 @@
 import {isExternalLinkContext} from '#external-links';
 
 export default {
-  extraDependencies: ['html', 'language'],
-
   data: (url) => ({url}),
 
   slots: {

--- a/src/content/dependencies/generateExternalIcon.js
+++ b/src/content/dependencies/generateExternalIcon.js
@@ -1,8 +1,6 @@
 import {isExternalLinkContext} from '#external-links';
 
 export default {
-  extraDependencies: ['html', 'language', 'to'],
-
   data: (url) => ({url}),
 
   slots: {

--- a/src/content/dependencies/generateExternalPlatform.js
+++ b/src/content/dependencies/generateExternalPlatform.js
@@ -1,8 +1,6 @@
 import {isExternalLinkContext} from '#external-links';
 
 export default {
-  extraDependencies: ['html', 'language'],
-
   data: (url) => ({url}),
 
   slots: {

--- a/src/content/dependencies/generateFlashActGalleryPage.js
+++ b/src/content/dependencies/generateFlashActGalleryPage.js
@@ -1,19 +1,6 @@
 import striptags from 'striptags';
 
 export default {
-  contentDependencies: [
-    'generateCoverGrid',
-    'generateFlashActNavAccent',
-    'generateFlashActSidebar',
-    'generatePageLayout',
-    'image',
-    'linkFlash',
-    'linkFlashAct',
-    'linkFlashIndex',
-  ],
-
-  extraDependencies: ['language'],
-
   relations: (relation, act) => ({
     layout:
       relation('generatePageLayout'),

--- a/src/content/dependencies/generateFlashActNavAccent.js
+++ b/src/content/dependencies/generateFlashActNavAccent.js
@@ -1,15 +1,6 @@
 import {atOffset} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateInterpageDotSwitcher',
-    'generateNextLink',
-    'generatePreviousLink',
-    'linkFlashAct',
-  ],
-
-  extraDependencies: ['wikiData'],
-
   sprawl: ({flashActData}) =>
     ({flashActData}),
 

--- a/src/content/dependencies/generateFlashActSidebar.js
+++ b/src/content/dependencies/generateFlashActSidebar.js
@@ -1,10 +1,4 @@
 export default {
-  contentDependencies: [
-    'generateFlashActSidebarCurrentActBox',
-    'generateFlashActSidebarSideMapBox',
-    'generatePageSidebar',
-  ],
-
   relations: (relation, act, flash) => ({
     sidebar:
       relation('generatePageSidebar'),

--- a/src/content/dependencies/generateFlashActSidebarCurrentActBox.js
+++ b/src/content/dependencies/generateFlashActSidebarCurrentActBox.js
@@ -1,12 +1,4 @@
 export default {
-  contentDependencies: [
-    'generatePageSidebarBox',
-    'linkFlash',
-    'linkFlashAct',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   relations: (relation, act, _flash) => ({
     box:
       relation('generatePageSidebarBox'),

--- a/src/content/dependencies/generateFlashActSidebarSideMapBox.js
+++ b/src/content/dependencies/generateFlashActSidebarSideMapBox.js
@@ -1,15 +1,6 @@
 import {stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateColorStyleAttribute',
-    'generatePageSidebarBox',
-    'linkFlashAct',
-    'linkFlashIndex',
-  ],
-
-  extraDependencies: ['html', 'wikiData'],
-
   sprawl: ({flashSideData}) => ({flashSideData}),
 
   relations: (relation, sprawl, _act, _flash) => ({

--- a/src/content/dependencies/generateFlashArtworkColumn.js
+++ b/src/content/dependencies/generateFlashArtworkColumn.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['generateCoverArtwork'],
-
   relations: (relation, flash) => ({
     coverArtwork:
       relation('generateCoverArtwork', flash.coverArtwork),

--- a/src/content/dependencies/generateFlashIndexPage.js
+++ b/src/content/dependencies/generateFlashIndexPage.js
@@ -1,17 +1,6 @@
 import {stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateColorStyleAttribute',
-    'generateCoverGrid',
-    'generatePageLayout',
-    'image',
-    'linkFlash',
-    'linkFlashAct',
-  ],
-
-  extraDependencies: ['html', 'language', 'wikiData'],
-
   sprawl: ({flashActData}) => ({flashActData}),
 
   query(sprawl) {

--- a/src/content/dependencies/generateFlashInfoPage.js
+++ b/src/content/dependencies/generateFlashInfoPage.js
@@ -14,25 +14,6 @@ function checkInterrupted(which, relations, {html}) {
 }
 
 export default {
-  contentDependencies: [
-    'generateAdditionalNamesBox',
-    'generateCollapsedContentEntrySection',
-    'generateCommentaryEntry',
-    'generateCommentaryContentHeading',
-    'generateContentHeading',
-    'generateContributionList',
-    'generateFlashActSidebar',
-    'generateFlashArtworkColumn',
-    'generateFlashNavAccent',
-    'generatePageLayout',
-    'generateReadCommentaryLine',
-    'generateTrackList',
-    'linkExternal',
-    'linkFlashAct',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   query(flash) {
     const query = {};
 

--- a/src/content/dependencies/generateFlashNavAccent.js
+++ b/src/content/dependencies/generateFlashNavAccent.js
@@ -1,15 +1,6 @@
 import {atOffset} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateInterpageDotSwitcher',
-    'generateNextLink',
-    'generatePreviousLink',
-    'linkFlash',
-  ],
-
-  extraDependencies: ['html', 'language', 'wikiData'],
-
   sprawl: ({flashActData}) =>
     ({flashActData}),
 

--- a/src/content/dependencies/generateFooterLocalizationLinks.js
+++ b/src/content/dependencies/generateFooterLocalizationLinks.js
@@ -2,15 +2,6 @@ import {sortByName} from '#sort';
 import {stitchArrays} from '#sugar';
 
 export default {
-  extraDependencies: [
-    'defaultLanguage',
-    'html',
-    'language',
-    'languages',
-    'pagePath',
-    'to',
-  ],
-
   generate({
     defaultLanguage,
     html,

--- a/src/content/dependencies/generateGridActionLinks.js
+++ b/src/content/dependencies/generateGridActionLinks.js
@@ -1,6 +1,4 @@
 export default {
-  extraDependencies: ['html'],
-
   slots: {
     actionLinks: {validate: v => v.sparseArrayOf(v.isHTML)},
   },

--- a/src/content/dependencies/generateGridExpando.js
+++ b/src/content/dependencies/generateGridExpando.js
@@ -1,6 +1,4 @@
 export default {
-  extraDependencies: ['html', 'language'],
-
   slots: {
     caption: {type: 'html', mutable: false},
   },

--- a/src/content/dependencies/generateGroupGalleryPage.js
+++ b/src/content/dependencies/generateGroupGalleryPage.js
@@ -2,22 +2,6 @@ import {sortChronologically} from '#sort';
 import {filterItemsForCarousel, getTotalDuration} from '#wiki-data';
 
 export default {
-  contentDependencies: [
-    'generateCoverCarousel',
-    'generateGroupGalleryPageAlbumsByDateView',
-    'generateGroupGalleryPageAlbumsBySeriesView',
-    'generateGroupNavLinks',
-    'generateGroupSecondaryNav',
-    'generateIntrapageDotSwitcher',
-    'generatePageLayout',
-    'generateQuickDescription',
-    'image',
-    'linkAlbum',
-    'linkListing',
-  ],
-
-  extraDependencies: ['html', 'language', 'wikiData'],
-
   sprawl: ({wikiInfo}) =>
     ({enableGroupUI: wikiInfo.enableGroupUI}),
 

--- a/src/content/dependencies/generateGroupGalleryPageAlbumGrid.js
+++ b/src/content/dependencies/generateGroupGalleryPageAlbumGrid.js
@@ -2,15 +2,6 @@ import {stitchArrays} from '#sugar';
 import {getTotalDuration} from '#wiki-data';
 
 export default {
-  contentDependencies: [
-    'generateCoverGrid',
-    'generateGroupGalleryPageAlbumGridTab',
-    'image',
-    'linkAlbum',
-  ],
-
-  extraDependencies: ['language', 'wikiData'],
-
   query: (albums, _group) => ({
     artworks:
       albums.map(album =>

--- a/src/content/dependencies/generateGroupGalleryPageAlbumGridTab.js
+++ b/src/content/dependencies/generateGroupGalleryPageAlbumGridTab.js
@@ -1,9 +1,6 @@
 import {empty} from '#sugar';
 
 export default {
-  contentDependencies: ['generateArtistCredit'],
-  extraDependencies: ['language'],
-
   query(album, group) {
     if (album.groups.length > 1) {
       const contextGroup = group;

--- a/src/content/dependencies/generateGroupGalleryPageAlbumsByDateView.js
+++ b/src/content/dependencies/generateGroupGalleryPageAlbumsByDateView.js
@@ -1,13 +1,6 @@
 import {sortChronologically} from '#sort';
 
 export default {
-  contentDependencies: [
-    'generateGroupGalleryPageAlbumGrid',
-    'generateGroupGalleryPageStyleSelector',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   query: (group) => ({
     albums:
       sortChronologically(group.albums.slice(), {latestFirst: true}),

--- a/src/content/dependencies/generateGroupGalleryPageAlbumsBySeriesView.js
+++ b/src/content/dependencies/generateGroupGalleryPageAlbumsBySeriesView.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['generateGroupGalleryPageSeriesSection'],
-  extraDependencies: ['html'],
-
   relations: (relation, group) => ({
     seriesSections:
       group.serieses

--- a/src/content/dependencies/generateGroupGalleryPageSeriesSection.js
+++ b/src/content/dependencies/generateGroupGalleryPageSeriesSection.js
@@ -1,13 +1,6 @@
 import {sortChronologically} from '#sort';
 
 export default {
-  contentDependencies: [
-    'generateContentHeading',
-    'generateGroupGalleryPageAlbumGrid',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   query(series) {
     const query = {};
 

--- a/src/content/dependencies/generateGroupGalleryPageStyleSelector.js
+++ b/src/content/dependencies/generateGroupGalleryPageStyleSelector.js
@@ -1,8 +1,6 @@
 import {unique} from '#sugar';
 
 export default {
-  extraDependencies: ['html', 'language'],
-
   query: (group) => ({
     styles:
       unique(group.albums.map(album => album.style)),

--- a/src/content/dependencies/generateGroupInfoPage.js
+++ b/src/content/dependencies/generateGroupInfoPage.js
@@ -1,20 +1,6 @@
 import {stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateColorStyleAttribute',
-    'generateGroupInfoPageAlbumsSection',
-    'generateGroupNavLinks',
-    'generateGroupSecondaryNav',
-    'generateGroupSidebar',
-    'generatePageLayout',
-    'linkArtist',
-    'linkExternal',
-    'transformContent',
-  ],
-
-  extraDependencies: ['html', 'language', 'wikiData'],
-
   sprawl: ({wikiInfo}) => ({
     enableGroupUI:
       wikiInfo.enableGroupUI,

--- a/src/content/dependencies/generateGroupInfoPageAlbumsListByDate.js
+++ b/src/content/dependencies/generateGroupInfoPageAlbumsListByDate.js
@@ -1,10 +1,6 @@
 import {sortChronologically} from '#sort';
 
 export default {
-  contentDependencies: ['generateGroupInfoPageAlbumsListItem'],
-
-  extraDependencies: ['html'],
-
   query: (group) => ({
     // Typically, a latestFirst: false (default) chronological sort would be
     // appropriate here, but navigation between adjacent albums in a group is a

--- a/src/content/dependencies/generateGroupInfoPageAlbumsListBySeries.js
+++ b/src/content/dependencies/generateGroupInfoPageAlbumsListBySeries.js
@@ -1,13 +1,6 @@
 import {stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateContentHeading',
-    'generateGroupInfoPageAlbumsListItem',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   query: (group) => ({
     closelyLinkedArtists:
       group.closelyLinkedArtists

--- a/src/content/dependencies/generateGroupInfoPageAlbumsListItem.js
+++ b/src/content/dependencies/generateGroupInfoPageAlbumsListItem.js
@@ -1,16 +1,6 @@
 import {empty} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateAbsoluteDatetimestamp',
-    'generateArtistCredit',
-    'generateColorStyleAttribute',
-    'linkAlbum',
-    'linkGroup',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   query: (album, group) => {
     const otherCategory =
       album.groups

--- a/src/content/dependencies/generateGroupInfoPageAlbumsSection.js
+++ b/src/content/dependencies/generateGroupInfoPageAlbumsSection.js
@@ -1,14 +1,4 @@
 export default {
-  contentDependencies: [
-    'generateContentHeading',
-    'generateGroupInfoPageAlbumsListByDate',
-    'generateGroupInfoPageAlbumsListBySeries',
-    'generateIntrapageDotSwitcher',
-    'linkGroupGallery',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   relations: (relation, group) => ({
     contentHeading:
       relation('generateContentHeading'),

--- a/src/content/dependencies/generateGroupNavAccent.js
+++ b/src/content/dependencies/generateGroupNavAccent.js
@@ -1,14 +1,6 @@
 import {empty} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateInterpageDotSwitcher',
-    'linkGroup',
-    'linkGroupGallery',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   relations: (relation, group) => ({
     switcher:
       relation('generateInterpageDotSwitcher'),

--- a/src/content/dependencies/generateGroupNavLinks.js
+++ b/src/content/dependencies/generateGroupNavLinks.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['generateGroupNavAccent', 'linkGroup'],
-  extraDependencies: ['html', 'language', 'wikiData'],
-
   sprawl: ({groupCategoryData, wikiInfo}) => ({
     groupCategoryData,
     enableGroupUI: wikiInfo.enableGroupUI,

--- a/src/content/dependencies/generateGroupSecondaryNav.js
+++ b/src/content/dependencies/generateGroupSecondaryNav.js
@@ -1,9 +1,4 @@
 export default {
-  contentDependencies: [
-    'generateSecondaryNav',
-    'generateGroupSecondaryNavCategoryPart',
-  ],
-
   relations: (relation, group) => ({
     secondaryNav:
       relation('generateSecondaryNav'),

--- a/src/content/dependencies/generateGroupSecondaryNavCategoryPart.js
+++ b/src/content/dependencies/generateGroupSecondaryNavCategoryPart.js
@@ -1,15 +1,6 @@
 import {atOffset} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateColorStyleAttribute',
-    'generateSecondaryNavParentSiblingsPart',
-    'linkGroupDynamically',
-    'linkListing',
-  ],
-
-  extraDependencies: ['html', 'language', 'wikiData'],
-
   sprawl: ({listingSpec, wikiInfo}) => ({
     groupsByCategoryListing:
       (wikiInfo.enableListings

--- a/src/content/dependencies/generateGroupSidebar.js
+++ b/src/content/dependencies/generateGroupSidebar.js
@@ -1,12 +1,4 @@
 export default {
-  contentDependencies: [
-    'generateGroupSidebarCategoryDetails',
-    'generatePageSidebar',
-    'generatePageSidebarBox',
-  ],
-
-  extraDependencies: ['html', 'language', 'wikiData'],
-
   sprawl: ({groupCategoryData}) => ({groupCategoryData}),
 
   relations: (relation, sprawl, group) => ({

--- a/src/content/dependencies/generateGroupSidebarCategoryDetails.js
+++ b/src/content/dependencies/generateGroupSidebarCategoryDetails.js
@@ -1,14 +1,6 @@
 import {empty, stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateColorStyleAttribute',
-    'linkGroup',
-    'linkGroupGallery',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   relations(relation, category) {
     return {
       colorStyle:

--- a/src/content/dependencies/generateImageOverlay.js
+++ b/src/content/dependencies/generateImageOverlay.js
@@ -1,6 +1,4 @@
 export default {
-  extraDependencies: ['html', 'language'],
-
   generate: ({html, language}) =>
     html.tag('div', {id: 'image-overlay-container'},
       html.tag('div', {id: 'image-overlay-content-container'}, [

--- a/src/content/dependencies/generateInterpageDotSwitcher.js
+++ b/src/content/dependencies/generateInterpageDotSwitcher.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['generateDotSwitcherTemplate'],
-  extraDependencies: ['html', 'language'],
-
   relations: (relation) => ({
     template:
       relation('generateDotSwitcherTemplate'),

--- a/src/content/dependencies/generateIntrapageDotSwitcher.js
+++ b/src/content/dependencies/generateIntrapageDotSwitcher.js
@@ -1,9 +1,6 @@
 import {stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: ['generateDotSwitcherTemplate'],
-  extraDependencies: ['html', 'language'],
-
   relations: (relation) => ({
     template:
       relation('generateDotSwitcherTemplate'),

--- a/src/content/dependencies/generateListAllAdditionalFilesAlbumChunk.js
+++ b/src/content/dependencies/generateListAllAdditionalFilesAlbumChunk.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['generateListAllAdditionalFilesChunk'],
-  extraDependencies: ['html', 'language'],
-
   relations: (relation, _album, additionalFiles) => ({
     chunk:
       relation('generateListAllAdditionalFilesChunk', additionalFiles),

--- a/src/content/dependencies/generateListAllAdditionalFilesAlbumSection.js
+++ b/src/content/dependencies/generateListAllAdditionalFilesAlbumSection.js
@@ -1,13 +1,4 @@
 export default {
-  contentDependencies: [
-    'generateContentHeading',
-    'generateListAllAdditionalFilesAlbumChunk',
-    'generateListAllAdditionalFilesTrackChunk',
-    'linkAlbum',
-  ],
-
-  extraDependencies: ['html'],
-
   relations: (relation, album, property) => ({
     heading:
       relation('generateContentHeading'),

--- a/src/content/dependencies/generateListAllAdditionalFilesChunk.js
+++ b/src/content/dependencies/generateListAllAdditionalFilesChunk.js
@@ -1,9 +1,6 @@
 import {stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: ['linkAdditionalFile'],
-  extraDependencies: ['html', 'language'],
-
   relations: (relation, additionalFiles) => ({
     links:
       additionalFiles

--- a/src/content/dependencies/generateListAllAdditionalFilesTrackChunk.js
+++ b/src/content/dependencies/generateListAllAdditionalFilesTrackChunk.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['generateListAllAdditionalFilesChunk', 'linkTrack'],
-  extraDependencies: ['html'],
-
   relations: (relation, track, additionalFiles) => ({
     trackLink:
       relation('linkTrack', track),

--- a/src/content/dependencies/generateListRandomPageLinksAlbumLink.js
+++ b/src/content/dependencies/generateListRandomPageLinksAlbumLink.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['linkAlbum'],
-
   data: (album) =>
     ({directory: album.directory}),
 

--- a/src/content/dependencies/generateListingIndexList.js
+++ b/src/content/dependencies/generateListingIndexList.js
@@ -1,9 +1,6 @@
 import {empty, stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: ['linkListing'],
-  extraDependencies: ['html', 'language', 'wikiData'],
-
   sprawl({listingTargetSpec, wikiInfo}) {
     return {listingTargetSpec, wikiInfo};
   },

--- a/src/content/dependencies/generateListingPage.js
+++ b/src/content/dependencies/generateListingPage.js
@@ -1,17 +1,6 @@
 import {bindOpts, empty, stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateContentHeading',
-    'generateListingSidebar',
-    'generatePageLayout',
-    'linkListing',
-    'linkListingIndex',
-    'linkTemplate',
-  ],
-
-  extraDependencies: ['html', 'language', 'wikiData'],
-
   relations(relation, listing) {
     const relations = {};
 

--- a/src/content/dependencies/generateListingSidebar.js
+++ b/src/content/dependencies/generateListingSidebar.js
@@ -1,13 +1,4 @@
 export default {
-  contentDependencies: [
-    'generateListingIndexList',
-    'generatePageSidebar',
-    'generatePageSidebarBox',
-    'linkListingIndex',
-  ],
-
-  extraDependencies: ['html'],
-
   relations: (relation, currentListing) => ({
     sidebar:
       relation('generatePageSidebar'),

--- a/src/content/dependencies/generateListingsIndexPage.js
+++ b/src/content/dependencies/generateListingsIndexPage.js
@@ -1,14 +1,6 @@
 import {getTotalDuration} from '#wiki-data';
 
 export default {
-  contentDependencies: [
-    'generateListingIndexList',
-    'generateListingSidebar',
-    'generatePageLayout',
-  ],
-
-  extraDependencies: ['html', 'language', 'wikiData'],
-
   sprawl({albumData, trackData, wikiInfo}) {
     return {
       wikiName: wikiInfo.name,

--- a/src/content/dependencies/generateLyricsEntry.js
+++ b/src/content/dependencies/generateLyricsEntry.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['linkArtist', 'linkExternal', 'transformContent'],
-  extraDependencies: ['html', 'language'],
-
   relations: (relation, entry) => ({
     content:
       relation('transformContent', entry.body),

--- a/src/content/dependencies/generateLyricsSection.js
+++ b/src/content/dependencies/generateLyricsSection.js
@@ -1,15 +1,6 @@
 import {stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateContentHeading',
-    'generateIntrapageDotSwitcher',
-    'generateLyricsEntry',
-    'transformContent',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   relations: (relation, entries) => ({
     heading:
       relation('generateContentHeading'),

--- a/src/content/dependencies/generateNewsEntryNavAccent.js
+++ b/src/content/dependencies/generateNewsEntryNavAccent.js
@@ -1,11 +1,4 @@
 export default {
-  contentDependencies: [
-    'generateInterpageDotSwitcher',
-    'generateNextLink',
-    'generatePreviousLink',
-    'linkNewsEntry',
-  ],
-
   relations: (relation, previousEntry, nextEntry) => ({
     switcher:
       relation('generateInterpageDotSwitcher'),

--- a/src/content/dependencies/generateNewsEntryPage.js
+++ b/src/content/dependencies/generateNewsEntryPage.js
@@ -2,16 +2,6 @@ import {sortChronologically} from '#sort';
 import {atOffset} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateNewsEntryNavAccent',
-    'generateNewsEntryReadAnotherLinks',
-    'generatePageLayout',
-    'linkNewsIndex',
-    'transformContent',
-  ],
-
-  extraDependencies: ['html', 'language', 'wikiData'],
-
   sprawl({newsData}) {
     return {newsData};
   },

--- a/src/content/dependencies/generateNewsEntryReadAnotherLinks.js
+++ b/src/content/dependencies/generateNewsEntryReadAnotherLinks.js
@@ -1,12 +1,4 @@
 export default {
-  contentDependencies: [
-    'generateAbsoluteDatetimestamp',
-    'generateRelativeDatetimestamp',
-    'linkNewsEntry',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   relations(relation, currentEntry, previousEntry, nextEntry) {
     const relations = {};
 

--- a/src/content/dependencies/generateNewsIndexPage.js
+++ b/src/content/dependencies/generateNewsIndexPage.js
@@ -2,14 +2,6 @@ import {sortChronologically} from '#sort';
 import {stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generatePageLayout',
-    'linkNewsEntry',
-    'transformContent',
-  ],
-
-  extraDependencies: ['html', 'language', 'wikiData'],
-
   sprawl({newsData}) {
     return {newsData};
   },

--- a/src/content/dependencies/generateNextLink.js
+++ b/src/content/dependencies/generateNextLink.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['generatePreviousNextLink'],
-
   relations: (relation) => ({
     link:
       relation('generatePreviousNextLink'),

--- a/src/content/dependencies/generatePageLayout.js
+++ b/src/content/dependencies/generatePageLayout.js
@@ -2,28 +2,6 @@ import {openAggregate} from '#aggregate';
 import {atOffset, empty, repeat} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateColorStyleTag',
-    'generateFooterLocalizationLinks',
-    'generateImageOverlay',
-    'generatePageSidebar',
-    'generateSearchSidebarBox',
-    'generateStaticURLStyleTag',
-    'generateStickyHeadingContainer',
-    'generateWikiWallpaperStyleTag',
-    'transformContent',
-  ],
-
-  extraDependencies: [
-    'getColors',
-    'html',
-    'language',
-    'pagePath',
-    'pagePathStringFromRoot',
-    'to',
-    'wikiData',
-  ],
-
   sprawl: ({wikiInfo}) => ({
     enableSearch: wikiInfo.enableSearch,
     footerContent: wikiInfo.footerContent,

--- a/src/content/dependencies/generatePageSidebar.js
+++ b/src/content/dependencies/generatePageSidebar.js
@@ -1,6 +1,4 @@
 export default {
-  extraDependencies: ['html'],
-
   slots: {
     // Attributes to apply to the whole sidebar. This be added to the
     // containing sidebar-column, arr - specify attributes on each section if

--- a/src/content/dependencies/generatePageSidebarBox.js
+++ b/src/content/dependencies/generatePageSidebarBox.js
@@ -1,6 +1,4 @@
 export default {
-  extraDependencies: ['html'],
-
   slots: {
     content: {
       type: 'html',

--- a/src/content/dependencies/generatePageSidebarConjoinedBox.js
+++ b/src/content/dependencies/generatePageSidebarConjoinedBox.js
@@ -4,9 +4,6 @@
 // templates' resolved content), take care when slotting into this.
 
 export default {
-  contentDependencies: ['generatePageSidebarBox'],
-  extraDependencies: ['html'],
-
   relations: (relation) => ({
     box:
       relation('generatePageSidebarBox'),

--- a/src/content/dependencies/generatePreviousLink.js
+++ b/src/content/dependencies/generatePreviousLink.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['generatePreviousNextLink'],
-
   relations: (relation) => ({
     link:
       relation('generatePreviousNextLink'),

--- a/src/content/dependencies/generatePreviousNextLink.js
+++ b/src/content/dependencies/generatePreviousNextLink.js
@@ -1,6 +1,4 @@
 export default {
-  extraDependencies: ['html', 'language'],
-
   slots: {
     link: {
       type: 'html',

--- a/src/content/dependencies/generateQuickDescription.js
+++ b/src/content/dependencies/generateQuickDescription.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['transformContent'],
-  extraDependencies: ['html', 'language'],
-
   query: (thing) => ({
     hasDescription:
       !!thing.description,

--- a/src/content/dependencies/generateReadCommentaryLine.js
+++ b/src/content/dependencies/generateReadCommentaryLine.js
@@ -1,8 +1,6 @@
 import {empty} from '#sugar';
 
 export default {
-  extraDependencies: ['html', 'language'],
-
   query: (thing) => ({
     entries:
       (thing.isTrack

--- a/src/content/dependencies/generateReferencedArtworksPage.js
+++ b/src/content/dependencies/generateReferencedArtworksPage.js
@@ -1,14 +1,4 @@
 export default {
-  contentDependencies: [
-    'generateCoverArtwork',
-    'generateCoverGrid',
-    'generatePageLayout',
-    'image',
-    'linkAnythingMan',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   relations: (relation, artwork) => ({
     layout:
       relation('generatePageLayout'),

--- a/src/content/dependencies/generateReferencingArtworksPage.js
+++ b/src/content/dependencies/generateReferencingArtworksPage.js
@@ -1,14 +1,4 @@
 export default {
-  contentDependencies: [
-    'generateCoverArtwork',
-    'generateCoverGrid',
-    'generatePageLayout',
-    'image',
-    'linkAnythingMan',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   relations: (relation, artwork) => ({
     layout:
       relation('generatePageLayout'),

--- a/src/content/dependencies/generateRelativeDatetimestamp.js
+++ b/src/content/dependencies/generateRelativeDatetimestamp.js
@@ -1,12 +1,4 @@
 export default {
-  contentDependencies: [
-    'generateAbsoluteDatetimestamp',
-    'generateDatetimestampTemplate',
-    'generateTooltip',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   data: (currentDate, referenceDate) =>
     (currentDate.getTime() === referenceDate.getTime()
       ? {equal: true, date: currentDate}

--- a/src/content/dependencies/generateReleaseInfoContributionsLine.js
+++ b/src/content/dependencies/generateReleaseInfoContributionsLine.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['generateArtistCredit'],
-  extraDependencies: ['html'],
-
   relations: (relation, contributions, formatText) => ({
     credit:
       relation('generateArtistCredit', contributions, [], formatText),

--- a/src/content/dependencies/generateReleaseInfoListenLine.js
+++ b/src/content/dependencies/generateReleaseInfoListenLine.js
@@ -24,9 +24,6 @@ function getReleaseContext(urlString, {
 }
 
 export default {
-  contentDependencies: ['linkExternal'],
-  extraDependencies: ['html', 'language'],
-
   query(thing) {
     const query = {};
 

--- a/src/content/dependencies/generateSearchSidebarBox.js
+++ b/src/content/dependencies/generateSearchSidebarBox.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['generatePageSidebarBox'],
-  extraDependencies: ['html', 'language'],
-
   relations: (relation) => ({
     sidebarBox:
       relation('generatePageSidebarBox'),

--- a/src/content/dependencies/generateSecondaryNav.js
+++ b/src/content/dependencies/generateSecondaryNav.js
@@ -1,6 +1,4 @@
 export default {
-  extraDependencies: ['html'],
-
   slots: {
     content: {
       type: 'html',

--- a/src/content/dependencies/generateSecondaryNavParentSiblingsPart.js
+++ b/src/content/dependencies/generateSecondaryNavParentSiblingsPart.js
@@ -1,15 +1,4 @@
 export default {
-  contentDependencies: [
-    'generateColorStyleAttribute',
-    'generateInterpageDotSwitcher',
-    'generateNextLink',
-    'generatePreviousLink',
-    'linkAlbumDynamically',
-    'linkGroup',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   relations: (relation) => ({
     switcher:
       relation('generateInterpageDotSwitcher'),

--- a/src/content/dependencies/generateSocialEmbed.js
+++ b/src/content/dependencies/generateSocialEmbed.js
@@ -1,6 +1,4 @@
 export default {
-  extraDependencies: ['absoluteTo', 'html', 'language', 'wikiData'],
-
   sprawl({wikiInfo}) {
     return {
       canonicalBase: wikiInfo.canonicalBase,

--- a/src/content/dependencies/generateStaticPage.js
+++ b/src/content/dependencies/generateStaticPage.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['generatePageLayout', 'transformContent'],
-  extraDependencies: ['html'],
-
   relations(relation, staticPage) {
     return {
       layout: relation('generatePageLayout'),

--- a/src/content/dependencies/generateStaticURLStyleTag.js
+++ b/src/content/dependencies/generateStaticURLStyleTag.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['generateStyleTag'],
-  extraDependencies: ['to'],
-
   relations: (relation) => ({
     styleTag:
       relation('generateStyleTag'),

--- a/src/content/dependencies/generateStickyHeadingContainer.js
+++ b/src/content/dependencies/generateStickyHeadingContainer.js
@@ -1,6 +1,4 @@
 export default {
-  extraDependencies: ['html'],
-
   slots: {
     rootAttributes: {
       type: 'attributes',

--- a/src/content/dependencies/generateStyleTag.js
+++ b/src/content/dependencies/generateStyleTag.js
@@ -7,8 +7,6 @@ const indent = text =>
     .join('\n');
 
 export default {
-  extraDependencies: ['html'],
-
   slots: {
     attributes: {
       type: 'attributes',

--- a/src/content/dependencies/generateTextWithTooltip.js
+++ b/src/content/dependencies/generateTextWithTooltip.js
@@ -1,6 +1,4 @@
 export default {
-  extraDependencies: ['html'],
-
   slots: {
     attributes: {
       type: 'attributes',

--- a/src/content/dependencies/generateTooltip.js
+++ b/src/content/dependencies/generateTooltip.js
@@ -1,6 +1,4 @@
 export default {
-  extraDependencies: ['html'],
-
   slots: {
     attributes: {
       type: 'attributes',

--- a/src/content/dependencies/generateTrackArtistCommentarySection.js
+++ b/src/content/dependencies/generateTrackArtistCommentarySection.js
@@ -1,15 +1,6 @@
 import {empty, stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateCommentaryContentHeading',
-    'generateCommentaryEntry',
-    'linkAlbum',
-    'linkTrack',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   query: (track) => ({
     otherSecondaryReleasesWithCommentary:
       track.otherReleases

--- a/src/content/dependencies/generateTrackArtworkColumn.js
+++ b/src/content/dependencies/generateTrackArtworkColumn.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['generateCoverArtwork'],
-  extraDependencies: ['html'],
-
   relations: (relation, track) => ({
     albumCover:
       (!track.hasUniqueCoverArt && track.album.hasCoverArt

--- a/src/content/dependencies/generateTrackInfoPage.js
+++ b/src/content/dependencies/generateTrackInfoPage.js
@@ -20,37 +20,6 @@ function checkInterrupted(which, relations, {html}) {
 }
 
 export default {
-  contentDependencies: [
-    'generateAdditionalFilesList',
-    'generateAdditionalNamesBox',
-    'generateAlbumArtworkColumn',
-    'generateAlbumNavAccent',
-    'generateAlbumSecondaryNav',
-    'generateAlbumSidebar',
-    'generateAlbumStyleTags',
-    'generateCommentaryEntry',
-    'generateCollapsedContentEntrySection',
-    'generateContentHeading',
-    'generateContributionList',
-    'generateLyricsSection',
-    'generatePageLayout',
-    'generateReadCommentaryLine',
-    'generateTrackArtistCommentarySection',
-    'generateTrackArtworkColumn',
-    'generateTrackInfoPageFeaturedByFlashesList',
-    'generateTrackInfoPageOtherReleasesList',
-    'generateTrackList',
-    'generateTrackListDividedByGroups',
-    'generateTrackNavLinks',
-    'generateTrackReleaseInfo',
-    'generateTrackSocialEmbed',
-    'linkAlbum',
-    'linkTrack',
-    'transformContent',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   query: (track) => ({
     mainReleaseTrack:
       (track.isMainRelease

--- a/src/content/dependencies/generateTrackInfoPageFeaturedByFlashesList.js
+++ b/src/content/dependencies/generateTrackInfoPageFeaturedByFlashesList.js
@@ -2,9 +2,6 @@ import {sortFlashesChronologically} from '#sort';
 import {stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: ['linkFlash', 'linkTrack'],
-  extraDependencies: ['html', 'language', 'wikiData'],
-
   sprawl: ({wikiInfo}) => ({
     enableFlashesAndGames:
       wikiInfo.enableFlashesAndGames,

--- a/src/content/dependencies/generateTrackInfoPageOtherReleasesList.js
+++ b/src/content/dependencies/generateTrackInfoPageOtherReleasesList.js
@@ -1,9 +1,6 @@
 import {onlyItem, stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: ['linkTrack'],
-  extraDependencies: ['html', 'language'],
-
   query(track) {
     const query = {};
 

--- a/src/content/dependencies/generateTrackList.js
+++ b/src/content/dependencies/generateTrackList.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['generateTrackListItem'],
-  extraDependencies: ['html'],
-
   query: (tracks, contextTrack) => ({
     presentedTracks:
       (contextTrack

--- a/src/content/dependencies/generateTrackListDividedByGroups.js
+++ b/src/content/dependencies/generateTrackListDividedByGroups.js
@@ -1,14 +1,6 @@
 import {empty, filterMultipleArrays, stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateContentHeading',
-    'generateTrackList',
-    'linkGroup',
-  ],
-
-  extraDependencies: ['html', 'language', 'wikiData'],
-
   sprawl: ({wikiInfo}) => ({
     divideTrackListsByGroups:
       wikiInfo.divideTrackListsByGroups,

--- a/src/content/dependencies/generateTrackListItem.js
+++ b/src/content/dependencies/generateTrackListItem.js
@@ -1,13 +1,4 @@
 export default {
-  contentDependencies: [
-    'generateArtistCredit',
-    'generateColorStyleAttribute',
-    'generateTrackListMissingDuration',
-    'linkTrack',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   relations: (relation, track, contextContributions) => ({
     trackLink:
       relation('linkTrack', track),

--- a/src/content/dependencies/generateTrackListMissingDuration.js
+++ b/src/content/dependencies/generateTrackListMissingDuration.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['generateTextWithTooltip', 'generateTooltip'],
-  extraDependencies: ['html', 'language'],
-
   relations: (relation) => ({
     textWithTooltip:
       relation('generateTextWithTooltip'),

--- a/src/content/dependencies/generateTrackNavLinks.js
+++ b/src/content/dependencies/generateTrackNavLinks.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['linkAlbum', 'linkTrack'],
-  extraDependencies: ['html', 'language'],
-
   relations: (relation, track) => ({
     albumLink:
       relation('linkAlbum', track.album),

--- a/src/content/dependencies/generateTrackReferencedArtworksPage.js
+++ b/src/content/dependencies/generateTrackReferencedArtworksPage.js
@@ -1,13 +1,4 @@
 export default {
-  contentDependencies: [
-    'generateAlbumStyleTags',
-    'generateBackToTrackLink',
-    'generateReferencedArtworksPage',
-    'generateTrackNavLinks',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   relations: (relation, track) => ({
     page:
       relation('generateReferencedArtworksPage', track.trackArtworks[0]),

--- a/src/content/dependencies/generateTrackReferencingArtworksPage.js
+++ b/src/content/dependencies/generateTrackReferencingArtworksPage.js
@@ -1,13 +1,4 @@
 export default {
-  contentDependencies: [
-    'generateAlbumStyleTags',
-    'generateBackToTrackLink',
-    'generateReferencingArtworksPage',
-    'generateTrackNavLinks',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   relations: (relation, track) => ({
     page:
       relation('generateReferencingArtworksPage', track.trackArtworks[0]),

--- a/src/content/dependencies/generateTrackReleaseBox.js
+++ b/src/content/dependencies/generateTrackReleaseBox.js
@@ -1,12 +1,4 @@
 export default {
-  contentDependencies: [
-    'generateColorStyleAttribute',
-    'generatePageSidebarBox',
-    'linkTrack',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   relations: (relation, track) => ({
     box:
       relation('generatePageSidebarBox'),

--- a/src/content/dependencies/generateTrackReleaseInfo.js
+++ b/src/content/dependencies/generateTrackReleaseInfo.js
@@ -1,14 +1,6 @@
 import {compareArrays} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateReleaseInfoContributionsLine',
-    'generateReleaseInfoListenLine',
-    'linkAlbum',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   relations(relation, track) {
     const relations = {};
 

--- a/src/content/dependencies/generateTrackSocialEmbed.js
+++ b/src/content/dependencies/generateTrackSocialEmbed.js
@@ -1,11 +1,4 @@
 export default {
-  contentDependencies: [
-    'generateSocialEmbed',
-    'generateTrackSocialEmbedDescription',
-  ],
-
-  extraDependencies: ['absoluteTo', 'language'],
-
   relations(relation, track) {
     return {
       socialEmbed:

--- a/src/content/dependencies/generateTrackSocialEmbedDescription.js
+++ b/src/content/dependencies/generateTrackSocialEmbedDescription.js
@@ -1,8 +1,6 @@
 import {empty} from '#sugar';
 
 export default {
-  extraDependencies: ['html', 'language'],
-
   data: (track) => ({
     artistNames:
       track.artistContribs

--- a/src/content/dependencies/generateUnsafeMunchy.js
+++ b/src/content/dependencies/generateUnsafeMunchy.js
@@ -1,6 +1,4 @@
 export default {
-  extraDependencies: ['html'],
-
   slots: {
     contentSource: {type: 'string'},
   },

--- a/src/content/dependencies/generateWallpaperStyleTag.js
+++ b/src/content/dependencies/generateWallpaperStyleTag.js
@@ -1,9 +1,6 @@
 import {empty, stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: ['generateStyleTag'],
-  extraDependencies: ['html', 'to'],
-
   relations: (relation) => ({
     styleTag:
       relation('generateStyleTag'),

--- a/src/content/dependencies/generateWikiHomepageActionsRow.js
+++ b/src/content/dependencies/generateWikiHomepageActionsRow.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['generateGridActionLinks', 'transformContent'],
-
   relations: (relation, row) => ({
     template:
       relation('generateGridActionLinks'),

--- a/src/content/dependencies/generateWikiHomepageAlbumCarouselRow.js
+++ b/src/content/dependencies/generateWikiHomepageAlbumCarouselRow.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['generateCoverCarousel', 'image', 'linkAlbum'],
-
   relations: (relation, row) => ({
     coverCarousel:
       relation('generateCoverCarousel'),

--- a/src/content/dependencies/generateWikiHomepageAlbumGridRow.js
+++ b/src/content/dependencies/generateWikiHomepageAlbumGridRow.js
@@ -2,9 +2,6 @@ import {empty, stitchArrays} from '#sugar';
 import {getNewAdditions, getNewReleases} from '#wiki-data';
 
 export default {
-  contentDependencies: ['generateCoverGrid', 'image', 'linkAlbum'],
-  extraDependencies: ['language', 'wikiData'],
-
   sprawl({albumData}, row) {
     const sprawl = {};
 

--- a/src/content/dependencies/generateWikiHomepageNewsBox.js
+++ b/src/content/dependencies/generateWikiHomepageNewsBox.js
@@ -1,14 +1,6 @@
 import {stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generatePageSidebarBox',
-    'linkNewsEntry',
-    'transformContent',
-  ],
-
-  extraDependencies: ['html', 'language', 'wikiData'],
-
   sprawl: ({newsData}) => ({
     entries:
       newsData.slice(0, 3),

--- a/src/content/dependencies/generateWikiHomepagePage.js
+++ b/src/content/dependencies/generateWikiHomepagePage.js
@@ -1,15 +1,4 @@
 export default {
-  contentDependencies: [
-    'generatePageLayout',
-    'generatePageSidebar',
-    'generatePageSidebarBox',
-    'generateWikiHomepageNewsBox',
-    'generateWikiHomepageSection',
-    'transformContent',
-  ],
-
-  extraDependencies: ['wikiData'],
-
   sprawl: ({wikiInfo}) => ({
     wikiName:
       wikiInfo.name,

--- a/src/content/dependencies/generateWikiHomepageSection.js
+++ b/src/content/dependencies/generateWikiHomepageSection.js
@@ -1,13 +1,4 @@
 export default {
-  contentDependencies: [
-    'generateColorStyleAttribute',
-    'generateWikiHomepageActionsRow',
-    'generateWikiHomepageAlbumCarouselRow',
-    'generateWikiHomepageAlbumGridRow',
-  ],
-
-  extraDependencies: ['html'],
-
   relations: (relation, homepageSection) => ({
     colorStyle:
       relation('generateColorStyleAttribute', homepageSection.color),

--- a/src/content/dependencies/generateWikiWallpaperStyleTag.js
+++ b/src/content/dependencies/generateWikiWallpaperStyleTag.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['generateWallpaperStyleTag'],
-  extraDependencies: ['wikiData'],
-
   sprawl: ({wikiInfo}) => ({wikiInfo}),
 
   relations: (relation) => ({

--- a/src/content/dependencies/image.js
+++ b/src/content/dependencies/image.js
@@ -2,20 +2,6 @@ import {logWarn} from '#cli';
 import {empty} from '#sugar';
 
 export default {
-  extraDependencies: [
-    'checkIfImagePathHasCachedThumbnails',
-    'getDimensionsOfImagePath',
-    'getSizeOfMediaFile',
-    'getThumbnailEqualOrSmaller',
-    'getThumbnailsAvailableForDimensions',
-    'html',
-    'language',
-    'missingImagePaths',
-    'to',
-  ],
-
-  contentDependencies: ['generateColorStyleAttribute'],
-
   relations: (relation, _artwork) => ({
     colorStyle:
       relation('generateColorStyleAttribute'),

--- a/src/content/dependencies/linkAdditionalFile.js
+++ b/src/content/dependencies/linkAdditionalFile.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['linkTemplate'],
-
   query: (file, filename) => ({
     index:
       file.filenames.indexOf(filename),

--- a/src/content/dependencies/linkAlbum.js
+++ b/src/content/dependencies/linkAlbum.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['linkThing', 'linkTrack'],
-  extraDependencies: ['language'],
-
   relations: (relation, album) => ({
     link:
       (album.style === 'single'

--- a/src/content/dependencies/linkAlbumCommentary.js
+++ b/src/content/dependencies/linkAlbumCommentary.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['linkThing'],
-
   relations: (relation, album) =>
     ({link: relation('linkThing', 'localized.albumCommentary', album)}),
 

--- a/src/content/dependencies/linkAlbumDynamically.js
+++ b/src/content/dependencies/linkAlbumDynamically.js
@@ -1,14 +1,6 @@
 import {empty} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'linkAlbumCommentary',
-    'linkAlbumGallery',
-    'linkAlbum',
-  ],
-
-  extraDependencies: ['html', 'pagePath'],
-
   relations: (relation, album) => ({
     galleryLink:
       relation('linkAlbumGallery', album),

--- a/src/content/dependencies/linkAlbumGallery.js
+++ b/src/content/dependencies/linkAlbumGallery.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['linkThing'],
-
   relations: (relation, album) =>
     ({link: relation('linkThing', 'localized.albumGallery', album)}),
 

--- a/src/content/dependencies/linkAlbumReferencedArtworks.js
+++ b/src/content/dependencies/linkAlbumReferencedArtworks.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['linkThing'],
-
   relations: (relation, album) =>
     ({link: relation('linkThing', 'localized.albumReferencedArtworks', album)}),
 

--- a/src/content/dependencies/linkAlbumReferencingArtworks.js
+++ b/src/content/dependencies/linkAlbumReferencingArtworks.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['linkThing'],
-
   relations: (relation, album) =>
     ({link: relation('linkThing', 'localized.albumReferencingArtworks', album)}),
 

--- a/src/content/dependencies/linkAnythingMan.js
+++ b/src/content/dependencies/linkAnythingMan.js
@@ -1,11 +1,4 @@
 export default {
-  contentDependencies: [
-    'linkAlbum',
-    'linkArtwork',
-    'linkFlash',
-    'linkTrack',
-  ],
-
   relations: (relation, thing) => ({
     link:
       (thing.isAlbum

--- a/src/content/dependencies/linkArtTagDynamically.js
+++ b/src/content/dependencies/linkArtTagDynamically.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['linkArtTagGallery', 'linkArtTagInfo'],
-  extraDependencies: ['pagePath'],
-
   relations: (relation, artTag) => ({
     galleryLink: relation('linkArtTagGallery', artTag),
     infoLink: relation('linkArtTagInfo', artTag),

--- a/src/content/dependencies/linkArtTagGallery.js
+++ b/src/content/dependencies/linkArtTagGallery.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['linkThing'],
-
   relations: (relation, artTag) =>
     ({link: relation('linkThing', 'localized.artTagGallery', artTag)}),
 

--- a/src/content/dependencies/linkArtTagInfo.js
+++ b/src/content/dependencies/linkArtTagInfo.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['linkThing'],
-
   relations: (relation, artTag) =>
     ({link: relation('linkThing', 'localized.artTagInfo', artTag)}),
 

--- a/src/content/dependencies/linkArtist.js
+++ b/src/content/dependencies/linkArtist.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['linkThing'],
-
   relations: (relation, artist) =>
     ({link: relation('linkThing', 'localized.artist', artist)}),
 

--- a/src/content/dependencies/linkArtistGallery.js
+++ b/src/content/dependencies/linkArtistGallery.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['linkThing'],
-
   relations: (relation, artist) =>
     ({link: relation('linkThing', 'localized.artistGallery', artist)}),
 

--- a/src/content/dependencies/linkArtistRollingWindow.js
+++ b/src/content/dependencies/linkArtistRollingWindow.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['linkThing'],
-
   relations: (relation, artist) =>
     ({link: relation('linkThing', 'localized.artistRollingWindow', artist)}),
 

--- a/src/content/dependencies/linkArtwork.js
+++ b/src/content/dependencies/linkArtwork.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['linkAlbum', 'linkTrack'],
-
   relations: (relation, artwork) => ({
     link:
       (artwork.thing.isAlbum

--- a/src/content/dependencies/linkCommentaryIndex.js
+++ b/src/content/dependencies/linkCommentaryIndex.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['linkStationaryIndex'],
-
   relations: (relation) =>
     ({link:
         relation(

--- a/src/content/dependencies/linkContribution.js
+++ b/src/content/dependencies/linkContribution.js
@@ -1,12 +1,4 @@
 export default {
-  contentDependencies: [
-    'generateContributionTooltip',
-    'generateTextWithTooltip',
-    'linkArtist',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   relations: (relation, contribution) => ({
     artistLink:
       relation('linkArtist', contribution.artist),

--- a/src/content/dependencies/linkExternal.js
+++ b/src/content/dependencies/linkExternal.js
@@ -1,8 +1,6 @@
 import {isExternalLinkContext, isExternalLinkStyle} from '#external-links';
 
 export default {
-  extraDependencies: ['html', 'language', 'to', 'wikiData'],
-
   sprawl: ({wikiInfo}) => ({
     canonicalBase:
       wikiInfo.canonicalBase,

--- a/src/content/dependencies/linkFlash.js
+++ b/src/content/dependencies/linkFlash.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['linkThing'],
-
   relations: (relation, flash) =>
     ({link: relation('linkThing', 'localized.flash', flash)}),
 

--- a/src/content/dependencies/linkFlashAct.js
+++ b/src/content/dependencies/linkFlashAct.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['generateUnsafeMunchy', 'linkThing'],
-
   relations: (relation, flashAct) => ({
     unsafeMunchy:
       relation('generateUnsafeMunchy'),

--- a/src/content/dependencies/linkFlashIndex.js
+++ b/src/content/dependencies/linkFlashIndex.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['linkStationaryIndex'],
-
   relations: (relation) =>
     ({link:
         relation(

--- a/src/content/dependencies/linkFlashSide.js
+++ b/src/content/dependencies/linkFlashSide.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['linkFlashAct'],
-
   relations: (relation, flashSide) => ({
     link:
       relation('linkFlashAct', flashSide.acts[0]),

--- a/src/content/dependencies/linkGroup.js
+++ b/src/content/dependencies/linkGroup.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['linkThing'],
-
   relations: (relation, group) =>
     ({link: relation('linkThing', 'localized.groupInfo', group)}),
 

--- a/src/content/dependencies/linkGroupDynamically.js
+++ b/src/content/dependencies/linkGroupDynamically.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['linkGroupGallery', 'linkGroup'],
-  extraDependencies: ['pagePath'],
-
   relations: (relation, group) => ({
     galleryLink: relation('linkGroupGallery', group),
     infoLink: relation('linkGroup', group),

--- a/src/content/dependencies/linkGroupExtra.js
+++ b/src/content/dependencies/linkGroupExtra.js
@@ -1,13 +1,6 @@
 import {empty} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'linkGroup',
-    'linkGroupGallery',
-  ],
-
-  extraDependencies: ['html'],
-
   relations(relation, group) {
     const relations = {};
 

--- a/src/content/dependencies/linkGroupGallery.js
+++ b/src/content/dependencies/linkGroupGallery.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['linkThing'],
-
   relations: (relation, group) =>
     ({link: relation('linkThing', 'localized.groupGallery', group)}),
 

--- a/src/content/dependencies/linkListing.js
+++ b/src/content/dependencies/linkListing.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['linkThing'],
-  extraDependencies: ['language'],
-
   relations: (relation, listing) =>
     ({link: relation('linkThing', 'localized.listing', listing)}),
 

--- a/src/content/dependencies/linkListingIndex.js
+++ b/src/content/dependencies/linkListingIndex.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['linkStationaryIndex'],
-
   relations: (relation) =>
     ({link:
         relation(

--- a/src/content/dependencies/linkNewsEntry.js
+++ b/src/content/dependencies/linkNewsEntry.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['linkThing'],
-
   relations: (relation, newsEntry) =>
     ({link: relation('linkThing', 'localized.newsEntry', newsEntry)}),
 

--- a/src/content/dependencies/linkNewsIndex.js
+++ b/src/content/dependencies/linkNewsIndex.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['linkStationaryIndex'],
-
   relations: (relation) =>
     ({link:
         relation(

--- a/src/content/dependencies/linkOtherReleaseOnArtistInfoPage.js
+++ b/src/content/dependencies/linkOtherReleaseOnArtistInfoPage.js
@@ -3,9 +3,6 @@ import {sortAlbumsTracksChronologically, sortContributionsChronologically}
 import {chunkArtistTrackContributions} from '#wiki-data';
 
 export default {
-  contentDependencies: ['generateColorStyleAttribute'],
-  extraDependencies: ['html', 'language'],
-
   query(track, artist) {
     const relevantInfoPageChunkingContributions =
       track.allReleases

--- a/src/content/dependencies/linkPathFromMedia.js
+++ b/src/content/dependencies/linkPathFromMedia.js
@@ -1,17 +1,6 @@
 import {empty} from '#sugar';
 
 export default {
-  contentDependencies: ['linkTemplate'],
-
-  extraDependencies: [
-    'checkIfImagePathHasCachedThumbnails',
-    'getDimensionsOfImagePath',
-    'getSizeOfMediaFile',
-    'getThumbnailsAvailableForDimensions',
-    'html',
-    'to',
-  ],
-
   relations: (relation) =>
     ({link: relation('linkTemplate')}),
 

--- a/src/content/dependencies/linkPathFromRoot.js
+++ b/src/content/dependencies/linkPathFromRoot.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['linkTemplate'],
-
   relations: (relation) =>
     ({link: relation('linkTemplate')}),
 

--- a/src/content/dependencies/linkPathFromSite.js
+++ b/src/content/dependencies/linkPathFromSite.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['linkTemplate'],
-
   relations: (relation) =>
     ({link: relation('linkTemplate')}),
 

--- a/src/content/dependencies/linkReferencedArtworks.js
+++ b/src/content/dependencies/linkReferencedArtworks.js
@@ -1,9 +1,4 @@
 export default {
-  contentDependencies: [
-    'linkAlbumReferencedArtworks',
-    'linkTrackReferencedArtworks',
-  ],
-
   relations: (relation, artwork) => ({
     link:
       (artwork.thing.isAlbum

--- a/src/content/dependencies/linkReferencingArtworks.js
+++ b/src/content/dependencies/linkReferencingArtworks.js
@@ -1,9 +1,4 @@
 export default {
-  contentDependencies: [
-    'linkAlbumReferencingArtworks',
-    'linkTrackReferencingArtworks',
-  ],
-
   relations: (relation, artwork) => ({
     link:
       (artwork.thing.isAlbum

--- a/src/content/dependencies/linkStaticPage.js
+++ b/src/content/dependencies/linkStaticPage.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['linkThing'],
-
   relations: (relation, staticPage) =>
     ({link: relation('linkThing', 'localized.staticPage', staticPage)}),
 

--- a/src/content/dependencies/linkStationaryIndex.js
+++ b/src/content/dependencies/linkStationaryIndex.js
@@ -1,9 +1,6 @@
 // Not to be confused with "html.Stationery".
 
 export default {
-  contentDependencies: ['linkTemplate'],
-  extraDependencies: ['language'],
-
   relations(relation) {
     return {
       linkTemplate: relation('linkTemplate'),

--- a/src/content/dependencies/linkTemplate.js
+++ b/src/content/dependencies/linkTemplate.js
@@ -3,13 +3,6 @@ import {empty} from '#sugar';
 import striptags from 'striptags';
 
 export default {
-  extraDependencies: [
-    'appendIndexHTML',
-    'html',
-    'language',
-    'to',
-  ],
-
   slots: {
     href: {type: 'string'},
     path: {validate: v => v.validateArrayItems(v.isString)},

--- a/src/content/dependencies/linkThing.js
+++ b/src/content/dependencies/linkThing.js
@@ -1,13 +1,4 @@
 export default {
-  contentDependencies: [
-    'generateColorStyleAttribute',
-    'generateTextWithTooltip',
-    'generateTooltip',
-    'linkTemplate',
-  ],
-
-  extraDependencies: ['html', 'language'],
-
   relations: (relation, _pathKey, thing) => ({
     linkTemplate:
       relation('linkTemplate'),

--- a/src/content/dependencies/linkTrack.js
+++ b/src/content/dependencies/linkTrack.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['linkThing'],
-
   relations: (relation, track) =>
     ({link: relation('linkThing', 'localized.track', track)}),
 

--- a/src/content/dependencies/linkTrackDynamically.js
+++ b/src/content/dependencies/linkTrackDynamically.js
@@ -1,9 +1,6 @@
 import {empty} from '#sugar';
 
 export default {
-  contentDependencies: ['linkTrack'],
-  extraDependencies: ['pagePath'],
-
   relations: (relation, track) => ({
     infoLink: relation('linkTrack', track),
   }),

--- a/src/content/dependencies/linkTrackReferencedArtworks.js
+++ b/src/content/dependencies/linkTrackReferencedArtworks.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['linkThing'],
-
   relations: (relation, track) =>
     ({link: relation('linkThing', 'localized.trackReferencedArtworks', track)}),
 

--- a/src/content/dependencies/linkTrackReferencingArtworks.js
+++ b/src/content/dependencies/linkTrackReferencingArtworks.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['linkThing'],
-
   relations: (relation, track) =>
     ({link: relation('linkThing', 'localized.trackReferencingArtworks', track)}),
 

--- a/src/content/dependencies/linkWikiHomepage.js
+++ b/src/content/dependencies/linkWikiHomepage.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['linkTemplate'],
-  extraDependencies: ['wikiData'],
-
   sprawl({wikiInfo}) {
     return {wikiShortName: wikiInfo.nameShort};
   },

--- a/src/content/dependencies/listAlbumsByDate.js
+++ b/src/content/dependencies/listAlbumsByDate.js
@@ -2,9 +2,6 @@ import {sortChronologically} from '#sort';
 import {stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: ['generateListingPage', 'linkAlbum'],
-  extraDependencies: ['language', 'wikiData'],
-
   sprawl({albumData}) {
     return {albumData};
   },

--- a/src/content/dependencies/listAlbumsByDateAdded.js
+++ b/src/content/dependencies/listAlbumsByDateAdded.js
@@ -2,9 +2,6 @@ import {sortAlphabetically} from '#sort';
 import {chunkByProperties} from '#sugar';
 
 export default {
-  contentDependencies: ['generateListingPage', 'linkAlbum'],
-  extraDependencies: ['language', 'wikiData'],
-
   sprawl({albumData}) {
     return {albumData};
   },

--- a/src/content/dependencies/listAlbumsByDuration.js
+++ b/src/content/dependencies/listAlbumsByDuration.js
@@ -3,9 +3,6 @@ import {filterByCount, stitchArrays} from '#sugar';
 import {getTotalDuration} from '#wiki-data';
 
 export default {
-  contentDependencies: ['generateListingPage', 'linkAlbum'],
-  extraDependencies: ['language', 'wikiData'],
-
   sprawl({albumData}) {
     return {albumData};
   },

--- a/src/content/dependencies/listAlbumsByName.js
+++ b/src/content/dependencies/listAlbumsByName.js
@@ -2,9 +2,6 @@ import {sortAlphabetically} from '#sort';
 import {stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: ['generateListingPage', 'linkAlbum'],
-  extraDependencies: ['language', 'wikiData'],
-
   sprawl({albumData}) {
     return {albumData};
   },

--- a/src/content/dependencies/listAlbumsByTracks.js
+++ b/src/content/dependencies/listAlbumsByTracks.js
@@ -2,9 +2,6 @@ import {sortAlphabetically, sortByCount} from '#sort';
 import {filterByCount, stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: ['generateListingPage', 'linkAlbum'],
-  extraDependencies: ['language', 'wikiData'],
-
   sprawl({albumData}) {
     return {albumData};
   },

--- a/src/content/dependencies/listAllAdditionalFiles.js
+++ b/src/content/dependencies/listAllAdditionalFiles.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['listAllAdditionalFilesTemplate'],
-
   relations: (relation, spec) =>
     ({page: relation('listAllAdditionalFilesTemplate', spec, 'additionalFiles')}),
 

--- a/src/content/dependencies/listAllAdditionalFilesTemplate.js
+++ b/src/content/dependencies/listAllAdditionalFilesTemplate.js
@@ -1,13 +1,6 @@
 import {sortChronologically} from '#sort';
 
 export default {
-  contentDependencies: [
-    'generateListingPage',
-    'generateListAllAdditionalFilesAlbumSection',
-  ],
-
-  extraDependencies: ['html', 'wikiData'],
-
   sprawl: ({albumData}) => ({albumData}),
 
   query: (sprawl, spec, property) => ({

--- a/src/content/dependencies/listAllMidiProjectFiles.js
+++ b/src/content/dependencies/listAllMidiProjectFiles.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['listAllAdditionalFilesTemplate'],
-
   relations: (relation, spec) =>
     ({page: relation('listAllAdditionalFilesTemplate', spec, 'midiProjectFiles')}),
 

--- a/src/content/dependencies/listAllSheetMusicFiles.js
+++ b/src/content/dependencies/listAllSheetMusicFiles.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['listAllAdditionalFilesTemplate'],
-
   relations: (relation, spec) =>
     ({page: relation('listAllAdditionalFilesTemplate', spec, 'sheetMusicFiles')}),
 

--- a/src/content/dependencies/listArtTagNetwork.js
+++ b/src/content/dependencies/listArtTagNetwork.js
@@ -2,9 +2,6 @@ import {sortAlphabetically} from '#sort';
 import {empty, stitchArrays, unique} from '#sugar';
 
 export default {
-  contentDependencies: ['generateListingPage', 'linkArtTagInfo'],
-  extraDependencies: ['html', 'language', 'wikiData'],
-
   sprawl({artTagData}) {
     return {artTagData};
   },

--- a/src/content/dependencies/listArtTagsByName.js
+++ b/src/content/dependencies/listArtTagsByName.js
@@ -2,9 +2,6 @@ import {sortAlphabetically} from '#sort';
 import {stitchArrays, unique} from '#sugar';
 
 export default {
-  contentDependencies: ['generateListingPage', 'linkArtTagGallery'],
-  extraDependencies: ['language', 'wikiData'],
-
   sprawl({artTagData}) {
     return {artTagData};
   },

--- a/src/content/dependencies/listArtTagsByUses.js
+++ b/src/content/dependencies/listArtTagsByUses.js
@@ -2,9 +2,6 @@ import {sortAlphabetically, sortByCount} from '#sort';
 import {filterByCount, stitchArrays, unique} from '#sugar';
 
 export default {
-  contentDependencies: ['generateListingPage', 'linkArtTagGallery'],
-  extraDependencies: ['language', 'wikiData'],
-
   sprawl: ({artTagData}) =>
     ({artTagData}),
 

--- a/src/content/dependencies/listArtistsByCommentaryEntries.js
+++ b/src/content/dependencies/listArtistsByCommentaryEntries.js
@@ -2,9 +2,6 @@ import {sortAlphabetically, sortByCount} from '#sort';
 import {filterByCount, stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: ['generateListingPage', 'linkArtist'],
-  extraDependencies: ['language', 'wikiData'],
-
   sprawl({artistData}) {
     return {artistData};
   },

--- a/src/content/dependencies/listArtistsByContributions.js
+++ b/src/content/dependencies/listArtistsByContributions.js
@@ -3,9 +3,6 @@ import {empty, filterByCount, filterMultipleArrays, stitchArrays}
   from '#sugar';
 
 export default {
-  contentDependencies: ['generateListingPage', 'linkArtist'],
-  extraDependencies: ['html', 'language', 'wikiData'],
-
   sprawl({artistData, wikiInfo}) {
     return {
       artistData,

--- a/src/content/dependencies/listArtistsByDuration.js
+++ b/src/content/dependencies/listArtistsByDuration.js
@@ -2,9 +2,6 @@ import {sortAlphabetically, sortByCount} from '#sort';
 import {filterByCount, stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: ['generateListingPage', 'linkArtist'],
-  extraDependencies: ['language', 'wikiData'],
-
   sprawl({artistData}) {
     return {artistData};
   },

--- a/src/content/dependencies/listArtistsByGroup.js
+++ b/src/content/dependencies/listArtistsByGroup.js
@@ -10,9 +10,6 @@ import {
 } from '#sugar';
 
 export default {
-  contentDependencies: ['generateListingPage', 'linkArtist', 'linkGroup'],
-  extraDependencies: ['language', 'wikiData'],
-
   sprawl({artistData, wikiInfo}) {
     return {artistData, wikiInfo};
   },

--- a/src/content/dependencies/listArtistsByLatestContribution.js
+++ b/src/content/dependencies/listArtistsByLatestContribution.js
@@ -11,15 +11,6 @@ import {
 const {Album, Flash} = T;
 
 export default {
-  contentDependencies: [
-    'generateListingPage',
-    'linkAlbum',
-    'linkArtist',
-    'linkFlash',
-  ],
-
-  extraDependencies: ['html', 'language', 'wikiData'],
-
   sprawl: ({albumData, artistData, flashData, trackData, wikiInfo}) =>
     ({albumData, artistData, flashData, trackData,
       enableFlashesAndGames: wikiInfo.enableFlashesAndGames}),

--- a/src/content/dependencies/listArtistsByName.js
+++ b/src/content/dependencies/listArtistsByName.js
@@ -3,9 +3,6 @@ import {stitchArrays} from '#sugar';
 import {getArtistNumContributions} from '#wiki-data';
 
 export default {
-  contentDependencies: ['generateListingPage', 'linkArtist', 'linkGroup'],
-  extraDependencies: ['language', 'wikiData'],
-
   sprawl: ({artistData, wikiInfo}) =>
     ({artistData, wikiInfo}),
 

--- a/src/content/dependencies/listGroupsByAlbums.js
+++ b/src/content/dependencies/listGroupsByAlbums.js
@@ -2,9 +2,6 @@ import {sortAlphabetically, sortByCount} from '#sort';
 import {filterByCount, stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: ['generateListingPage', 'linkGroup'],
-  extraDependencies: ['language', 'wikiData'],
-
   sprawl({groupData}) {
     return {groupData};
   },

--- a/src/content/dependencies/listGroupsByCategory.js
+++ b/src/content/dependencies/listGroupsByCategory.js
@@ -1,9 +1,6 @@
 import {stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: ['generateListingPage', 'linkGroup', 'linkGroupGallery'],
-  extraDependencies: ['language', 'wikiData'],
-
   sprawl({groupCategoryData}) {
     return {groupCategoryData};
   },

--- a/src/content/dependencies/listGroupsByDuration.js
+++ b/src/content/dependencies/listGroupsByDuration.js
@@ -3,9 +3,6 @@ import {filterByCount, stitchArrays} from '#sugar';
 import {getTotalDuration} from '#wiki-data';
 
 export default {
-  contentDependencies: ['generateListingPage', 'linkGroup'],
-  extraDependencies: ['language', 'wikiData'],
-
   sprawl({groupData}) {
     return {groupData};
   },

--- a/src/content/dependencies/listGroupsByLatestAlbum.js
+++ b/src/content/dependencies/listGroupsByLatestAlbum.js
@@ -2,15 +2,6 @@ import {compareDates, sortChronologically} from '#sort';
 import {filterMultipleArrays, sortMultipleArrays, stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateListingPage',
-    'linkAlbum',
-    'linkGroup',
-    'linkGroupGallery',
-  ],
-
-  extraDependencies: ['language', 'wikiData'],
-
   sprawl({groupData}) {
     return {groupData};
   },

--- a/src/content/dependencies/listGroupsByName.js
+++ b/src/content/dependencies/listGroupsByName.js
@@ -2,9 +2,6 @@ import {sortAlphabetically} from '#sort';
 import {stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: ['generateListingPage', 'linkGroup', 'linkGroupGallery'],
-  extraDependencies: ['language', 'wikiData'],
-
   sprawl({groupData}) {
     return {groupData};
   },

--- a/src/content/dependencies/listGroupsByTracks.js
+++ b/src/content/dependencies/listGroupsByTracks.js
@@ -2,9 +2,6 @@ import {sortAlphabetically, sortByCount} from '#sort';
 import {accumulateSum, filterByCount, stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: ['generateListingPage', 'linkGroup'],
-  extraDependencies: ['language', 'wikiData'],
-
   sprawl({groupData}) {
     return {groupData};
   },

--- a/src/content/dependencies/listRandomPageLinks.js
+++ b/src/content/dependencies/listRandomPageLinks.js
@@ -2,14 +2,6 @@ import {sortChronologically} from '#sort';
 import {empty} from '#sugar';
 
 export default {
-  contentDependencies: [
-    'generateListingPage',
-    'generateListRandomPageLinksAlbumLink',
-    'linkGroup',
-  ],
-
-  extraDependencies: ['html', 'language', 'wikiData'],
-
   sprawl: ({albumData, wikiInfo}) => ({albumData, wikiInfo}),
 
   query(sprawl, spec) {

--- a/src/content/dependencies/listTracksByAlbum.js
+++ b/src/content/dependencies/listTracksByAlbum.js
@@ -1,7 +1,4 @@
 export default {
-  contentDependencies: ['generateListingPage', 'linkAlbum', 'linkTrack'],
-  extraDependencies: ['language', 'wikiData'],
-
   sprawl({albumData}) {
     return {albumData};
   },

--- a/src/content/dependencies/listTracksByDate.js
+++ b/src/content/dependencies/listTracksByDate.js
@@ -2,9 +2,6 @@ import {sortAlbumsTracksChronologically} from '#sort';
 import {chunkByProperties, stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: ['generateListingPage', 'linkAlbum', 'linkTrack'],
-  extraDependencies: ['language', 'wikiData'],
-
   sprawl: ({trackData}) => ({trackData}),
 
   query({trackData}, spec) {

--- a/src/content/dependencies/listTracksByDuration.js
+++ b/src/content/dependencies/listTracksByDuration.js
@@ -2,9 +2,6 @@ import {sortAlphabetically, sortByCount} from '#sort';
 import {filterByCount, stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: ['generateListingPage', 'linkTrack'],
-  extraDependencies: ['language', 'wikiData'],
-
   sprawl({trackData}) {
     return {trackData};
   },

--- a/src/content/dependencies/listTracksByDurationInAlbum.js
+++ b/src/content/dependencies/listTracksByDurationInAlbum.js
@@ -2,9 +2,6 @@ import {sortByCount, sortChronologically} from '#sort';
 import {filterByCount, filterMultipleArrays, stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: ['generateListingPage', 'linkAlbum', 'linkTrack'],
-  extraDependencies: ['language', 'wikiData'],
-
   sprawl({albumData}) {
     return {albumData};
   },

--- a/src/content/dependencies/listTracksByName.js
+++ b/src/content/dependencies/listTracksByName.js
@@ -1,9 +1,6 @@
 import {sortAlphabetically} from '#sort';
 
 export default {
-  contentDependencies: ['generateListingPage', 'linkTrack'],
-  extraDependencies: ['wikiData'],
-
   sprawl({trackData}) {
     return {trackData};
   },

--- a/src/content/dependencies/listTracksByTimesReferenced.js
+++ b/src/content/dependencies/listTracksByTimesReferenced.js
@@ -2,9 +2,6 @@ import {sortAlbumsTracksChronologically, sortByCount} from '#sort';
 import {filterByCount, stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: ['generateListingPage', 'linkTrack'],
-  extraDependencies: ['language', 'wikiData'],
-
   sprawl({trackData}) {
     return {trackData};
   },

--- a/src/content/dependencies/listTracksInFlashesByAlbum.js
+++ b/src/content/dependencies/listTracksInFlashesByAlbum.js
@@ -2,9 +2,6 @@ import {sortChronologically} from '#sort';
 import {empty, filterMultipleArrays, stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: ['generateListingPage', 'linkAlbum', 'linkFlash', 'linkTrack'],
-  extraDependencies: ['language', 'wikiData'],
-
   sprawl({albumData}) {
     return {albumData};
   },

--- a/src/content/dependencies/listTracksInFlashesByFlash.js
+++ b/src/content/dependencies/listTracksInFlashesByFlash.js
@@ -2,9 +2,6 @@ import {sortFlashesChronologically} from '#sort';
 import {empty, stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: ['generateListingPage', 'linkAlbum', 'linkFlash', 'linkTrack'],
-  extraDependencies: ['wikiData'],
-
   sprawl({flashData}) {
     return {flashData};
   },

--- a/src/content/dependencies/listTracksNeedingLyrics.js
+++ b/src/content/dependencies/listTracksNeedingLyrics.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['listTracksWithExtra'],
-
   relations: (relation, spec) =>
     ({page: relation('listTracksWithExtra', spec, 'needsLyrics', 'truthy')}),
 

--- a/src/content/dependencies/listTracksWithExtra.js
+++ b/src/content/dependencies/listTracksWithExtra.js
@@ -2,9 +2,6 @@ import {sortChronologically} from '#sort';
 import {empty, filterMultipleArrays, stitchArrays} from '#sugar';
 
 export default {
-  contentDependencies: ['generateListingPage', 'linkAlbum', 'linkTrack'],
-  extraDependencies: ['html', 'language', 'wikiData'],
-
   sprawl({albumData}) {
     return {albumData};
   },

--- a/src/content/dependencies/listTracksWithLyrics.js
+++ b/src/content/dependencies/listTracksWithLyrics.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['listTracksWithExtra'],
-
   relations: (relation, spec) =>
     ({page: relation('listTracksWithExtra', spec, 'lyrics', 'array')}),
 

--- a/src/content/dependencies/listTracksWithMidiProjectFiles.js
+++ b/src/content/dependencies/listTracksWithMidiProjectFiles.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['listTracksWithExtra'],
-
   relations: (relation, spec) =>
     ({page: relation('listTracksWithExtra', spec, 'midiProjectFiles', 'array')}),
 

--- a/src/content/dependencies/listTracksWithSheetMusicFiles.js
+++ b/src/content/dependencies/listTracksWithSheetMusicFiles.js
@@ -1,6 +1,4 @@
 export default {
-  contentDependencies: ['listTracksWithExtra'],
-
   relations: (relation, spec) =>
     ({page: relation('listTracksWithExtra', spec, 'sheetMusicFiles', 'array')}),
 

--- a/src/content/dependencies/transformContent.js
+++ b/src/content/dependencies/transformContent.js
@@ -58,26 +58,6 @@ function getArg(node, argKey) {
 }
 
 export default {
-  contentDependencies: [
-    ...(
-      Object.values(replacerSpec)
-        .map(description => description.link)
-        .filter(Boolean)),
-
-    'image',
-    'generateTextWithTooltip',
-    'generateTooltip',
-    'linkExternal',
-  ],
-
-  extraDependencies: [
-    'html',
-    'language',
-    'niceShowAggregate',
-    'to',
-    'wikiData',
-  ],
-
   sprawl(wikiData, content) {
     const find =
       bindFind(wikiData, {


### PR DESCRIPTION
What it says on the tin.

* Removes `contentDependencies` and `extraDependencies` from all content functions' specs.
* Availability of relations is still checked, just against the list of all dependencies accessed, instead of associating with the relating dependency in a tree-ish manner.
* Availability of extra dependencies is no longer checked. We can check this in a similar manner as seeing which dependencies are destructured from a proxy object, as we do with compositions (#507), but it's out of scope for this pull request.
* Enables content functions to be recursive, directly or indirectly specifying themselves as their own dependencies. (The demonstration that this works is in new content code separate from this PR.)

Most deletions in this PR are just dropping `contentDependencies` and `extraDependencies`, but the main functionality diff (7cc9ad78a134e6a778ec4ad7ac71790494377342) really is +82, -369. Lots of logic is cut out or simpler now!